### PR TITLE
Fix add_team_member

### DIFF
--- a/lib/gitlab/client/projects.rb
+++ b/lib/gitlab/client/projects.rb
@@ -85,7 +85,7 @@ class Gitlab::Client
     # @param  [Integer] access_level The access level to project.
     # @return [Array<Gitlab::ObjectifiedHash>] Information about added team member.
     def add_team_member(project, id, access_level)
-      post("/projects/#{project}/members/#{id}", :body => {:access_level => access_level})
+      post("/projects/#{project}/members", :body => {:user_id => id, :access_level => access_level})
     end
 
     # Updates a team member's project access level.

--- a/spec/gitlab/client/projects_spec.rb
+++ b/spec/gitlab/client/projects_spec.rb
@@ -83,13 +83,13 @@ describe Gitlab::Client do
 
   describe ".add_team_member" do
     before do
-      stub_post("/projects/3/members/1", "team_member")
+      stub_post("/projects/3/members", "team_member")
       @team_member = Gitlab.add_team_member(3, 1, 40)
     end
 
     it "should get the correct resource" do
-      a_post("/projects/3/members/1").
-        with(:body => {:access_level => '40'}).should have_been_made
+      a_post("/projects/3/members").
+        with(:body => {:user_id => '1', :access_level => '40'}).should have_been_made
     end
 
     it "should return information about an added team member" do


### PR DESCRIPTION
According to the API document(https://github.com/gitlabhq/gitlabhq/blob/stable/doc/api/projects.md),
add_team_member post url should be "/projects/#{project}/members" and body should
have user_id.So I fixed this method and related specs.
