### PR TITLE
Add missing merge request note actions

### DIFF
--- a/lib/gitlab/client/notes.rb
+++ b/lib/gitlab/client/notes.rb
@@ -170,5 +170,17 @@ class Gitlab::Client
     def modify_merge_request_note(project, merge_request, note, body)
       put("/projects/#{project}/merge_requests/#{merge_request}/notes/#{note}", body: { body: body })
     end
+
+    # Delete existing note for a single merge request.
+    #
+    # @example
+    #   Gitlab.delete_merge_request_note(5, 3, 1)
+    #
+    # @param [Integer] project The ID of a project.
+    # @param [Integer] merge_request The ID of a merge request.
+    # @param [Integer] note The ID of existing note.
+    def delete_merge_request_note(project, merge_request, note)
+      delete("/projects/#{project}/merge_requests/#{merge_request}/notes/#{note}")
+    end
   end
 end

--- a/lib/gitlab/client/notes.rb
+++ b/lib/gitlab/client/notes.rb
@@ -157,5 +157,18 @@ class Gitlab::Client
     def create_merge_request_note(project, merge_request, body)
       post("/projects/#{project}/merge_requests/#{merge_request}/notes", body: { body: body })
     end
+
+    # Modify existing note for a single merge request.
+    #
+    # @example
+    #   Gitlab.modify_merge_request_note(5, 3, 1, 'This MR is ready for review.')
+    #
+    # @param [Integer] project The ID of a project.
+    # @param [Integer] merge_request The ID of a merge request.
+    # @param [Integer] note The ID of existing note.
+    # @param [String] body The content of a note.
+    def modify_merge_request_note(project, merge_request, note, body)
+      put("/projects/#{project}/merge_requests/#{merge_request}/notes/#{note}", body: { body: body })
+    end
   end
 end

--- a/spec/gitlab/client/notes_spec.rb
+++ b/spec/gitlab/client/notes_spec.rb
@@ -221,4 +221,23 @@ describe Gitlab::Client do
       end
     end
   end
+
+  describe 'delete existing note' do
+    context 'when merge request note' do
+      before do
+        stub_delete("/projects/3/merge_requests/7/notes/1", "note")
+        @note = Gitlab.delete_merge_request_note(3, 7, 1)
+      end
+
+      it "should get the correct resource" do
+        expect(a_delete("/projects/3/merge_requests/7/notes/1").
+          with(body: nil)).to have_been_made
+      end
+
+      it "should return information about a created note" do
+        expect(@note.body).to eq("The solution is rather tricky")
+        expect(@note.author.name).to eq("John Smith")
+      end
+    end
+  end
 end

--- a/spec/gitlab/client/notes_spec.rb
+++ b/spec/gitlab/client/notes_spec.rb
@@ -202,4 +202,23 @@ describe Gitlab::Client do
       end
     end
   end
+
+  describe 'modify existing note' do
+    context 'when merge request note' do
+      before do
+        stub_put("/projects/3/merge_requests/7/notes/1", "note")
+        @note = Gitlab.modify_merge_request_note(3, 7, 1, "The solution is rather tricky")
+      end
+
+      it "should get the correct resource" do
+        expect(a_put("/projects/3/merge_requests/7/notes/1").
+          with(body: { body: 'The solution is rather tricky' })).to have_been_made
+      end
+
+      it "should return information about a created note" do
+        expect(@note.body).to eq("The solution is rather tricky")
+        expect(@note.author.name).to eq("John Smith")
+      end
+    end
+  end
 end


### PR DESCRIPTION
According to [API Documentation](http://docs.gitlab.com/ee/api/notes.html#merge-requests) it's possible to modify, and delete existing merge request notes. I didn't see that those methods were implemented so I added them.
