### PR TITLE
Added ability to create client session with GitLab/LDAP credentials.

### DIFF
--- a/lib/gitlab/api.rb
+++ b/lib/gitlab/api.rb
@@ -11,7 +11,7 @@ module Gitlab
       Configuration::VALID_OPTIONS_KEYS.each do |key|
         send("#{key}=", options[key])
       end
-      set_request_defaults @endpoint, @private_token, @sudo
+      set_request_defaults @endpoint, @private_token, @email, @password, @sudo
     end
   end
 end

--- a/lib/gitlab/configuration.rb
+++ b/lib/gitlab/configuration.rb
@@ -2,7 +2,7 @@ module Gitlab
   # Defines constants and methods related to configuration.
   module Configuration
     # An array of valid keys in the options hash when configuring a Gitlab::API.
-    VALID_OPTIONS_KEYS = [:endpoint, :private_token, :user_agent, :sudo].freeze
+    VALID_OPTIONS_KEYS = [:endpoint, :private_token, :email, :password, :user_agent, :sudo].freeze
 
     # The user agent that will be sent to the API endpoint if none is set.
     DEFAULT_USER_AGENT = "Gitlab Ruby Gem #{Gitlab::VERSION}".freeze
@@ -32,6 +32,8 @@ module Gitlab
     def reset
       self.endpoint       = nil
       self.private_token  = nil
+      self.email          = nil
+      self.password       = nil
       self.sudo           = nil
       self.user_agent     = DEFAULT_USER_AGENT
     end

--- a/lib/gitlab/request.rb
+++ b/lib/gitlab/request.rb
@@ -65,12 +65,22 @@ module Gitlab
     end
 
     # Sets a base_uri and default_params for requests.
-    # @raise [Error::MissingCredentials] if endpoint or private_token not set.
-    def set_request_defaults(endpoint, private_token, sudo=nil)
+    # If email and password provided, get GitLab session and extract private_token from it.
+    # @raise [Error::MissingCredentials] if endpoint is not set.
+    # @raise [Error::MissingCredentials] if
+    #        private_token OR (email AND password) are not set.
+    def set_request_defaults(endpoint, private_token, email, password, sudo=nil)
       raise Error::MissingCredentials.new("Please set an endpoint to API") unless endpoint
-      raise Error::MissingCredentials.new("Please set a private_token for user") unless private_token
-
       self.class.base_uri endpoint
+      
+      unless private_token
+        unless email and password
+          raise Error::MissingCredentials.new("Please set a private_token or email and password for user")    
+        end
+        response = post("/session", :body => { email: email, password: password })
+        private_token = response.private_token
+        @password = nil #security?
+      end
       self.class.default_params :private_token => private_token, :sudo => sudo
       self.class.default_params.delete(:sudo) if sudo.nil?
     end


### PR DESCRIPTION
Using API key is sometimes inconvenient, mostly when company/school uses LDAP authentication across all services.

This minor change enables creating client with either GitLab account or from version 6 with LDAP as well.

Tests will be added after a merge with pull request #25 by zedtux.
