### PR TITLE
adds feature to create a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,25 @@ gitlab user --except=email,bio
 gitlab create_merge_request 4 "I'm creating a new merge request." "{source_branch: 'new_branch', target_branch: 'master', assignee_id: 42}"
 
 ```
+## Configuration files
+In some cases if might be useful to specify your connection settings in a config file so that you can easily switch
+to different servers.  Your not required to use configuration files as environment variables is still the default method
+of supplying the gitlab config. In order to use this functionality, you will need to generate the primary config below.
+
+```shell
+   mkdir ~/.gitlab_cli
+   # ~/.gitlab_cli/gitlab_cli_config.yml
+   :gitlab_api_endpoint: https://gitlab.com/api/v3
+   :gitlab_private_token: 1234567abcdefg!#JK
+```
+
+To work with secondary GitLab servers you can create additional config files in the ~/.gitlab_cli directory.
+When you want to connect to your secondary server you can specify the config file in a environment variable before
+calling your gitlab cli.
+
+`GITLAB_CONFIG_FILE=gitlab_saas.yml`
+
+The gitlab api will always load the primary config first unless specified to load the secondary config.
 
 ## CLI Shell
 

--- a/lib/gitlab/configuration.rb
+++ b/lib/gitlab/configuration.rb
@@ -1,3 +1,5 @@
+require_relative 'settings'
+
 module Gitlab
   # Defines constants and methods related to configuration.
   module Configuration
@@ -30,10 +32,10 @@ module Gitlab
 
     # Resets all configuration options to the defaults.
     def reset
-      self.endpoint       = ENV['GITLAB_API_ENDPOINT']
-      self.private_token  = ENV['GITLAB_API_PRIVATE_TOKEN']
-      self.sudo           = nil
-      self.user_agent     = DEFAULT_USER_AGENT
+      self.endpoint       = Settings.config.endpoint
+      self.private_token  = Settings.config.private_token
+      self.sudo           = Settings.config.sudo
+      self.user_agent     = Settings.config.user_agent
     end
   end
 end

--- a/lib/gitlab/settings.rb
+++ b/lib/gitlab/settings.rb
@@ -1,0 +1,70 @@
+require 'yaml'
+
+module Gitlab
+  module Configuration
+    class Settings
+      # The user agent that will be sent to the API endpoint if none is set.
+      DEFAULT_USER_AGENT = "Gitlab Ruby Gem #{Gitlab::VERSION}".freeze
+
+      # by default we look in the environment variable for the config file name in case the user
+      # wants to switch servers, otherwise we always looking ~/.gitlab_cli/gitlab_cli_config.yml
+      def config_file
+        @config_file ||= ENV['GITLAB_CONFIG_FILE'] || 'gitlab_cli_config.yml'
+      end
+
+      def settings_path
+        @settings_path ||= File.expand_path(File.join('~', '.gitlab_cli', config_file))
+      end
+
+      def file_config
+        begin
+          if File.exists?(settings_path)
+            @settings ||= YAML.load_file(settings_path) || {}
+            raise "Invalid Config file" unless @settings.instance_of?(Hash)
+          else
+            @settings = {}
+          end
+        rescue Exception => e
+          raise "Unable to load gitlab cli config file at #{settings_path}\n #{e.message}"
+        end
+        @settings
+      end
+
+      def sudo
+        file_config[:sudo]
+      end
+
+      def user_agent
+        file_config[:user_agent] || DEFAULT_USER_AGENT
+      end
+
+      def endpoint
+        ENV['GITLAB_API_ENDPOINT'] || file_config[:gitlab_api_endpoint]
+      end
+
+      def private_token
+        ENV['GITLAB_API_PRIVATE_TOKEN'] || file_config[:gitlab_private_token]
+      end
+
+      def http_party
+
+      end
+
+      def http_proxy
+        file_config[:http_proxy]
+      end
+
+      def proxy_username
+        file_config[:proxy_username]
+      end
+
+      def proxy_password
+        file_config[:proxy_password]
+      end
+
+      def self.config
+        Gitlab::Configuration::Settings.new
+      end
+    end
+  end
+end

--- a/spec/fixtures/settings.yml
+++ b/spec/fixtures/settings.yml
@@ -1,0 +1,2 @@
+:gitlab_api_endpoint: https://gitlab.com/api/v3
+:gitlab_private_token: 1234567abcdefg!#JK

--- a/spec/fixtures/settings_bad.yml
+++ b/spec/fixtures/settings_bad.yml
@@ -1,0 +1,1 @@
+dsfasdfasdfasdfasd

--- a/spec/gitlab/settings_spec.rb
+++ b/spec/gitlab/settings_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Gitlab::Configuration::Settings do
+
+   before :each do
+     @settings = Gitlab::Configuration::Settings.config
+   end
+
+  it 'should get settings config' do
+    expect(@settings).to be_instance_of(Gitlab::Configuration::Settings)
+  end
+
+  it 'should load the config file' do
+    allow(@settings).to receive(:settings_path).and_return(File.join(fixtures_dir, 'settings.yml'))
+    expect(@settings.file_config).to be_instance_of(Hash)
+  end
+
+   it 'should throw error config file is bad' do
+     allow(@settings).to receive(:settings_path).and_return(File.join(fixtures_dir, 'settings_bad.yml'))
+     expect{@settings.file_config}.to raise_error
+   end
+
+  it 'should prefer endpoint environment variable' do
+    ENV['GITLAB_API_ENDPOINT'] = 'http://special.com'
+    allow(@settings).to receive(:settings_path).and_return(File.join(fixtures_dir, 'settings.yml'))
+    expect(@settings.endpoint).to eq('http://special.com')
+  end
+
+   it 'should prefer token environment variable' do
+     ENV['GITLAB_API_PRIVATE_TOKEN'] = 'some_token'
+     allow(@settings).to receive(:settings_path).and_return(File.join(fixtures_dir, 'settings.yml'))
+     expect(@settings.private_token).to eq('some_token')
+   end
+
+   it 'should get endpoint variable' do
+     ENV['GITLAB_API_ENDPOINT'] = nil
+     allow(@settings).to receive(:settings_path).and_return(File.join(fixtures_dir, 'settings.yml'))
+     expect(@settings.endpoint).to eq('https://gitlab.com/api/v3')
+   end
+
+   it 'should prefer environment variable' do
+     ENV['GITLAB_API_PRIVATE_TOKEN'] = nil
+     allow(@settings).to receive(:settings_path).and_return(File.join(fixtures_dir, 'settings.yml'))
+     expect(@settings.private_token).to eq('1234567abcdefg!#JK')
+   end
+
+   it 'should retrun a default agent' do
+     allow(@settings).to receive(:settings_path).and_return(File.join(fixtures_dir, 'settings.yml'))
+     expect(@settings.user_agent).to eq("Gitlab Ruby Gem #{Gitlab::VERSION}")
+   end
+
+   it 'should load the secondary config' do
+     ENV['GITLAB_CONFIG_FILE'] = 'server_a.yml'
+     expect(@settings.config_file).to eq('server_a.yml')
+   end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,10 @@ def capture_output
   out.string
 end
 
+def fixtures_dir
+  File.expand_path(File.join(File.dirname(__FILE__), 'fixtures'))
+end
+
 def load_fixture(name)
   File.new(File.dirname(__FILE__) + "/fixtures/#{name}.json")
 end


### PR DESCRIPTION
previously you were required to specify a configuration via
environment variables.  With this change you can now optionally
specify the same configs in a config file.
Additionally if you have multiple gitlab servers that you connect
to you can easily switch by specifying a default config file to use.
This is handy where the config files are named after servers.