### PR TITLE
Add method edit_group_member

### DIFF
--- a/lib/gitlab/client/groups.rb
+++ b/lib/gitlab/client/groups.rb
@@ -69,6 +69,19 @@ class Gitlab::Client
       post("/groups/#{team_id}/members", body: { user_id: user_id, access_level: access_level })
     end
 
+    # Edit a user of a group.
+    #
+    # @example
+    #   Gitlab.edit_group_member(1, 2, 40)
+    #
+    # @param  [Integer] team_id The group id of member to edit.
+    # @param  [Integer] user_id The user id of the user to edit.
+    # @param  [Integer] access_level Project access level.
+    # @return [Gitlab::ObjectifiedHash] Information about edited team member.
+    def edit_group_member(team_id, user_id, access_level)
+      put("/groups/#{team_id}/members/#{user_id}", body: { access_level: access_level })
+    end
+
     # Removes user from user group.
     #
     # @example

--- a/spec/fixtures/group_member_edit.json
+++ b/spec/fixtures/group_member_edit.json
@@ -1,0 +1,1 @@
+{"id":2,"username":"jsmith","email":"jsmith@local.host","name":"John Smith","state":"active","created_at":"2013-09-04T18:15:30Z","access_level":50}

--- a/spec/gitlab/client/groups_spec.rb
+++ b/spec/gitlab/client/groups_spec.rb
@@ -113,6 +113,22 @@ describe Gitlab::Client do
     end
   end
 
+  describe ".edit_group_member" do
+    before do
+      stub_put("/groups/3/members/1", "group_member_edit")
+      @member = Gitlab.edit_group_member(3, 1, 50)
+    end
+
+    it "should get the correct resource" do
+      expect(a_put("/groups/3/members/1")
+          .with(body: { access_level: '50'})).to have_been_made
+    end
+
+    it "should return information about the edited member" do
+      expect(@member.access_level).to eq(50)
+    end
+  end
+
   describe ".remove_group_member" do
     before do
       stub_delete("/groups/3/members/1", "group_member_delete")


### PR DESCRIPTION
This pull request add the missing method edit_group_member to the groups client.