### PR TITLE
Auto paginate to include all results and pass through CLI args

### DIFF
--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -15,7 +15,7 @@ module Gitlab
   #
   # @return [Gitlab::Client]
   def self.client(options={})
-    Gitlab::CI::Client.new(options)
+    Gitlab::Client.new(options)
   end
 
   # Delegate to Gitlab::Client

--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -22,7 +22,7 @@ module Gitlab
   def self.method_missing(method, *args, &block)
     args.flatten!
     if args.last.is_a?(Hash)
-      options = args.pop
+      options = args.last
     else
       options = {}
     end

--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -20,8 +20,8 @@ module Gitlab
 
   # Delegate to Gitlab::Client
   def self.method_missing(method, *args, &block)
-    return super unless client.respond_to?(method)
-    client.send(method, *args, &block)
+    return super unless client(*args).respond_to?(method)
+    client(*args).send(method, *args, &block)
   end
 
   # Delegate to Gitlab::Client

--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -20,12 +20,7 @@ module Gitlab
 
   # Delegate to Gitlab::Client
   def self.method_missing(method, *args, &block)
-    args.flatten!
-    if args.last.is_a?(Hash)
-      options = args.last
-    else
-      options = {}
-    end
+    options = args.flatten.last.is_a?(Hash) ? args.flatten.last : {}
     return super unless client(options).respond_to?(method)
     client(options).send(method, *args, &block)
   end

--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -6,7 +6,7 @@ require 'gitlab/page_links'
 require 'gitlab/paginated_response'
 require 'gitlab/request'
 require 'gitlab/api'
-require 'gitlab/client'
+require 'gitlab/ci/client'
 
 module Gitlab
   extend Configuration
@@ -15,13 +15,19 @@ module Gitlab
   #
   # @return [Gitlab::Client]
   def self.client(options={})
-    Gitlab::Client.new(options)
+    Gitlab::CI::Client.new(options)
   end
 
   # Delegate to Gitlab::Client
   def self.method_missing(method, *args, &block)
-    return super unless client(*args).respond_to?(method)
-    client(*args).send(method, *args, &block)
+    args.flatten!
+    if args.last.is_a?(Hash)
+      options = args.pop
+    else
+      options = {}
+    end
+    return super unless client(options).respond_to?(method)
+    client(options).send(method, *args, &block)
   end
 
   # Delegate to Gitlab::Client

--- a/lib/gitlab/cli_helpers.rb
+++ b/lib/gitlab/cli_helpers.rb
@@ -218,8 +218,6 @@ class Gitlab::CLI
             raise "error: cannot convert hash key to symbol: #{key}"
           end
 				end
-			else
-				hash = {}
       end
 
       hash

--- a/lib/gitlab/cli_helpers.rb
+++ b/lib/gitlab/cli_helpers.rb
@@ -94,7 +94,7 @@ class Gitlab::CLI
       when Gitlab::ObjectifiedHash
         puts record_table([data], cmd, args)
       when Gitlab::PaginatedResponse
-        puts record_table(data, cmd, args)
+        puts record_table(data.auto_paginate, cmd, args)
       else # probably just an error msg
         puts data
       end
@@ -108,7 +108,7 @@ class Gitlab::CLI
                       when Gitlab::ObjectifiedHash
                         record_hash([data], cmd, args, true)
                       when Gitlab::PaginatedResponse
-                        record_hash(data, cmd, args)
+                        record_hash(data.auto_paginate, cmd, args)
                       else
                         { cmd: cmd, data: data, args: args }
         end

--- a/lib/gitlab/cli_helpers.rb
+++ b/lib/gitlab/cli_helpers.rb
@@ -217,7 +217,9 @@ class Gitlab::CLI
           rescue NoMethodError
             raise "error: cannot convert hash key to symbol: #{key}"
           end
-        end
+				end
+			else
+				hash = {}
       end
 
       hash

--- a/lib/gitlab/cli_helpers.rb
+++ b/lib/gitlab/cli_helpers.rb
@@ -226,6 +226,9 @@ class Gitlab::CLI
     # YAML::load on a single argument
     def yaml_load(arg)
       begin
+        if File.exists?(arg)
+          arg = File.read(arg)
+        end
         yaml = YAML.load(arg)
       rescue Psych::SyntaxError
         raise "error: Argument is not valid YAML syntax: #{arg}"

--- a/lib/gitlab/cli_helpers.rb
+++ b/lib/gitlab/cli_helpers.rb
@@ -94,7 +94,7 @@ class Gitlab::CLI
       when Gitlab::ObjectifiedHash
         puts record_table([data], cmd, args)
       when Gitlab::PaginatedResponse
-        puts record_table(data.auto_paginate, cmd, args)
+        puts record_table(data, cmd, args)
       else # probably just an error msg
         puts data
       end
@@ -108,7 +108,7 @@ class Gitlab::CLI
                       when Gitlab::ObjectifiedHash
                         record_hash([data], cmd, args, true)
                       when Gitlab::PaginatedResponse
-                        record_hash(data.auto_paginate, cmd, args)
+                        record_hash(data, cmd, args)
                       else
                         { cmd: cmd, data: data, args: args }
         end

--- a/lib/gitlab/cli_helpers.rb
+++ b/lib/gitlab/cli_helpers.rb
@@ -230,6 +230,7 @@ class Gitlab::CLI
           arg = File.read(arg)
         end
         yaml = YAML.load(arg)
+				yaml = {} if yaml.is_a?(String)
       rescue Psych::SyntaxError
         raise "error: Argument is not valid YAML syntax: #{arg}"
       end

--- a/lib/gitlab/cli_helpers.rb
+++ b/lib/gitlab/cli_helpers.rb
@@ -230,7 +230,6 @@ class Gitlab::CLI
           arg = File.read(arg)
         end
         yaml = YAML.load(arg)
-				yaml = {} if yaml.is_a?(String)
       rescue Psych::SyntaxError
         raise "error: Argument is not valid YAML syntax: #{arg}"
       end

--- a/lib/gitlab/cli_helpers.rb
+++ b/lib/gitlab/cli_helpers.rb
@@ -94,7 +94,7 @@ class Gitlab::CLI
       when Gitlab::ObjectifiedHash
         puts record_table([data], cmd, args)
       when Gitlab::PaginatedResponse
-        puts record_table(data, cmd, args)
+        puts record_table(data.auto_paginate, cmd, args)
       else # probably just an error msg
         puts data
       end
@@ -108,7 +108,7 @@ class Gitlab::CLI
                       when Gitlab::ObjectifiedHash
                         record_hash([data], cmd, args, true)
                       when Gitlab::PaginatedResponse
-                        record_hash(data, cmd, args)
+                        record_hash(data.auto_paginate, cmd, args)
                       else
                         { cmd: cmd, data: data, args: args }
         end
@@ -217,7 +217,7 @@ class Gitlab::CLI
           rescue NoMethodError
             raise "error: cannot convert hash key to symbol: #{key}"
           end
-				end
+        end
       end
 
       hash

--- a/spec/gitlab/client/projects_spec.rb
+++ b/spec/gitlab/client/projects_spec.rb
@@ -138,13 +138,15 @@ describe Gitlab::Client do
 
     context "with the sudo option" do
       before do
-        stub_post("/projects/fork/3", "project_forked_for_user")
         @sudoed_username = 'jack.smith'
+        stub_post("/projects/fork/3?sudo=#{@sudoed_username}", "project_forked_for_user").
+            with(body: { sudo: @sudoed_username })
         @project = Gitlab.create_fork(3, sudo: @sudoed_username)
       end
 
       it "should post to the correct resource" do
-        expect(a_post("/projects/fork/3")).to have_been_made
+        expect(a_post("/projects/fork/3?sudo=#{@sudoed_username}").
+            with(body: { sudo: @sudoed_username })).to have_been_made
       end
 
       it "should return information about the forked project" do


### PR DESCRIPTION
A paginated response will only display first page worth of results ...
Command line args like 'endpoint: https://gitlab..../' is ignored and results in "Please set an endpoint to API"