### PR TITLE
Save/Load Shell Mode History

### DIFF
--- a/lib/gitlab/shell_history.rb
+++ b/lib/gitlab/shell_history.rb
@@ -1,0 +1,52 @@
+class Gitlab::Shell
+  class History
+    DEFAULT_FILE_PATH = File.join(Dir.home, '.gitlab_shell_history')
+
+    def initialize(options = {})
+      @file_path = options[:file_path] || DEFAULT_FILE_PATH
+      Readline::HISTORY.clear
+    end
+
+    def load
+      read_from_file { |line| Readline::HISTORY << line.chomp }
+    end
+
+    def save(line)
+      Readline::HISTORY << line
+      history_file.puts line if history_file
+    end
+
+    def lines
+      Readline::HISTORY.to_a
+    end
+
+    private
+
+    def history_file
+      if defined?(@history_file)
+        @history_file
+      else
+        @history_file = File.open(history_file_path, 'a', 0600).tap do |file|
+          file.sync = true
+        end
+      end
+    rescue Errno::EACCES
+      warn 'History not saved; unable to open your history file for writing.'
+      @history_file = false
+    end
+
+    def history_file_path
+      File.expand_path(@file_path)
+    end
+
+    def read_from_file
+      path = history_file_path
+
+      if File.exist?(path)
+        File.foreach(path) { |line| yield(line) }
+      end
+    rescue => error
+      warn "History file not loaded: #{error.message}"
+    end
+  end
+end

--- a/spec/fixtures/shell_history.json
+++ b/spec/fixtures/shell_history.json
@@ -1,0 +1,2 @@
+party on, dudes
+be excellent to each other

--- a/spec/gitlab/shell_history_spec.rb
+++ b/spec/gitlab/shell_history_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'tempfile'
+
+describe Gitlab::Shell::History do
+  context 'saving to a file' do
+    before do
+      @file = Tempfile.new('.gitlab_shell_history')
+      @history = Gitlab::Shell::History.new(file_path: @file.path)
+    end
+
+    after do @file.close(true) end
+
+    it 'saves the lines' do
+      @history.save('party on, dudes')
+      @history.save('be excellent to each other')
+      expect(File.read @file.path).
+        to eq("party on, dudes\nbe excellent to each other\n")
+    end
+
+    it 'has the lines' do
+      @history.save('party on, dudes')
+      @history.save('be excellent to each other')
+      expect(@history.lines).
+        to eq(["party on, dudes", "be excellent to each other"])
+    end
+  end
+
+  context 'loading a file' do
+    before do
+      @file = load_fixture('shell_history')
+      @history = Gitlab::Shell::History.new(file_path: @file.path)
+    end
+
+    it 'has the lines' do
+      @history.load
+      expect(@history.lines).
+        to eq(["party on, dudes", "be excellent to each other"])
+    end
+  end
+end


### PR DESCRIPTION
Saves to ~/.gitlab_shell_history, and loads the history back when a new shell is started.
