### PR TITLE
deleting a gitlab project returns the string "true"

### DIFF
--- a/lib/gitlab/request.rb
+++ b/lib/gitlab/request.rb
@@ -19,6 +19,10 @@ module Gitlab
         ObjectifiedHash.new body
       elsif body.is_a? Array
         body.collect! { |e| ObjectifiedHash.new(e) }
+      elsif body
+        true
+      elsif !body
+        false
       elsif body.nil?
         false
       else

--- a/spec/gitlab/request_spec.rb
+++ b/spec/gitlab/request_spec.rb
@@ -27,6 +27,10 @@ describe Gitlab::Request do
     it "should return ObjectifiedHash" do
       body = JSON.unparse({a: 1, b: 2})
       expect(Gitlab::Request.parse(body)).to be_an Gitlab::ObjectifiedHash
+      expect(Gitlab::Request.parse("true")).to be true
+      expect(Gitlab::Request.parse("false")).to be false
+
+      expect { Gitlab::Request.parse("string") }.to raise_error(Gitlab::Error::Parsing)
     end
   end
 


### PR DESCRIPTION
JSON.parse converts "true" to a boolean, but the custom parsing function
just checks if the body is an array or hash.

So check if the body is a real boolean and if it's true, return an
empty hash.

This is with gitlab 7.11.4, didn't check any other versions...