### PR TITLE
Improved parameter description in help output.

### DIFF
--- a/lib/gitlab/help.rb
+++ b/lib/gitlab/help.rb
@@ -83,6 +83,13 @@ module Gitlab::Help
     def change_help_output!(cmd, output_str)
       output_str.gsub!(/#{cmd}\((.*?)\)/m, cmd+' \1')
       output_str.gsub!(/\,[\s]*/, ' ')
+      
+      # Ensure @option descriptions are on a single line
+      output_str.gsub!(/\n\[/, " \[")
+      output_str.gsub!(/\s(@)/, "\n@")
+      output_str.gsub!(/(\])\n(\:)/, '\1 \2')
+      output_str.gsub!(/(\:.*)(\n)(.*\.)/, '\1 \3')
+      
     end
 
   end # class << self


### PR DESCRIPTION
We now render each `@option` value on a separate line for
better readability.
This is a PoC example - still need to write a spec for this.

`rake && exe/gitlab help create_project`

Before:
```
= Gitlab::Client::Projects.create_project

(from gem gitlab-3.4.0)
=== Implementation from Projects
------------------------------------------------------------------------------
  create_project name options={}

------------------------------------------------------------------------------

Creates a new project.

@example
  gitlab create_project 'gitlab'
  gitlab create_project 'viking' :description => 'Awesome project'
  gitlab create_project 'Red' :wall_enabled => false

@param  [String] name The name of a project. @param  [Hash] options A
customizable set of options. @option options [String] :description The
description of a project. @option options [String] :default_branch The default
branch of a project. @option options [String] :group_id The group in which to
create a project. @option options [String] :namespace_id The namespace in
which to create a project. @option options [Boolean] :wiki_enabled The wiki
integration for a project (0 = false 1 = true). @option options [Boolean]
:wall_enabled The wall functionality for a project (0 = false 1 = true).
@option options [Boolean] :issues_enabled The issues integration for a project
(0 = false 1 = true). @option options [Boolean] :snippets_enabled The
snippets integration for a project (0 = false 1 = true). @option options
[Boolean] :merge_requests_enabled The merge requests functionality for a
project (0 = false 1 = true). @option options [Boolean] :public The setting
for making a project public (0 = false 1 = true). @option options [Integer]
:user_id The user/owner id of a project. @return [Gitlab::ObjectifiedHash]
Information about created project.
```


After: 
```
= Gitlab::Client::Projects.create_project

(from gem gitlab-3.4.0)
=== Implementation from Projects
------------------------------------------------------------------------------
  create_project name options={}

------------------------------------------------------------------------------

Creates a new project.

@example
  gitlab create_project 'gitlab'
  gitlab create_project 'viking' :description => 'Awesome project'   gitlab create_project 'Red' :wall_enabled => false

@param  [String] name The name of a project.
@param  [Hash] options A
customizable set of options.
@option options [String] :description The description of a project.
@option options [String] :default_branch The default branch of a project.
@option options [String] :group_id The group in which to create a project.
@option options [String] :namespace_id The namespace in which to create a project.
@option options [Boolean] :wiki_enabled The wiki integration for a project (0 = false 1 = true).
@option options [Boolean] :wall_enabled The wall functionality for a project (0 = false 1 = true).
@option options [Boolean] :issues_enabled The issues integration for a project (0 = false 1 = true).
@option options [Boolean] :snippets_enabled The snippets integration for a project (0 = false 1 = true).
@option options [Boolean] :merge_requests_enabled The merge requests functionality for a project (0 = false 1 = true).
@option options [Boolean] :public The setting for making a project public (0 = false 1 = true).
@option options [Integer] :user_id The user/owner id of a project.
@return [Gitlab::ObjectifiedHash] Information about created project.
```