### PR TITLE
Add missing Build APIs

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -6,6 +6,7 @@ module Gitlab
     include Branches
     include Builds
     include BuildTriggers
+    include BuildVariables
     include Commits
     include Groups
     include Issues

--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -5,6 +5,7 @@ module Gitlab
 
     include Branches
     include Builds
+    include BuildTriggers
     include Commits
     include Groups
     include Issues

--- a/lib/gitlab/client/build_triggers.rb
+++ b/lib/gitlab/client/build_triggers.rb
@@ -1,0 +1,51 @@
+class Gitlab::Client
+  # Defines methods related to builds.
+  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/build_triggers.md
+  module BuildTriggers
+    # Gets a list of the project's build triggers
+    #
+    # @example
+    #   Gitlab.triggers(5)
+    #
+    # @param  [Integer] project The ID of a project.
+    # @return [Array<Gitlab::ObjectifiedHash>] The list of triggers.
+    def triggers(project)
+      get("/projects/#{project}/triggers")
+    end
+
+    # Gets details of project's build trigger.
+    #
+    # @example
+    #   Gitlab.trigger(5, '7b9148c158980bbd9bcea92c17522d')
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [String] token The token of a trigger.
+    # @return [Gitlab::ObjectifiedHash] The trigger.
+    def trigger(project, token)
+      get("/projects/#{project}/triggers/#{token}")
+    end
+
+    # Create a build trigger for a project.
+    #
+    # @example
+    #   Gitlab.create_trigger(5)
+    #
+    # @param  [Integer] project The ID of a project.
+    # @return [Gitlab::ObjectifiedHash] The trigger.
+    def create_trigger(project)
+      post("/projects/#{project}/triggers")
+    end
+
+    # Remove a project's build trigger.
+    #
+    # @example
+    #   Gitlab.remove_trigger(5, '7b9148c158980bbd9bcea92c17522d')
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [String] token The token of a trigger.
+    # @return [Gitlab::ObjectifiedHash] The trigger.
+    def remove_trigger(project, token)
+      delete("/projects/#{project}/triggers/#{token}")
+    end
+  end
+end

--- a/lib/gitlab/client/build_variables.rb
+++ b/lib/gitlab/client/build_variables.rb
@@ -1,0 +1,66 @@
+class Gitlab::Client
+  # Defines methods related to builds.
+  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/build_variables.md
+  module BuildVariables
+    # Gets a list of the project's build variables
+    #
+    # @example
+    #   Gitlab.variables(5)
+    #
+    # @param  [Integer] project The ID of a project.
+    # @return [Array<Gitlab::ObjectifiedHash>] The list of variables.
+    def variables(project)
+      get("/projects/#{project}/variables")
+    end
+
+    # Gets details of a project's specific build variable.
+    #
+    # @example
+    #   Gitlab.build(5, "TEST_VARIABLE_1")
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [String] key The key of a variable.
+    # @return [Gitlab::ObjectifiedHash] The variable.
+    def variable(project, key)
+      get("/projects/#{project}/variables/#{key}")
+    end
+
+    # Create a build variable for a project.
+    #
+    # @example
+    #   Gitlab.create_variable(5, "NEW_VARIABLE", "new value")
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [String] key The key of a variable; must have no more than 255 characters; only `A-Z`, `a-z`, `0-9` and `_` are allowed
+    # @param  [String] value The value of a variable
+    # @return [Gitlab::ObjectifiedHash] The variable.
+    def create_variable(project, key, value)
+      post("/projects/#{project}/variables", body: { key: key, value: value })
+    end
+
+    # Update a project's build variable.
+    #
+    # @example
+    #   Gitlab.create_variable(5, "NEW_VARIABLE", "updated value")
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [String] key The key of a variable
+    # @param  [String] value The value of a variable
+    # @return [Gitlab::ObjectifiedHash] The variable.
+    def update_variable(project, key, value)
+      put("/projects/#{project}/variables/#{key}", body: { value: value })
+    end
+
+    # Remove a project's build variable.
+    #
+    # @example
+    #   Gitlab.remove_variable(5, "VARIABLE_1")
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [String] key The key of a variable.
+    # @return [Gitlab::ObjectifiedHash] The variable.
+    def remove_variable(project, key)
+      delete("/projects/#{project}/variables/#{key}")
+    end
+  end
+end

--- a/lib/gitlab/client/builds.rb
+++ b/lib/gitlab/client/builds.rb
@@ -25,9 +25,9 @@ class Gitlab::Client
     #
     # @param  [Integer] project The ID of a project.
     # @param  [Integer] id The ID of a build.
-    # @return <Gitlab::ObjectifiedHash]
+    # @return [Gitlab::ObjectifiedHash]
     def build(project, id)
-      get("/projects/#{project}/build/#{id}")
+      get("/projects/#{project}/builds/#{id}")
     end
 
     # Gets a list of builds for specific commit in a project.

--- a/lib/gitlab/client/builds.rb
+++ b/lib/gitlab/client/builds.rb
@@ -69,5 +69,17 @@ class Gitlab::Client
     def build_retry(project, id)
       post("/projects/#{project}/builds/#{id}/retry")
     end
+
+    # Erase a single build of a project (remove build artifacts and a build trace)
+    #
+    # @example
+    #   Gitlab.build_erase(5, 1)
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [Integer] id The ID of a build.
+    # @return [Gitlab::ObjectifiedHash] The build's changes.
+    def build_erase(project, id)
+      post("/projects/#{project}/builds/#{id}/erase")
+    end
   end
 end

--- a/spec/fixtures/build_erase.json
+++ b/spec/fixtures/build_erase.json
@@ -1,0 +1,24 @@
+{
+    "commit": {
+        "author_email": "admin@example.com",
+        "author_name": "John Smith",
+        "created_at": "2015-12-24T16:51:14.000+01:00",
+        "id": "0ff3ae198f8601a285adcf5c0fff204ee6fba5fd",
+        "message": "Test the CI integration.",
+        "short_id": "0ff3ae19",
+        "title": "Test the CI integration."
+    },
+    "coverage": null,
+    "download_url": null,
+    "id": 69,
+    "name": "rubocop",
+    "ref": "master",
+    "runner": null,
+    "stage": "test",
+    "created_at": "2016-01-11T10:13:33.506Z",
+    "started_at": "2016-01-11T10:13:33.506Z",
+    "finished_at": "2016-01-11T10:15:10.506Z",
+    "status": "failed",
+    "tag": false,
+    "user": null
+}

--- a/spec/fixtures/trigger.json
+++ b/spec/fixtures/trigger.json
@@ -1,0 +1,7 @@
+{
+    "created_at": "2015-12-23T16:25:56.760Z",
+    "deleted_at": null,
+    "last_used": null,
+    "token": "7b9148c158980bbd9bcea92c17522d",
+    "updated_at": "2015-12-23T16:25:56.760Z"
+}

--- a/spec/fixtures/triggers.json
+++ b/spec/fixtures/triggers.json
@@ -1,0 +1,16 @@
+[
+    {
+        "created_at": "2015-12-23T16:24:34.716Z",
+        "deleted_at": null,
+        "last_used": "2016-01-04T15:41:21.986Z",
+        "token": "fbdb730c2fbdb095a0862dbd8ab88b",
+        "updated_at": "2015-12-23T16:24:34.716Z"
+    },
+    {
+        "created_at": "2015-12-23T16:25:56.760Z",
+        "deleted_at": null,
+        "last_used": null,
+        "token": "7b9148c158980bbd9bcea92c17522d",
+        "updated_at": "2015-12-23T16:25:56.760Z"
+    }
+]

--- a/spec/fixtures/variable.json
+++ b/spec/fixtures/variable.json
@@ -1,0 +1,4 @@
+{
+    "key": "VARIABLE",
+    "value": "the value"
+}

--- a/spec/fixtures/variables.json
+++ b/spec/fixtures/variables.json
@@ -1,0 +1,10 @@
+[
+    {
+        "key": "TEST_VARIABLE_1",
+        "value": "TEST_1"
+    },
+    {
+        "key": "TEST_VARIABLE_2",
+        "value": "TEST_2"
+    }
+]

--- a/spec/gitlab/client/build_triggers_spec.rb
+++ b/spec/gitlab/client/build_triggers_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe Gitlab::Client do
+  describe ".triggers" do
+    before do
+      stub_get("/projects/3/triggers", "triggers")
+      @triggers = Gitlab.triggers(3)
+    end
+
+    it "should get the correct resource" do
+      expect(a_get("/projects/3/triggers")).to have_been_made
+    end
+
+    it "should return an array of project's triggers" do
+      expect(@triggers).to be_a Gitlab::PaginatedResponse
+      expect(@triggers.first.token).to eq("fbdb730c2fbdb095a0862dbd8ab88b")
+    end
+  end
+
+  describe ".trigger" do
+    before do
+      stub_get("/projects/3/triggers/7b9148c158980bbd9bcea92c17522d", "trigger")
+      @trigger = Gitlab.trigger(3, "7b9148c158980bbd9bcea92c17522d")
+    end
+
+    it "should get the correct resource" do
+      expect(a_get("/projects/3/triggers/7b9148c158980bbd9bcea92c17522d")).to have_been_made
+    end
+
+    it "should return information about a trigger" do
+      expect(@trigger.created_at).to eq("2015-12-23T16:25:56.760Z")
+      expect(@trigger.token).to eq("7b9148c158980bbd9bcea92c17522d")
+    end
+  end
+
+  describe ".create_trigger" do
+    before do
+      stub_post("/projects/3/triggers", "trigger")
+      @trigger = Gitlab.create_trigger(3)
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/triggers")).to have_been_made
+    end
+
+    it "should return information about a new trigger" do
+      expect(@trigger.created_at).to eq("2015-12-23T16:25:56.760Z")
+      expect(@trigger.token).to eq("7b9148c158980bbd9bcea92c17522d")
+    end
+  end
+
+  describe ".remove_trigger" do
+    before do
+      stub_delete("/projects/3/triggers/7b9148c158980bbd9bcea92c17522d", "trigger")
+      @trigger = Gitlab.remove_trigger(3, "7b9148c158980bbd9bcea92c17522d")
+    end
+
+    it "should get the correct resource" do
+      expect(a_delete("/projects/3/triggers/7b9148c158980bbd9bcea92c17522d")).to have_been_made
+    end
+
+    it "should return information about a deleted trigger" do
+      expect(@trigger.created_at).to eq("2015-12-23T16:25:56.760Z")
+      expect(@trigger.token).to eq("7b9148c158980bbd9bcea92c17522d")
+    end
+  end
+end

--- a/spec/gitlab/client/build_variables_spec.rb
+++ b/spec/gitlab/client/build_variables_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+describe Gitlab::Client do
+  describe ".variables" do
+    before do
+      stub_get("/projects/3/variables", "variables")
+      @variables = Gitlab.variables(3)
+    end
+
+    it "should get the correct resource" do
+      expect(a_get("/projects/3/variables")).to have_been_made
+    end
+
+    it "should return an array of project's variables" do
+      expect(@variables).to be_a Gitlab::PaginatedResponse
+      expect(@variables.first.key).to eq("TEST_VARIABLE_1")
+      expect(@variables.first.value).to eq("TEST_1")
+    end
+  end
+
+  describe ".variable" do
+    before do
+      stub_get("/projects/3/variables/VARIABLE", "variable")
+      @variable = Gitlab.variable(3, "VARIABLE")
+    end
+
+    it "should get the correct resource" do
+      expect(a_get("/projects/3/variables/VARIABLE")).to have_been_made
+    end
+
+    it "should return information about a variable" do
+      expect(@variable.key).to eq("VARIABLE")
+      expect(@variable.value).to eq("the value")
+    end
+  end
+
+  describe ".create_variable" do
+    before do
+      stub_post("/projects/3/variables", "variable")
+      @variable = Gitlab.create_variable(3, "NEW_VARIABLE", "new value")
+    end
+
+    it "should get the correct resource" do
+      body = { key: "NEW_VARIABLE", value: "new value" }
+      expect(a_post("/projects/3/variables").with(body: body)).to have_been_made
+    end
+
+    it "should return information about a new variable" do
+      expect(@variable.key).to eq("VARIABLE")
+      expect(@variable.value).to eq("the value")
+    end
+  end
+
+  describe ".update_variable" do
+    before do
+      stub_put("/projects/3/variables/UPD_VARIABLE", "variable")
+      @variable = Gitlab.update_variable(3, "UPD_VARIABLE", "updated value")
+    end
+
+    it "should put the correct resource" do
+      body = { value: "updated value" }
+      expect(a_put("/projects/3/variables/UPD_VARIABLE").with(body: body)).to have_been_made
+    end
+
+    it "should return information about an updated variable" do
+      expect(@variable.key).to eq("VARIABLE")
+      expect(@variable.value).to eq("the value")
+    end
+  end
+
+  describe ".remove_variable" do
+    before do
+      stub_delete("/projects/3/variables/DEL_VARIABLE", "variable")
+      @variable = Gitlab.remove_variable(3, "DEL_VARIABLE")
+    end
+
+    it "should get the correct resource" do
+      expect(a_delete("/projects/3/variables/DEL_VARIABLE")).to have_been_made
+    end
+
+    it "should return information about a deleted variable" do
+      expect(@variable.key).to eq("VARIABLE")
+      expect(@variable.value).to eq("the value")
+    end
+  end
+end

--- a/spec/gitlab/client/builds_spec.rb
+++ b/spec/gitlab/client/builds_spec.rb
@@ -55,6 +55,8 @@ describe Gitlab::Client do
     end
   end
 
+
+
   describe ".build_cancel" do
     before do
       stub_post("/projects/3/builds/8/cancel", "build_cancel")
@@ -93,4 +95,22 @@ describe Gitlab::Client do
     end
   end
 
+  describe ".build_erase" do
+    before do
+      stub_post("/projects/3/builds/69/erase", "build_erase")
+      @build_retry = Gitlab.build_erase(3, 69)
+    end
+    
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/builds/69/erase")).to have_been_made
+    end
+
+    it "should return a single build" do
+      expect(@build_retry).to be_a Gitlab::ObjectifiedHash
+    end
+    
+    it "should return information about a build" do
+      expect(@build_retry.commit.author_name).to eq("John Smith")
+    end
+  end
 end

--- a/spec/gitlab/client/builds_spec.rb
+++ b/spec/gitlab/client/builds_spec.rb
@@ -18,12 +18,12 @@ describe Gitlab::Client do
   
   describe ".build" do
     before do
-      stub_get("/projects/3/build/8", "build")
+      stub_get("/projects/3/builds/8", "build")
       @build = Gitlab.build(3, 8)
     end
     
     it "should get the correct resource" do
-      expect(a_get("/projects/3/build/8")).to have_been_made
+      expect(a_get("/projects/3/builds/8")).to have_been_made
     end
 
     it "should return a single build" do


### PR DESCRIPTION
This client was missing APIs for various new CI features such as:
* Build triggers
* Build variables
* Build content erasing

Also missing is (artifact download)[https://gitlab.com/help/api/builds.md#get-build-artifacts], but I don't know how to go about returning the binary zipfile content.