### PR TITLE
Add API to get a list of projects under a group

### DIFF
--- a/lib/gitlab/client/groups.rb
+++ b/lib/gitlab/client/groups.rb
@@ -120,5 +120,15 @@ class Gitlab::Client
       options[:search] = search
       get("/groups", query: options)
     end
+
+    # Get a list of projects under a group
+    # @example
+    #   Gitlab.group_projects(1)
+    #
+    # @param [Integer] id The ID of a group
+    # @return [Array<Gitlab::ObjectifiedHash>] List of projects under a group
+    def group_projects(id)
+      get("/groups/#{id}/projects")
+    end
   end
 end

--- a/spec/fixtures/group_projects.json
+++ b/spec/fixtures/group_projects.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": 4,
+    "description": null,
+    "default_branch": "master",
+    "public": false,
+    "visibility_level": 0,
+    "ssh_url_to_repo": "git@example.com:diaspora/diaspora-client.git",
+    "http_url_to_repo": "http://example.com/diaspora/diaspora-client.git",
+    "web_url": "http://example.com/diaspora/diaspora-client",
+    "tag_list": [
+      "example",
+      "disapora client"
+    ],
+    "owner": {
+      "id": 3,
+      "name": "Diaspora",
+      "created_at": "2013-09-30T13: 46: 02Z"
+    },
+    "name": "Diaspora Client",
+    "name_with_namespace": "Diaspora / Diaspora Client",
+    "path": "diaspora-client",
+    "path_with_namespace": "diaspora/diaspora-client",
+    "issues_enabled": true,
+    "merge_requests_enabled": true,
+    "builds_enabled": true,
+    "wiki_enabled": true,
+    "snippets_enabled": false,
+    "created_at": "2013-09-30T13: 46: 02Z",
+    "last_activity_at": "2013-09-30T13: 46: 02Z",
+    "creator_id": 3,
+    "namespace": {
+      "created_at": "2013-09-30T13: 46: 02Z",
+      "description": "",
+      "id": 3,
+      "name": "Diaspora",
+      "owner_id": 1,
+      "path": "diaspora",
+      "updated_at": "2013-09-30T13: 46: 02Z"
+    },
+    "archived": false,
+    "avatar_url": "http://example.com/uploads/project/avatar/4/uploads/avatar.png"
+  }
+]

--- a/spec/gitlab/client/groups_spec.rb
+++ b/spec/gitlab/client/groups_spec.rb
@@ -144,6 +144,23 @@ describe Gitlab::Client do
     end
   end
 
+  describe ".group_projects" do
+    before do
+      stub_get("/groups/4/projects", "group_projects")
+      @projects = Gitlab.group_projects(4)
+    end
+
+    it "should get the list of projects" do
+      expect(a_get("/groups/4/projects")).to have_been_made
+    end
+
+    it "should return a list of of projects under a group" do
+      expect(@projects).to be_a Gitlab::PaginatedResponse
+      expect(@projects.size).to eq(1)
+      expect(@projects[0].name).to eq("Diaspora Client")
+    end
+  end
+
   describe ".group_search" do
     before do
       stub_get("/groups?search=Group", "group_search")

--- a/spec/gitlab/shell_spec.rb
+++ b/spec/gitlab/shell_spec.rb
@@ -55,7 +55,7 @@ describe Gitlab::Shell do
       it "should return an Array of matching commands" do
         completed_cmds = @comp.call 'group'
         expect(completed_cmds).to be_a Array
-        expect(completed_cmds.sort).to eq(%w(group group_members group_search groups))
+        expect(completed_cmds.sort).to eq(%w(group group_members group_projects group_search groups))
       end
     end
   end


### PR DESCRIPTION
This allows the user to get a list of projects under a specific group.