### PR TITLE
Add in GitlabCI Runner support

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -18,6 +18,7 @@ module Gitlab
     include Projects
     include Repositories
     include RepositoryFiles
+    include Runners
     include Services
     include Snippets
     include SystemHooks

--- a/lib/gitlab/client/runners.rb
+++ b/lib/gitlab/client/runners.rb
@@ -1,0 +1,115 @@
+class Gitlab::Client
+  # Defines methods related to runners.
+  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+  module Runners
+
+    # Get a list of specific runners available to the user.
+    # Full runner params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+    #
+    # @example
+    #   Gitlab.runners
+    #   Gitlab.runners(:active)
+    #   Gitlab.runners(:paused)
+    #
+    # @param  [Hash] options A customizable set of options.
+    # @option options [String] :scope The scope of specific runners to show, one of: active, paused, online; showing all runners if none provided
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def runners(options = {})
+      get("/runners", query: options)
+    end
+
+    # Get a list of all runners in the GitLab instance (specific and shared). Access is restricted to users with admin privileges.
+    # Full runner params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+    #
+    # @example
+    #   Gitlab.all_runners
+    #
+    # @param  [Hash] options A customizable set of options.
+    # @option options [String] :scope The scope of runners to show, one of: specific, shared, active, paused, online; showing all runners if none provided
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def all_runners(options = {})
+      get("/runners/all", query: options)
+    end
+
+    # Get details of a runner..
+    # Full runner params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+    #
+    # @example
+    #   Gitlab.runner(42)
+    #
+    # @param  [Integer, String] id The ID of a runner
+    # @return <Gitlab::ObjectifiedHash>
+    def runner(id)
+      get("/runners/#{id}")
+    end
+
+    # Update details of a runner.
+    # Full runner params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+    #
+    # @example
+    #   Gitlab.update_runner(42, { description: 'Awesome runner' })
+    #   Gitlab.update_runner(42, { active: false })
+    #   Gitlab.update_runner(42, { tag_list: [ 'awesome', 'runner' ] })
+    #
+    # @param  [Integer, String] id The ID of a runner
+    # @param  [Hash] options A customizable set of options.
+    # @option options [String] :active The state of a runner; can be set to true or false.
+    # @option options [String] :tag_list The list of tags for a runner; put array of tags, that should be finally assigned to a runner
+    # @return <Gitlab::ObjectifiedHash>
+    def update_runner(id, options={})
+      put("/runners/#{id}", query: options)
+    end
+
+    # Remove a runner.
+    # Full runner params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+    #
+    # @example
+    #   Gitlab.delete_runner(42)
+    #
+    # @param  [Integer, String] id The ID of a runner
+    # @return <Gitlab::ObjectifiedHash>
+    def delete_runner(id)
+      delete("/runners/#{id}")
+    end
+
+    # List all runners (specific and shared) available in the project. Shared runners are listed if at least one shared runner is defined and shared runners usage is enabled in the project's settings.
+    # Full runner params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+    #
+    # @example
+    #   Gitlab.project_runners(42)
+    #
+    # @param  [Integer, String] id The ID of a project.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def project_runners(project_id)
+      get("/projects/#{project_id}/runners")
+    end
+
+    # Enable an available specific runner in the project.
+    # Full runner params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+    #
+    # @example
+    #   Gitlab.project_enable_runner(2, 42)
+    #
+    # @param  [Integer, String] id The ID of a project.
+    # @param  [Integer, String] id The ID of a runner.
+    # @return <Gitlab::ObjectifiedHash>
+    def project_enable_runner(project_id, id)
+      body = { runner_id: id }
+      post("/projects/#{project_id}/runners", body: body)
+    end
+
+    # Disable a specific runner from the project. It works only if the project isn't the only project associated with the specified runner.
+    # Full runner params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+    #
+    # @example
+    #   Gitlab.project_disable_runner(2, 42)
+    #
+    # @param  [Integer, String] id The ID of a project.
+    # @param  [Integer, String] runner_id The ID of a runner.
+    # @return <Gitlab::ObjectifiedHash>
+    def project_disable_runner(id, runner_id)
+      delete("/projects/#{id}/runners/#{runner_id}")
+    end
+
+  end
+end

--- a/spec/fixtures/project_runner_enable.json
+++ b/spec/fixtures/project_runner_enable.json
@@ -1,0 +1,7 @@
+{
+    "active": true,
+    "description": "test-2016-02-01",
+    "id": 9,
+    "is_shared": false,
+    "name": null
+}

--- a/spec/fixtures/project_runners.json
+++ b/spec/fixtures/project_runners.json
@@ -1,0 +1,16 @@
+[
+    {
+        "active": true,
+        "description": "test-2-20150125",
+        "id": 8,
+        "is_shared": false,
+        "name": null
+    },
+    {
+        "active": true,
+        "description": "development_runner",
+        "id": 5,
+        "is_shared": true,
+        "name": null
+    }
+]

--- a/spec/fixtures/runner.json
+++ b/spec/fixtures/runner.json
@@ -1,0 +1,26 @@
+{
+    "active": true,
+    "architecture": null,
+    "description": "test-1-20150125",
+    "id": 6,
+    "is_shared": false,
+    "contacted_at": "2016-01-25T16:39:48.066Z",
+    "name": null,
+    "platform": null,
+    "projects": [
+        {
+            "id": 1,
+            "name": "GitLab Community Edition",
+            "name_with_namespace": "GitLab.org / GitLab Community Edition",
+            "path": "gitlab-ce",
+            "path_with_namespace": "gitlab-org/gitlab-ce"
+        }
+    ],
+    "token": "205086a8e3b9a2b818ffac9b89d102",
+    "revision": null,
+    "tag_list": [
+        "ruby",
+        "mysql"
+    ],
+    "version": null
+}

--- a/spec/fixtures/runner_delete.json
+++ b/spec/fixtures/runner_delete.json
@@ -1,0 +1,7 @@
+{
+    "active": true,
+    "description": "test-1-20150125-test",
+    "id": 6,
+    "is_shared": false,
+    "name": null
+}

--- a/spec/fixtures/runner_edit.json
+++ b/spec/fixtures/runner_edit.json
@@ -1,0 +1,26 @@
+{
+    "active": true,
+    "architecture": null,
+    "description": "abcefg",
+    "id": 6,
+    "is_shared": false,
+    "contacted_at": "2016-01-25T16:39:48.066Z",
+    "name": null,
+    "platform": null,
+    "projects": [
+        {
+            "id": 1,
+            "name": "GitLab Community Edition",
+            "name_with_namespace": "GitLab.org / GitLab Community Edition",
+            "path": "gitlab-ce",
+            "path_with_namespace": "gitlab-org/gitlab-ce"
+        }
+    ],
+    "token": "205086a8e3b9a2b818ffac9b89d102",
+    "revision": null,
+    "tag_list": [
+        "ruby",
+        "mysql"
+    ],
+    "version": null
+}

--- a/spec/fixtures/runners.json
+++ b/spec/fixtures/runners.json
@@ -1,0 +1,16 @@
+[
+    {
+        "active": true,
+        "description": "test-1-20150125",
+        "id": 6,
+        "is_shared": false,
+        "name": null
+    },
+    {
+        "active": true,
+        "description": "test-2-20150125",
+        "id": 8,
+        "is_shared": false,
+        "name": null
+    }
+]

--- a/spec/fixtures/runners_all.json
+++ b/spec/fixtures/runners_all.json
@@ -1,0 +1,30 @@
+[
+    {
+        "active": true,
+        "description": "shared-runner-1",
+        "id": 1,
+        "is_shared": true,
+        "name": null
+    },
+    {
+        "active": true,
+        "description": "shared-runner-2",
+        "id": 3,
+        "is_shared": true,
+        "name": null
+    },
+    {
+        "active": true,
+        "description": "test-1-20150125",
+        "id": 6,
+        "is_shared": false,
+        "name": null
+    },
+    {
+        "active": true,
+        "description": "test-2-20150125",
+        "id": 8,
+        "is_shared": false,
+        "name": null
+    }
+]

--- a/spec/gitlab/client/runners_spec.rb
+++ b/spec/gitlab/client/runners_spec.rb
@@ -1,0 +1,185 @@
+require 'spec_helper'
+
+describe Gitlab::Client do
+
+  describe ".runners" do
+    before do
+      stub_get("/runners", "runners")
+    end
+
+    context 'without scope' do
+      before do
+        @runner = Gitlab.runners
+      end
+
+      it "should get the correct resource" do
+        expect(a_get("/runners")).to have_been_made
+      end
+
+      it "should return a paginated response of runners" do
+        expect(@runner).to be_a Gitlab::PaginatedResponse
+        expect(@runner.first.id).to eq(6)
+        expect(@runner.first.description).to eq('test-1-20150125')
+      end
+    end
+
+    context 'with scope' do
+      before do
+        stub_get("/runners?scope=online", "runners")
+        @runner = Gitlab.runners({scope: :online})
+      end
+
+      it "should get the correct resource" do
+        expect(a_get("/runners").with(query: { scope: :online })).to have_been_made
+      end
+
+      it "should return a paginated response of runners" do
+        expect(@runner).to be_a Gitlab::PaginatedResponse
+        expect(@runner.first.id).to eq(6)
+        expect(@runner.first.description).to eq('test-1-20150125')
+      end
+    end
+
+  end
+
+  describe ".all_runners" do
+    before do
+      stub_get("/runners/all", "runners")
+    end
+
+    context 'without scope' do
+      before do
+        @runner = Gitlab.all_runners
+      end
+
+      it "should get the correct resource" do
+        expect(a_get("/runners/all")).to have_been_made
+      end
+
+      it "should return a paginated response of runners" do
+        expect(@runner).to be_a Gitlab::PaginatedResponse
+        expect(@runner.first.id).to eq(6)
+        expect(@runner.first.description).to eq('test-1-20150125')
+      end
+    end
+
+    context 'with scope' do
+      before do
+        stub_get("/runners/all?scope=online", "runners")
+        @runner = Gitlab.all_runners({scope: :online})
+      end
+
+      it "should get the correct resource" do
+        expect(a_get("/runners/all").with(query: { scope: :online })).to have_been_made
+      end
+
+      it "should return a paginated response of runners" do
+        expect(@runner).to be_a Gitlab::PaginatedResponse
+        expect(@runner.first.id).to eq(6)
+        expect(@runner.first.description).to eq('test-1-20150125')
+      end
+    end
+  end
+
+  describe ".runner" do
+    before do
+      stub_get("/runners/6", "runner")
+      @runners = Gitlab.runner(6)
+    end
+
+    it "should get the correct resource" do
+      expect(a_get("/runners/6")).to have_been_made
+    end
+
+    it "should return a response of a runner" do
+      expect(@runners).to be_a Gitlab::ObjectifiedHash
+      expect(@runners.id).to eq(6)
+      expect(@runners.description).to eq('test-1-20150125')
+    end
+  end
+
+  describe ".update_runner" do
+    before do
+      stub_put("/runners/6", "runner_edit").with(query: { description: "abcefg" })
+      @runner = Gitlab.update_runner(6, description: "abcefg" )
+    end
+
+    it "should get the correct resource" do
+      expect(a_put("/runners/6").with(query: { description: "abcefg" })).to have_been_made
+    end
+
+    it "should return an updated response of a runner" do
+      expect(@runner).to be_a Gitlab::ObjectifiedHash
+      expect(@runner.description).to eq('abcefg')
+    end
+  end
+
+  describe ".delete_runner" do
+    before do
+      stub_delete("/runners/6", "runner_delete")
+      @runner = Gitlab.delete_runner(6)
+    end
+
+    it "should get the correct resource" do
+      expect(a_delete("/runners/6")).to have_been_made
+    end
+
+    it "should return a response of the deleted runner" do
+      expect(@runner).to be_a Gitlab::ObjectifiedHash
+      expect(@runner.id).to eq(6)
+    end
+  end
+
+  describe ".project_runners" do
+    before do
+      stub_get("/projects/1/runners", "project_runners")
+      @runners = Gitlab.project_runners(1)
+    end
+
+    it "should get the correct resource" do
+      expect(a_get("/projects/1/runners")).to have_been_made
+    end
+
+    it "should return a paginated response of runners" do
+      expect(@runners).to be_a Gitlab::PaginatedResponse
+      expect(@runners.first.id).to eq(8)
+      expect(@runners.first.description).to eq('test-2-20150125')
+    end
+  end
+
+  describe ".project_enable_runner" do
+    before do
+      stub_post("/projects/1/runners", "runner")
+      @runner = Gitlab.project_enable_runner(1, 6)
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/1/runners")).to have_been_made
+    end
+
+    it "should return a response of the enabled runner" do
+      expect(@runner).to be_a Gitlab::ObjectifiedHash
+      expect(@runner.id).to eq(6)
+      expect(@runner.description).to eq('test-1-20150125')
+    end
+  end
+
+  describe ".project_disable_runner" do
+    before do
+      stub_delete("/projects/1/runners/6", "runner")
+      @runner = Gitlab.project_disable_runner(1, 6)
+    end
+
+    it "should get the correct resource" do
+      expect(a_delete("/projects/1/runners/6")).to have_been_made
+    end
+
+    it "should return a response of the disabled runner" do
+      expect(@runner).to be_a Gitlab::ObjectifiedHash
+      expect(@runner.id).to eq(6)
+      expect(@runner.description).to eq('test-1-20150125')
+    end
+  end
+
+
+end


### PR DESCRIPTION
This pull request (as titled) adds in runner support:

* List users runners
* List all runners (if admin)
* List projects runners (specific)
* Get runner
* Update runner
* Delete runner
* Enable project runner
* Disable project runner
