### PR TITLE
Create tag via API

### DIFF
--- a/lib/gitlab/client/repositories.rb
+++ b/lib/gitlab/client/repositories.rb
@@ -16,6 +16,20 @@ class Gitlab::Client
     end
     alias_method :repo_tags, :tags
 
+    # Creates a new project repository tag.
+    #
+    # @example
+    #   Gitlab.create_tag(42,'new_tag','master'))
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [String]  tag_name The name of the new tag.
+    # @param  [String]  ref The ref (commit sha, branch name, or another tag) the tag will point to.
+    # @return [Gitlab::ObjectifiedHash]
+    def create_tag(project, tag_name, ref)
+      post("/projects/#{project}/repository/tags", body: {tag_name: tag_name, ref: ref})
+    end
+    alias_method :repo_create_tag, :create_tag
+
     # Gets a list of project commits.
     #
     # @example

--- a/spec/fixtures/tag.json
+++ b/spec/fixtures/tag.json
@@ -1,0 +1,1 @@
+{"name": "v1.0.0","commit": {"id": "2695effb5807a22ff3d138d593fd856244e155e7","parents": [],"message": "Initial commit","authored_date": "2012-05-28T04:42:42-07:00","author_name": "John Smith","author email": "john@example.com","committer_name": "Jack Smith","committed_date": "2012-05-28T04:42:42-07:00","committer_email": "jack@example.com"},"protected": false}

--- a/spec/gitlab/client/repositories_spec.rb
+++ b/spec/gitlab/client/repositories_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Gitlab::Client do
   it { should respond_to :repo_tags }
+  it { should respond_to :repo_create_tag }
   it { should respond_to :repo_branches }
   it { should respond_to :repo_branch }
   it { should respond_to :repo_commits }
@@ -21,6 +22,21 @@ describe Gitlab::Client do
     it "should return an array of repository tags" do
       expect(@tags).to be_an Array
       expect(@tags.first.name).to eq("v2.8.2")
+    end
+  end
+
+  describe ".create_tag" do
+    before do
+      stub_post("/projects/3/repository/tags", "tag")
+      @tag = Gitlab.create_tag(3,'v1.0.0','2695effb5807a22ff3d138d593fd856244e155e7')
+    end
+
+    it "should get the correct resource" do
+      a_post("/projects/3/repository/tags").should have_been_made
+    end
+
+    it "should return information about a new repository tag" do
+      @tag.name.should == 'v1.0.0'
     end
   end
 


### PR DESCRIPTION
Tag creation via API was merged to gitlab here:
https://github.com/gitlabhq/gitlabhq/pull/7014
