### PR TITLE
Utilize pagination headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tmp
 .idea
 .ruby-version
 .ruby-gemset
+vendor

--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -31,7 +31,7 @@ module Gitlab
   #
   # @return [Array<Symbol>]
   def self.actions
-    hidden = /endpoint|private_token|user_agent|sudo|get|post|put|\Adelete\z|validate|set_request_defaults/
+    hidden = /endpoint|private_token|user_agent|sudo|auto_paginate|get|post|put|\Adelete\z|validate|set_request_defaults/
     (Gitlab::Client.instance_methods - Object.methods).reject {|e| e[hidden]}
   end
 end

--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -14,5 +14,6 @@ module Gitlab
     include Snippets
     include SystemHooks
     include Users
+    include Helpers
   end
 end

--- a/lib/gitlab/client/branches.rb
+++ b/lib/gitlab/client/branches.rb
@@ -12,7 +12,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def branches(project, options={})
-      get("/projects/#{project}/repository/branches", :query => options)
+      paginate("/projects/#{project}/repository/branches", :query => options)
     end
     alias_method :repo_branches, :branches
 

--- a/lib/gitlab/client/client_helpers.rb
+++ b/lib/gitlab/client/client_helpers.rb
@@ -1,0 +1,26 @@
+class Gitlab::Client
+  module Helpers
+    def paginate url, options={}
+      list = []
+      loop do
+        resp = http_response_for(:get, url, options)
+        list.push validate resp
+        break unless auto_paginate
+        break if (url = rels(resp.headers)['next']).nil?
+      end
+      list.count > 1 ? list.flatten : list[0]
+    end
+
+    def rels headers
+      links = headers['Link']
+      return {} if links.nil?
+      Hash[ links.split(', ').map { |l|
+        (link,rel) = l.split('; ')
+        key = /rel="(.*)"/.match(rel)[1]
+        link = /<(.*)>/.match(link)[1]
+        [key, link]
+      }]
+    end
+
+  end
+end

--- a/lib/gitlab/client/groups.rb
+++ b/lib/gitlab/client/groups.rb
@@ -12,7 +12,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def groups(options={})
-      get("/groups", :query => options)
+      paginate("/groups", :query => options)
     end
 
     # Gets a single group.

--- a/lib/gitlab/client/issues.rb
+++ b/lib/gitlab/client/issues.rb
@@ -16,9 +16,9 @@ class Gitlab::Client
     # @return [Array<Gitlab::ObjectifiedHash>]
     def issues(project=nil, options={})
       if project.to_i.zero?
-        get("/issues", :query => options)
+        paginate("/issues", :query => options)
       else
-        get("/projects/#{project}/issues", :query => options)
+        paginate("/projects/#{project}/issues", :query => options)
       end
     end
 

--- a/lib/gitlab/client/merge_requests.rb
+++ b/lib/gitlab/client/merge_requests.rb
@@ -13,7 +13,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def merge_requests(project, options={})
-      get("/projects/#{project}/merge_requests", :query => options)
+      paginate("/projects/#{project}/merge_requests", :query => options)
     end
 
     # Gets a single merge request.

--- a/lib/gitlab/client/milestones.rb
+++ b/lib/gitlab/client/milestones.rb
@@ -12,7 +12,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def milestones(project, options={})
-      get("/projects/#{project}/milestones", :query => options)
+      paginate("/projects/#{project}/milestones", :query => options)
     end
 
     # Gets a single milestone.

--- a/lib/gitlab/client/projects.rb
+++ b/lib/gitlab/client/projects.rb
@@ -13,9 +13,9 @@ class Gitlab::Client
     # @return [Array<Gitlab::ObjectifiedHash>]
     def projects(options={})
       if (options[:scope])
-        get("/projects/#{options[:scope]}", :query => options)
+        paginate("/projects/#{options[:scope]}", :query => options)
       else
-        get("/projects", :query => options)
+        paginate("/projects", :query => options)
       end
     end
 
@@ -43,7 +43,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def project_events(project, options={})
-      get("/projects/#{project}/events", :query => options)
+      paginate("/projects/#{project}/events", :query => options)
     end
 
     # Creates a new project.
@@ -96,7 +96,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def team_members(project, options={})
-      get("/projects/#{project}/members", :query => options)
+      paginate("/projects/#{project}/members", :query => options)
     end
 
     # Gets a project team member.
@@ -164,7 +164,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def project_hooks(project, options={})
-      get("/projects/#{project}/hooks", :query => options)
+      paginate("/projects/#{project}/hooks", :query => options)
     end
 
     # Gets a project hook.
@@ -257,7 +257,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def deploy_keys(project, options={})
-      get("/projects/#{project}/keys", :query => options)
+      paginate("/projects/#{project}/keys", :query => options)
     end
 
     # Gets a single project deploy key.

--- a/lib/gitlab/client/repositories.rb
+++ b/lib/gitlab/client/repositories.rb
@@ -12,7 +12,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def tags(project, options={})
-      get("/projects/#{project}/repository/tags", :query => options)
+      paginate("/projects/#{project}/repository/tags", :query => options)
     end
     alias_method :repo_tags, :tags
 
@@ -43,7 +43,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def commits(project, options={})
-      get("/projects/#{project}/repository/commits", :query => options)
+      paginate("/projects/#{project}/repository/commits", :query => options)
     end
     alias_method :repo_commits, :commits
 

--- a/lib/gitlab/client/snippets.rb
+++ b/lib/gitlab/client/snippets.rb
@@ -12,7 +12,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Gitlab::ObjectifiedHash]
     def snippets(project, options={})
-      get("/projects/#{project}/snippets", :query => options)
+      paginate("/projects/#{project}/snippets", :query => options)
     end
 
     # Gets information about a snippet.

--- a/lib/gitlab/client/system_hooks.rb
+++ b/lib/gitlab/client/system_hooks.rb
@@ -12,7 +12,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def hooks(options={})
-      get("/hooks", query: options)
+      paginate("/hooks", query: options)
     end
     alias_method :system_hooks, :hooks
 

--- a/lib/gitlab/client/users.rb
+++ b/lib/gitlab/client/users.rb
@@ -11,7 +11,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def users(options={})
-      get("/users", :query => options)
+      paginate("/users", :query => options)
     end
 
     # Gets information about a user.

--- a/lib/gitlab/client/users.rb
+++ b/lib/gitlab/client/users.rb
@@ -83,7 +83,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def ssh_keys(options={})
-      get("/user/keys", :query => options)
+      paginate("/user/keys", :query => options)
     end
 
     # Gets information about SSH key.

--- a/lib/gitlab/configuration.rb
+++ b/lib/gitlab/configuration.rb
@@ -2,7 +2,7 @@ module Gitlab
   # Defines constants and methods related to configuration.
   module Configuration
     # An array of valid keys in the options hash when configuring a Gitlab::API.
-    VALID_OPTIONS_KEYS = [:endpoint, :private_token, :user_agent, :sudo, :httparty].freeze
+    VALID_OPTIONS_KEYS = [:endpoint, :private_token, :user_agent, :sudo, :httparty, :auto_paginate].freeze
 
     # The user agent that will be sent to the API endpoint if none is set.
     DEFAULT_USER_AGENT = "Gitlab Ruby Gem #{Gitlab::VERSION}".freeze

--- a/lib/gitlab/request.rb
+++ b/lib/gitlab/request.rb
@@ -33,28 +33,21 @@ module Gitlab
       end
     end
 
-    def get(path, options={})
+    def get(   path, opts={}); http_validated_response_body_for __method__, path, opts; end
+    def post(  path, opts={}); http_validated_response_body_for __method__, path, opts; end
+    def put(   path, opts={}); http_validated_response_body_for __method__, path, opts; end
+    def delete(path, opts={}); http_validated_response_body_for __method__, path, opts; end
+
+    def http_response_for verb, path, options={}
       set_httparty_config(options)
-      set_private_token_header(options)
-      validate self.class.get(path, options)
+      set_private_token_header(options, (verb==:post ? path : nil) )
+      # Here, self is probably Gitlab::Client, to which
+      # Gitlab delegates missing methods.
+      self.class.send(verb, path, options)
     end
 
-    def post(path, options={})
-      set_httparty_config(options)
-      set_private_token_header(options, path)
-      validate self.class.post(path, options)
-    end
-
-    def put(path, options={})
-      set_httparty_config(options)
-      set_private_token_header(options)
-      validate self.class.put(path, options)
-    end
-
-    def delete(path, options={})
-      set_httparty_config(options)
-      set_private_token_header(options)
-      validate self.class.delete(path, options)
+    def http_validated_response_body_for verb, path, options
+      validate http_response_for verb, path, options
     end
 
     # Checks the response code for common errors.

--- a/spec/gitlab/request_spec.rb
+++ b/spec/gitlab/request_spec.rb
@@ -6,6 +6,61 @@ describe Gitlab::Request do
   it { should respond_to :put }
   it { should respond_to :delete }
 
+  describe "pagination" do
+    context "when requesting the first page of users" do
+      it "should find the 'next' link in the headers" do
+        stub_page_1_get("/users", "users")
+        response = Gitlab.http_response_for(:get, "/users")
+        nexturl = Gitlab.rels(response.headers)['next']
+        expect(nexturl).to_not be nil
+      end
+    end
+
+    context "when requesting with auto_paginate false" do
+      context "and per_page=1" do
+        it "should only return one user record (and not in an array)" do
+          stub_page_1_get("/users?per_page=1", "user")
+          Gitlab.auto_paginate = false
+          result = Gitlab.users per_page: 1
+          expect(result).to be_a Gitlab::ObjectifiedHash # (and not an Array)
+        end
+      end
+      context "and per_page more than 1" do
+        it "should return an array of several user records" do
+          stub_page_1_get("/users?per_page=7", "users")
+          Gitlab.auto_paginate = false
+          result = Gitlab.users per_page: 7
+          expect(result).to be_a Array
+          expect(result.count).to eql 7
+        end
+      end
+    end
+
+    context "when requesting with auto_paginate true" do
+      it "should make multiple requests for results" do
+        stub_page_1_get("/users?per_page=1", "user")
+        stub_page_2_get("/users?page=2&per_page=1", "user") # for this test, don't mind returning copies of same user
+        stub_page_3_get("/users?page=3&per_page=1", "user")
+        Gitlab.auto_paginate = true
+        result = Gitlab.users per_page: 1
+        expect(result).to be_a Array
+        expect(result.count).to eql 3
+      end
+
+      context "and more than one result per page" do
+        it "should return a flat result list of the right size" do
+          stub_page_1_get("/users?per_page=1", "users")
+          stub_page_2_get("/users?page=2&per_page=1", "users")
+          stub_page_3_get("/users?page=3&per_page=1", "users")
+          Gitlab.auto_paginate = true
+          result = Gitlab.users per_page: 1
+          expect(result).to be_a Array
+          expect(result.count).to eql 21
+        end
+      end
+    end
+  end
+
   describe ".default_options" do
     it "should have default values" do
       default_options = Gitlab::Request.default_options

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,26 @@ def stub_get(path, fixture)
     to_return(:body => load_fixture(fixture))
 end
 
+def stub_page_1_get(path, fixture)
+  # Normally, the 'Link' headers include a "per_page" param, but the API call tacks one on, so it's not
+  # in these URLs in order to avoid duplicating the param in a subsequent call.
+  stub_request(:get, "#{Gitlab.endpoint}#{path}").
+      with(:headers => {'PRIVATE-TOKEN' => Gitlab.private_token}).
+      to_return(body: load_fixture(fixture), :headers => { 'Link' => "<#{Gitlab.endpoint}/users?page=2>; rel=\"next\">, <#{Gitlab.endpoint}/users?page=1>; rel=\"first\">, <#{Gitlab.endpoint}/users?page=3>; rel=\"last\">" })
+end
+
+def stub_page_2_get(path, fixture)
+  stub_request(:get, "#{Gitlab.endpoint}#{path}").
+      with(:headers => {'PRIVATE-TOKEN' => Gitlab.private_token}).
+      to_return(body: load_fixture(fixture), :headers => { 'Link' => "<#{Gitlab.endpoint}/users?page=1>; rel=\"prev\">, <#{Gitlab.endpoint}/users?page=3>; rel=\"next\">, <#{Gitlab.endpoint}/users?page=1>; rel=\"first\">, <#{Gitlab.endpoint}/users?page=3>; rel=\"last\">" })
+end
+
+def stub_page_3_get(path, fixture)
+  stub_request(:get, "#{Gitlab.endpoint}#{path}").
+      with(:headers => {'PRIVATE-TOKEN' => Gitlab.private_token}).
+      to_return(body: load_fixture(fixture), :headers => { 'Link' => "<#{Gitlab.endpoint}/users?page=2>; rel=\"prev\">, <#{Gitlab.endpoint}/users?page=1>; rel=\"first\">, <#{Gitlab.endpoint}/users?page=3>; rel=\"last\">" })
+end
+
 def a_get(path)
   a_request(:get, "#{Gitlab.endpoint}#{path}").
     with(:headers => {'PRIVATE-TOKEN' => Gitlab.private_token})


### PR DESCRIPTION
Takes a swing at issue #51.  Before enhancing, I initially added monkey-patches to accommodate my migration of repos from github to gitlab, then decided to make it a Real Change, then noticed #51 was already created; I added some tests for the "/users endpoint", made them pass, and replaced the rest of the endpoints that needed "paginate".  I built a local version of the gem for my testing, threw away my monkey-patches and integrated the paginating version of the Gitlab gem back into my migration scripts.  (The "/projects" endpoint also got a workout at this point).  The existing tests still pass.

NOTE: These changes have NOT been tested via direct invocation of the Gitlab gem's command-line interface, but only via unit tests and calls via inclusion into my scripts).