### PR TITLE
Expose response status when Gitlab raises an error.

### DIFF
--- a/spec/gitlab/error_spec.rb
+++ b/spec/gitlab/error_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+describe Gitlab::Error do
+  describe "#handle_message" do
+		require "stringio"
+
+    before do
+      request_object  = HTTParty::Request.new(Net::HTTP::Get, '/')
+      response_object = Net::HTTPOK.new('1.1', 200, 'OK')
+      body = StringIO.new("{foo:'bar'}")
+      def body.message; self.string; end
+
+      parsed_response = lambda { body }
+      response_object['last-modified'] = Date.new(2010, 1, 15).to_s
+      response_object['content-length'] = "1024"
+
+      response = HTTParty::Response.new(request_object, response_object, parsed_response, body: body)
+      @error = Gitlab::Error::ResponseError.new(response)
+
+      @array = Array.new(['First message.', 'Second message.'])
+      @obj_h = Gitlab::ObjectifiedHash.new(user: ['not set'],
+                                           password: ['too short'],
+                                           embed_entity: { foo: ['bar'], sna: ['fu'] })
+    end
+
+    context "when passed an ObjectifiedHash" do
+      it "should return a joined string of error messages sorted by key" do
+        expect(@error.send(:handle_message, @obj_h)).to eq("'embed_entity' (foo: bar) (sna: fu), 'password' too short, 'user' not set")
+      end
+    end
+
+    context "when passed an Array" do
+      it "should return a joined string of messages" do
+        expect(@error.send(:handle_message, @array)).to eq("First message. Second message.")
+      end
+    end
+
+    context "when passed a String" do
+      it "should return the String untouched" do
+        error = 'this is an error string'
+        expect(@error.send(:handle_message, error)).to eq('this is an error string')
+      end
+    end
+  end
+end

--- a/spec/gitlab/request_spec.rb
+++ b/spec/gitlab/request_spec.rb
@@ -70,31 +70,4 @@ describe Gitlab::Request do
       expect(@request.send(:set_authorization_header, {})).to eq("Authorization" => "Bearer 3225e2804d31fea13fc41fc83bffef00cfaedc463118646b154acc6f94747603")
     end
   end
-
-  describe "#handle_error" do
-    before do
-      @array = Array.new(['First message.', 'Second message.'])
-      @obj_h = Gitlab::ObjectifiedHash.new(user: ['not set'],
-                                           password: ['too short'],
-                                           embed_entity: { foo: ['bar'], sna: ['fu'] })
-    end
-    context "when passed an ObjectifiedHash" do
-      it "should return a joined string of error messages sorted by key" do
-        expect(@request.send(:handle_error, @obj_h)).to eq("'embed_entity' (foo: bar) (sna: fu), 'password' too short, 'user' not set")
-      end
-    end
-
-    context "when passed an Array" do
-      it "should return a joined string of messages" do
-        expect(@request.send(:handle_error, @array)).to eq("First message. Second message.")
-      end
-    end
-
-    context "when passed a String" do
-      it "should return the String untouched" do
-        error = 'this is an error string'
-        expect(@request.send(:handle_error, error)).to eq('this is an error string')
-      end
-    end
-  end
 end


### PR DESCRIPTION
Gitlab subclasses errors depending on the response status.
This is great because it allows consumers to handle specific
errors properly.

It is not great if you want to keep audit logs of responses from remote servers.
You could use the class name, and do some normalization. You could also
parse the message that Gitlab provides, but that has some other issues:

1. You need to know all the possible error classes Gitlab implements to
handle error responses.

2. Parsing string is not the best way to do this.

3. It becomes a bigger issue if you integrate with different
Git Hostings that use different libraries and handle errors in different
ways.

Status codes are the canonical way to know what happened with
an http request. They are agnostic to programming languages,
libraries, producers, and consumers.

This patch exposes the status code from the response.

Signed-off-by: David Calavera <david.calavera@gmail.com>