### PR TITLE
Use `respond_to_missing?` instead of `respond_to?`

### DIFF
--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -25,8 +25,8 @@ module Gitlab
   end
 
   # Delegate to Gitlab::Client
-  def self.respond_to?(method)
-    client.respond_to?(method) || super
+  def respond_to_missing?(method_name, include_private = false)
+    client.respond_to?(method_name) || super
   end
 
   # Delegate to HTTParty.http_proxy

--- a/lib/gitlab/objectified_hash.rb
+++ b/lib/gitlab/objectified_hash.rb
@@ -27,7 +27,7 @@ module Gitlab
       @data.key?(key.to_s) ? @data[key.to_s] : nil
     end
 
-    def respond_to?(method_name, include_private=false)
+    def respond_to_missing?(method_name, include_private = false)
       @hash.keys.map(&:to_sym).include?(method_name.to_sym) || super
     end
   end

--- a/lib/gitlab/paginated_response.rb
+++ b/lib/gitlab/paginated_response.rb
@@ -23,8 +23,8 @@ module Gitlab
       end
     end
 
-    def respond_to?(method, include_all=false)
-      super || @array.respond_to?(method, include_all)
+    def respond_to_missing?(method_name, include_private = false)
+      super || @array.respond_to?(method_name, include_private)
     end
 
     def parse_headers!(headers)


### PR DESCRIPTION
See https://robots.thoughtbot.com/always-define-respond-to-missing-when-overriding

Prior, I was unable to mock the client, for example by doing:

```ruby
expect(Gitlab).to receive(:protect_branch).with(anything(), anything())
```