### PR TITLE
Added support description option in create_group method

### DIFF
--- a/lib/gitlab/client/groups.rb
+++ b/lib/gitlab/client/groups.rb
@@ -36,8 +36,8 @@ class Gitlab::Client
     # @param  [String] name The name of a group.
     # @param  [String] path The path of a group.
     # @return [Gitlab::ObjectifiedHash] Information about created group.
-    def create_group(name, path)
-      body = {:name => name, :path => path}
+    def create_group(name, path, options={})
+      body = {:name => name, :path => path}.merge(options)
       post("/groups", :body => body)
     end
 

--- a/spec/fixtures/group_create_with_description.json
+++ b/spec/fixtures/group_create_with_description.json
@@ -1,0 +1,1 @@
+{"id":3,"name":"Gitlab-Group","path":"gitlab-group","owner_id":1,"description":"gitlab group description"}

--- a/spec/gitlab/client/groups_spec.rb
+++ b/spec/gitlab/client/groups_spec.rb
@@ -21,19 +21,40 @@ describe Gitlab::Client do
   end
 
   describe ".create_group" do
-    before do
-      stub_post("/groups", "group_create")
-      @group = Gitlab.create_group('GitLab-Group', 'gitlab-path')
+    context "without description" do
+      before do
+        stub_post("/groups", "group_create")
+        @group = Gitlab.create_group('GitLab-Group', 'gitlab-path')
+      end
+
+      it "should get the correct resource" do
+        expect(a_post("/groups").
+            with(:body => {:path => 'gitlab-path', :name => 'GitLab-Group'})).to have_been_made
+      end
+
+      it "should return information about a created group" do
+        expect(@group.name).to eq("Gitlab-Group")
+        expect(@group.path).to eq("gitlab-group")
+      end
     end
 
-    it "should get the correct resource" do
-      expect(a_post("/groups").
-          with(:body => {:path => 'gitlab-path', :name => 'GitLab-Group'})).to have_been_made
-    end
+    context "with description" do
+      before do
+        stub_post("/groups", "group_create_with_description")
+        @group = Gitlab.create_group('GitLab-Group', 'gitlab-path', :description => 'gitlab group description')
+      end
 
-    it "should return information about a created group" do
-      expect(@group.name).to eq("Gitlab-Group")
-      expect(@group.path).to eq("gitlab-group")
+      it "should get the correct resource" do
+        expect(a_post("/groups").
+                 with(:body => {:path => 'gitlab-path', :name => 'GitLab-Group',
+                                :description => 'gitlab group description'})).to have_been_made
+      end
+
+      it "should return information about a created group" do
+        expect(@group.name).to eq("Gitlab-Group")
+        expect(@group.path).to eq("gitlab-group")
+        expect(@group.description).to eq("gitlab group description")
+      end
     end
   end
 


### PR DESCRIPTION
In the description of the method ```create_group``` indicated that the parameter ```description``` supported, but the method signature does not support it.