### PR TITLE
introduce HTTParty-configuration, fix #61

### DIFF
--- a/lib/gitlab/configuration.rb
+++ b/lib/gitlab/configuration.rb
@@ -2,7 +2,7 @@ module Gitlab
   # Defines constants and methods related to configuration.
   module Configuration
     # An array of valid keys in the options hash when configuring a Gitlab::API.
-    VALID_OPTIONS_KEYS = [:endpoint, :private_token, :user_agent, :sudo].freeze
+    VALID_OPTIONS_KEYS = [:endpoint, :private_token, :user_agent, :sudo, :httparty].freeze
 
     # The user agent that will be sent to the API endpoint if none is set.
     DEFAULT_USER_AGENT = "Gitlab Ruby Gem #{Gitlab::VERSION}".freeze

--- a/lib/gitlab/request.rb
+++ b/lib/gitlab/request.rb
@@ -34,21 +34,25 @@ module Gitlab
     end
 
     def get(path, options={})
+      set_httparty_config(options)
       set_private_token_header(options)
       validate self.class.get(path, options)
     end
 
     def post(path, options={})
+      set_httparty_config(options)
       set_private_token_header(options, path)
       validate self.class.post(path, options)
     end
 
     def put(path, options={})
+      set_httparty_config(options)
       set_private_token_header(options)
       validate self.class.put(path, options)
     end
 
     def delete(path, options={})
+      set_httparty_config(options)
       set_private_token_header(options)
       validate self.class.delete(path, options)
     end
@@ -90,6 +94,14 @@ module Gitlab
       unless path == '/session'
         raise Error::MissingCredentials.new("Please set a private_token for user") unless @private_token
         options[:headers] = {'PRIVATE-TOKEN' => @private_token}
+      end
+    end
+
+    # Set HTTParty configuration
+    # @see https://github.com/jnunemaker/httparty
+    def set_httparty_config(options)
+      if self.httparty
+        options.merge!(self.httparty)
       end
     end
 


### PR DESCRIPTION
This commit introduces a new option attribute, namely `httparty`, that allows passing configuration down to HTTParty.
For instance to disable verification of self-signed certificates you can now do as follow:

```
client1 = Gitlab.client(endpoint: 'https://api1.example.com', private_token: 'user-001', httparty: {verify: false})
```

The list of HTTParty configuration attributes can be found at https://github.com/jnunemaker/httparty
