### PR TITLE
Adding an all_users method

### DIFF
--- a/lib/gitlab/client/users.rb
+++ b/lib/gitlab/client/users.rb
@@ -15,6 +15,29 @@ class Gitlab::Client
     def users(options={})
       get("/users", :query => options)
     end
+    
+    # wrap the users call to get an Enumerable of all users
+    #
+    # @example
+    #    Gitlab.all_users
+    #
+    # @return [#<Enumerator:0x0000000270a4c0>]
+    def all_users()
+      page = 1
+      list = []
+      enum = Enumerator.new do |y|
+        loop do
+          if users.empty?
+            list = users(:page => page)
+            break if list.empty?
+            page += 1
+          end
+          y << list.pop
+        end
+      end
+      return enum
+    end
+
 
     # Gets information about a user.
     # Will return information about an authorized user if no ID passed.

--- a/lib/gitlab/client/users.rb
+++ b/lib/gitlab/client/users.rb
@@ -27,7 +27,7 @@ class Gitlab::Client
       list = []
       enum = Enumerator.new do |y|
         loop do
-          if users.empty?
+          if list.empty?
             list = users(:page => page)
             break if list.empty?
             page += 1


### PR DESCRIPTION
The all_users method wraps the paging of the users call into an Enumerator.

I got tired of writing the paging logic over and over whenever I needed to iterate over all of the users. This method solves that for me without immediately requesting every user in GitLab.