### PR TITLE
Require httparty ~> 0.13

### DIFF
--- a/gitlab.gemspec
+++ b/gitlab.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'httparty'
+  gem.add_runtime_dependency 'httparty', '~> 0.13'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
Closes #22 -- Add missing import

It was just an attempt to close it.  If you don't
want to add this constraint, then that's ok.
