### PR TITLE
Add support for namespaces endpoint

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -10,6 +10,7 @@ module Gitlab
     include Labels
     include MergeRequests
     include Milestones
+    include Namespaces
     include Notes
     include Projects
     include Repositories

--- a/lib/gitlab/client/namespaces.rb
+++ b/lib/gitlab/client/namespaces.rb
@@ -1,0 +1,19 @@
+class Gitlab::Client
+  # Defines methods related to namespaces
+  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/namespaces.md
+  module Namespaces
+    # Gets a list of namespaces.
+    #
+    # @example
+    #   Gitlab.namespaces
+    #
+    # @param  [Hash] options A customizable set of options.
+    # @options options [Integer] :page The page number.
+    # @options options [Integer] :per_page The number of results per page.
+    # @options opttion [String]  :search The string to search for.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def namespaces(options={})
+      get("/namespaces", :query => options)
+    end
+  end
+end

--- a/spec/fixtures/namespaces.json
+++ b/spec/fixtures/namespaces.json
@@ -1,0 +1,1 @@
+[{"id": 1, "path": "john", "kind": "user"}]

--- a/spec/gitlab/client/namespaces_spec.rb
+++ b/spec/gitlab/client/namespaces_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe Gitlab::Client do
+  it { should respond_to :namespaces }
+
+  describe ".namespaces" do
+    before do
+      stub_get("/namespaces", "namespaces")
+      @namespaces = Gitlab.namespaces
+    end
+
+    it "should get the correct resource" do
+      expect(a_get("/namespaces")).to have_been_made
+    end
+
+    it "should return an array of namespaces" do
+      expect(@namespaces).to be_an Array
+      expect(@namespaces.first.path).to eq("john")
+      expect(@namespaces.first.kind).to eq("user")
+    end
+  end
+end


### PR DESCRIPTION
I'd like to have support for the `/namespaces` [endpoint](https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/namespaces.md), especially in the context of using gitlab-ee. Usage supports `:per_page`, `:page`, and `:search` options. 

**Examples:**
```ruby
Gitlab.namespaces
Gitlab.namespaces(per_page: 5, page: 2)
Gitlab.namespaces(search: 'foobar')
```

Tests have been included.