### PR TITLE
fix cannot create hook without push_events bug

### DIFF
--- a/lib/gitlab/client/projects.rb
+++ b/lib/gitlab/client/projects.rb
@@ -191,7 +191,7 @@ class Gitlab::Client
     # @return [Gitlab::ObjectifiedHash] Information about added hook.
     def add_project_hook(project, url, options = {})
       available_events = [:push_events, :merge_requests_events, :issues_events]
-      passed_events = available_events.select { |event| options[event] }
+      passed_events = available_events.select { |event| options.has_key?(event) }
       events = Hash[passed_events.map { |event| [event, options[event]] }]
 
       post("/projects/#{project}/hooks", :body => {:url => url}.merge(events))


### PR DESCRIPTION
Because in GItlab, the push_events it default true in hooks: https://github.com/gitlabhq/gitlabhq/blob/master/db/schema.rb#L400

So, if you want to create hook only for merge_requests_events or issues_events, you must pass `push_events: true` in the arguments.

Now, the PR fix the bug ignore the argument.
