### PR TITLE
Added support for repository files create, edit and remove.

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -11,6 +11,7 @@ module Gitlab
     include Notes
     include Projects
     include Repositories
+    include RepositoryFiles
     include Snippets
     include SystemHooks
     include Users

--- a/lib/gitlab/client/repository_files.rb
+++ b/lib/gitlab/client/repository_files.rb
@@ -1,0 +1,71 @@
+require 'base64'
+
+class Gitlab::Client
+  # Defines methods related to repository files.
+  module RepositoryFiles
+    # Creates a new repository file.
+    #
+    # @example
+    #   Gitlab.create_file(42, "path", "branch", "content", "commit message")
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [String] full path to new file.
+    # @param  [String] the name of the branch.
+    # @param  [String] file content.
+    # @param  [String] commit message.
+    # @return [Gitlab::ObjectifiedHash]
+    def create_file(project, path, branch, content, commit_message)
+      post("/projects/#{project}/repository/files", body: {
+        file_path: path,
+        branch_name: branch,
+        commit_message: commit_message,
+      }.merge(encoded_content_attributes(content)))
+    end
+
+    # Edits an existing repository file.
+    #
+    # @example
+    #   Gitlab.edit_file(42, "path", "branch", "content", "commit message")
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [String] full path to new file.
+    # @param  [String] the name of the branch.
+    # @param  [String] file content.
+    # @param  [String] commit message.
+    # @return [Gitlab::ObjectifiedHash]
+    def edit_file(project, path, branch, content, commit_message)
+      put("/projects/#{project}/repository/files", body: {
+        file_path: path,
+        branch_name: branch,
+        commit_message: commit_message,
+      }.merge(encoded_content_attributes(content)))
+    end
+
+    # Removes an existing repository file.
+    #
+    # @example
+    #   Gitlab.remove_file(42, "path", "branch", "commit message")
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [String] full path to new file.
+    # @param  [String] the name of the branch.
+    # @param  [String] commit message.
+    # @return [Gitlab::ObjectifiedHash]
+    def remove_file(project, path, branch, commit_message)
+      delete("/projects/#{project}/repository/files", body: {
+        file_path: path,
+        branch_name: branch,
+        commit_message: commit_message,
+      })
+    end
+
+    private
+
+    def encoded_content_attributes(content)
+      {
+        encoding: 'base64',
+        content: Base64.encode64(content),
+      }
+    end
+  end
+end

--- a/spec/fixtures/repository_file.json
+++ b/spec/fixtures/repository_file.json
@@ -1,0 +1,1 @@
+{"file_path":"path","branch_name":"branch","encoding":"base64","content":"Y29udGVudA==","commit_message":"commit message"}

--- a/spec/gitlab/client/repository_files_spec.rb
+++ b/spec/gitlab/client/repository_files_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+describe Gitlab::Client do
+  describe ".create_file" do
+    let!(:request_stub) { stub_post("/projects/3/repository/files", "repository_file") }
+    let!(:file) { Gitlab.create_file(3, "path", "branch", "content", "commit message") }
+
+    it "should create the correct resource" do
+      expect(request_stub).to have_been_made
+    end
+
+    it "should return information about the new file" do
+      expect(file.file_path).to eq "path"
+      expect(file.branch_name).to eq "branch"
+    end
+  end
+
+  describe ".edit_file" do
+    let!(:request_stub) { stub_put("/projects/3/repository/files", "repository_file") }
+    let!(:file) { Gitlab.edit_file(3, "path", "branch", "content", "commit message") }
+
+    it "should create the correct resource" do
+      expect(request_stub).to have_been_made
+    end
+
+    it "should return information about the new file" do
+      expect(file.file_path).to eq "path"
+      expect(file.branch_name).to eq "branch"
+    end
+  end
+
+  describe ".remove_file" do
+    let!(:request_stub) { stub_delete("/projects/3/repository/files", "repository_file") }
+    let!(:file) { Gitlab.remove_file(3, "path", "branch", "commit message") }
+
+    it "should create the correct resource" do
+      expect(request_stub).to have_been_made
+    end
+
+    it "should return information about the new file" do
+      expect(file.file_path).to eq "path"
+      expect(file.branch_name).to eq "branch"
+    end
+  end
+end


### PR DESCRIPTION
The original doc is at http://doc.gitlab.com/ce/api/repository_files.html.
I didn't implement the GET as the functionality is already present, albeit in a different module. Let me know if it should be added anyway.
Cheers.