### PR TITLE
Move delete_group spec out of the create_group spec

### DIFF
--- a/spec/gitlab/client/groups_spec.rb
+++ b/spec/gitlab/client/groups_spec.rb
@@ -38,24 +38,6 @@ describe Gitlab::Client do
       end
     end
 
-    describe ".delete_group" do
-      context "without description" do
-        before do
-          stub_delete("/groups/42", "group_delete")
-          @group = Gitlab.delete_group(42)
-        end
-
-        it "should get the correct resource" do
-          expect(a_delete("/groups/42")).to have_been_made
-        end
-
-        it "should return information about a deleted group" do
-          expect(@group.name).to eq("Gitlab-Group")
-          expect(@group.path).to eq("gitlab-group")
-        end
-      end
-    end
-
     context "with description" do
       before do
         stub_post("/groups", "group_create_with_description")
@@ -72,6 +54,24 @@ describe Gitlab::Client do
         expect(@group.name).to eq("Gitlab-Group")
         expect(@group.path).to eq("gitlab-group")
         expect(@group.description).to eq("gitlab group description")
+      end
+    end
+  end
+
+  describe ".delete_group" do
+    context "without description" do
+      before do
+        stub_delete("/groups/42", "group_delete")
+        @group = Gitlab.delete_group(42)
+      end
+
+      it "should get the correct resource" do
+        expect(a_delete("/groups/42")).to have_been_made
+      end
+
+      it "should return information about a deleted group" do
+        expect(@group.name).to eq("Gitlab-Group")
+        expect(@group.path).to eq("gitlab-group")
       end
     end
   end


### PR DESCRIPTION
I sort of noticed this tonight, apologies for not noticing it in the previous PR.