### PR TITLE
By not including the 'json' gem the Request class is unable to find JSON class

### DIFF
--- a/lib/gitlab/request.rb
+++ b/lib/gitlab/request.rb
@@ -1,4 +1,5 @@
 require 'httparty'
+require 'json'
 
 module Gitlab
   # @private


### PR DESCRIPTION
Client request handling wasn't working.  Missing a require 'json'?  My environment is Ruby 2.0.0 (via rvm) on Mavericks.

JSON

```
 NameError:
   uninitialized constant Gitlab::Request::JSON
```

I would see the following error:

NameError: uninitialized constant Gitlab::Request::JSON
    from ~/.rvm/gems/ruby-2.0.0-p247/gems/gitlab-3.0.0/lib/gitlab/request.rb:28:in `rescue in decode'

rake spec runs cleanly after adding the missing dependency
