### PR TITLE
Add method `share_project_with_group`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Added possibility to change emails of user (@azomazo)
 - Added possibility to change services in the project (@azomazo)
 - Update README.md (@walterheck)
+- Add method `share_project_with_group` (@danhalligan)
 
 ### 3.6.1 (13/12/2015)
 

--- a/lib/gitlab/client/projects.rb
+++ b/lib/gitlab/client/projects.rb
@@ -405,5 +405,18 @@ class Gitlab::Client
     def edit_project(id, options={})
       put("/projects/#{id}", query: options)
     end
+
+    # Share project with group.
+    #
+    # @example
+    #   Gitlab.share_project_with_group('gitlab', 2, 40)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of a group.
+    # @param  [Integer] group_access The access level to project.
+    def share_project_with_group(project, id, group_access)
+      post("/projects/#{project}/share", body: { group_id: id, group_access: group_access })
+    end
+
   end
 end

--- a/spec/gitlab/client/projects_spec.rb
+++ b/spec/gitlab/client/projects_spec.rb
@@ -522,4 +522,20 @@ describe Gitlab::Client do
       expect(@deploy_key.id).to eq(2)
     end
   end
+
+  describe ".share_project_with_group" do
+    before do
+      stub_post("/projects/3/share", "group")
+      @group = Gitlab.share_project_with_group(3, 10, 40)
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/share").
+          with(body: { group_id: '10', group_access: '40' })).to have_been_made
+    end
+
+    it "should return information about an added group" do
+      expect(@group.id).to eq(10)
+    end
+  end
 end


### PR DESCRIPTION
Adds method + test (rspec) in Projects to share a project with a group.

Resolves #214