### PR TITLE
Add labels api for list, create, edit and delete.

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -14,5 +14,6 @@ module Gitlab
     include Snippets
     include SystemHooks
     include Users
+    include Labels
   end
 end

--- a/lib/gitlab/client/labels.rb
+++ b/lib/gitlab/client/labels.rb
@@ -1,0 +1,55 @@
+class Gitlab::Client
+  module Labels
+    # Gets a list of project's labels.
+    #
+    # @example
+    #   Gitlab.labels(5)
+    #
+    # @param  [Integer] project The ID of a project.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def labels(project)
+      get("/projects/#{project}/labels")
+    end
+
+    # Creates a new label.
+    #
+    # @example
+    #   Gitlab.create_label(42, "Backlog", '#DD10AA')
+    #
+    # @param  [Integer] project The ID of a project.
+    # @option [String] name The name of a label.
+    # @option [String] color The color of a label.
+    # @return [Gitlab::ObjectifiedHash] Information about created label.
+    def create_label(project, name, color)
+      post("/projects/#{project}/labels", :body => { :name => name, :color => color})
+    end
+
+    # Updates a label.
+    #
+    # @example
+    #   Gitlab.edit_label(42, "Backlog", :new_name => 'TODO')
+    #   Gitlab.edit_label(42, "Backlog", :new_name => 'TODO', :color => '#DD10AA')
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [String] name The name of a label.
+    # @param  [Hash] options A customizable set of options.
+    # @option options [String] :new_name The new name of a label.
+    # @option options [String] :color The color of a label.
+    # @return [Gitlab::ObjectifiedHash] Information about updated label.
+    def edit_label(project, name, options={})
+      put("/projects/#{project}/labels", :body => options.merge({:name => name}))
+    end
+
+    # Deletes a label.
+    #
+    # @example
+    #   Gitlab.delete_label(2, 'Backlog')
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [String] name The name of a label.
+    # @return [Gitlab::ObjectifiedHash] Information about deleted label.
+    def delete_label(project, name)
+      delete("/projects/#{project}/labels", :body => {:name => name} )
+    end
+  end
+end

--- a/spec/fixtures/label.json
+++ b/spec/fixtures/label.json
@@ -1,0 +1,1 @@
+{"name": "Backlog", "color": "#DD10AA"}

--- a/spec/fixtures/labels.json
+++ b/spec/fixtures/labels.json
@@ -1,0 +1,1 @@
+[{"name": "Backlog", "color": "#DD10AA"},{"name": "Documentation", "color": "#1E80DD"}]

--- a/spec/gitlab/client/labels_spec.rb
+++ b/spec/gitlab/client/labels_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe Gitlab::Client do
+  describe ".labels" do
+    before do
+      stub_get("/projects/3/labels", "labels")
+      @labels = Gitlab.labels(3)
+    end
+
+    it "should get the correct resource" do
+      expect(a_get("/projects/3/labels")).to have_been_made
+    end
+
+    it "should return an array of project's labels" do
+      expect(@labels).to be_an Array
+      expect(@labels.first.name).to eq("Backlog")
+    end
+  end
+
+  describe ".delete" do
+    before do
+      stub_delete("/projects/3/labels", "label")
+      @label = Gitlab.delete_label(3, "Backlog")
+    end
+
+    it "should get the correct resource" do
+      expect(a_delete("/projects/3/labels").
+             with(:body => {:name => 'Backlog'})).to have_been_made
+    end
+
+    it "should return information about a deleted snippet" do
+      expect(@label.name).to eq("Backlog")
+    end
+  end
+
+  describe ".edit_label" do
+    before do
+      stub_put("/projects/3/labels", "label")
+      @label = Gitlab.edit_label(3, "TODO", :new_name => 'Backlog')
+    end
+
+    it "should get the correct resource" do
+      expect(a_put("/projects/3/labels").
+             with(:body => {:name => 'TODO', :new_name => "Backlog"})).to have_been_made
+    end
+
+    it "should return information about an edited label" do
+      expect(@label.name).to eq("Backlog")
+    end
+  end
+
+  describe ".create_label" do
+    before do
+      stub_post("/projects/3/labels", "label")
+      @label = Gitlab.create_label(3, 'Backlog', '#DD10AA')
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/labels").
+             with(:body => {:name => 'Backlog', :color => '#DD10AA'})).to have_been_made
+    end
+
+    it "should return information about a created label" do
+      expect(@label.name).to eq('Backlog')
+      expect(@label.color).to eq('#DD10AA')
+    end
+  end
+end


### PR DESCRIPTION
Gitlab project added a new API for labels: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/labels.md
