### PR TITLE
Add a `--json` parameter to the CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ gitlab user --only=id,username
 
 gitlab user --except=email,bio
 
+# get a user and render result as json
+gitlab user 2 --json
+
 # passing options hash to a command (use YAML)
 gitlab create_merge_request 4 "New merge request" "{source_branch: 'new_branch', target_branch: 'master', assignee_id: 42}"
 

--- a/lib/gitlab/cli.rb
+++ b/lib/gitlab/cli.rb
@@ -6,6 +6,9 @@ require_relative 'shell'
 class Gitlab::CLI
   extend Helpers
 
+  # If set to true, JSON will be rendered as output
+  @render_json = false
+
   # Starts a new CLI session.
   #
   # @example
@@ -43,6 +46,11 @@ class Gitlab::CLI
     when 'shell'
       Gitlab::Shell.start
     else
+      if args.include? '--json'
+        @json_output = true
+        args.delete '--json'
+      end
+
       unless valid_command?(cmd)
         puts "Unknown command. Run `gitlab help` for a list of available commands."
         exit(1)
@@ -64,6 +72,17 @@ class Gitlab::CLI
       confirm_command(cmd)
 
       data = gitlab_helper(cmd, command_args) { exit(1) }
+
+      render_output(cmd, args, data)
+    end
+  end
+
+  # Helper method that checks whether we want to get the output as json
+  # return [nil]
+  def self.render_output(cmd,args,data)
+    if @json_output
+      output_json(cmd, args, data)
+    else
       output_table(cmd, args, data)
     end
   end

--- a/spec/gitlab/cli_spec.rb
+++ b/spec/gitlab/cli_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'json'
 
 describe Gitlab::CLI do
   describe ".run" do
@@ -58,6 +59,21 @@ describe Gitlab::CLI do
         expect(@output).to include('created_at')
       end
     end
+
+
+    context "when command with json output" do
+      before do
+        stub_get("/user", "user")
+        args = ['user', '--json']
+        @output = capture_output { Gitlab::CLI.start(args) }
+      end
+
+      it "should render output as json" do
+        expect(JSON.parse(@output)['result']).to eq(JSON.parse(File.read(File.dirname(__FILE__) + '/../fixtures/user.json')))
+        expect(JSON.parse(@output)['cmd']).to eq('Gitlab.user')
+      end
+    end
+
 
     context "when command with required fields" do
       before do


### PR DESCRIPTION
Adding a `--json` parameter to a CLI command returns the output in JSON. Example:

````
gitlab project 605 --json

>>>> {
       "cmd": "Gitlab.project 605",
       "result": {
         "archived": false,
         "avatar_url": null,
         "created_at": "2015-05-21T13:50:16.514Z",
         "default_branch": "master",
         "description": "",
        ...
       }
     }
````
For "single row" returned by the command, the `result` field will be a map. If there are multiple rows returned, the `result`field will be an array of maps.

You are then able to do things like this (given you have [jq](http://stedolan.github.io/jq/) installed on your system):

````
gitlab project PROJECT_ID --json | jq '.result.id'

>>>> PROJECT_ID
````

The JSON is pretty-printed to make it readable for humans :-)