### PR TITLE
Add repo_archive method

### DIFF
--- a/lib/gitlab/file_response.rb
+++ b/lib/gitlab/file_response.rb
@@ -40,6 +40,7 @@ module Gitlab
     # Parse filename from the 'Content Disposition' header.
     def parse_headers!(headers)
       @filename = headers[HEADER_CONTENT_DISPOSITION].split("filename=")[1]
+      @filename = @filename[1...-1] if @filename[0] == '"' # Unquote filenames
     end
   end
 end

--- a/spec/gitlab/file_response_spec.rb
+++ b/spec/gitlab/file_response_spec.rb
@@ -21,7 +21,12 @@ describe Gitlab::FileResponse do
 
   context '.parse_headers!' do
     it "should parse headers" do
-      @file_response.parse_headers!('Content-Disposition' => "attachment; filename=artifacts.zip")
+      @file_response.parse_headers!('Content-Disposition' => 'attachment; filename=artifacts.zip')
+      expect(@file_response.filename).to eq "artifacts.zip"
+    end
+
+    it "should handle quoted filenames" do
+      @file_response.parse_headers!('Content-Disposition' => 'attachment; filename="artifacts.zip"')
       expect(@file_response.filename).to eq "artifacts.zip"
     end
   end


### PR DESCRIPTION
This allows downloading a repository archive. Uses the same structure as for downloading build artifacts.

See http://docs.gitlab.com/ce/api/repositories.html#get-file-archive for more details.
