### PR TITLE
Improved arg parsing for gitlab readline shell.  Other small fixes/impro...

### DIFF
--- a/lib/gitlab/client/repositories.rb
+++ b/lib/gitlab/client/repositories.rb
@@ -19,7 +19,7 @@ class Gitlab::Client
     # Creates a new project repository tag.
     #
     # @example
-    #   Gitlab.create_tag(42,'new_tag','master'))
+    #   Gitlab.create_tag(42,'new_tag','master')
     #
     # @param  [Integer] project The ID of a project.
     # @param  [String]  tag_name The name of the new tag.

--- a/lib/gitlab/help.rb
+++ b/lib/gitlab/help.rb
@@ -20,10 +20,10 @@ module Gitlab::Help
             ri_output = `#{ri_cmd} -T #{namespace} 2>&1`.chomp
 
             if $? == 0
-              ri_output.gsub!(/#{cmd}\((.*)\)/, cmd+' \1')
+              ri_output.gsub!(/#{cmd}\((.*?)\)/, cmd+' \1')
               ri_output.gsub!(/Gitlab\./, 'gitlab> ')
               ri_output.gsub!(/Gitlab\..+$/, '')
-              ri_output.gsub!(/\,/, '')
+              ri_output.gsub!(/\,\s?/, ' ')
               help = ri_output
             else
               help = "Ri docs not found for #{namespace}, please install the docs to use 'help'"

--- a/lib/gitlab/shell.rb
+++ b/lib/gitlab/shell.rb
@@ -20,7 +20,7 @@ class Gitlab::Shell
       next if buf.nil? || buf.empty?
       break if buf == 'exit'
 
-      buf = buf.split.map(&:chomp)
+      buf = buf.scan(/["][^"]+["]|\S+/).map { |word| word.gsub(/^['"]|['"]$/,'') }
       cmd = buf.shift
       args = buf.count > 0 ? buf : []
 


### PR DESCRIPTION
...vements on regexes.

The current readline buf parsing is too naive.  Now it handles quoted strings as a single argument and strips the quotes.

This will allow for (quoted) sentences when annotated tags can be submitted through the API.  Pending PR: https://github.com/gitlabhq/gitlabhq/pull/7305.  I already have some code stashed in my local git repo to add the msg argument to the create_tag method once the PR gets merged.

I also fixed a typo and fixed a spacing problem when viewing some of the help.
