### PR TITLE
Update documentation links to use docs.gitlab.com.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 - Lock terminal-table to prevent build failures on Ruby 1.9/2.0. (@connorshea)
+- Update documentation to link to docs.gitlab.com instead of the GitHub mirror for GitLab CE. (@connorshea)
 
 ### 3.7.0 (16/08/2016)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [documentation](http://rubydoc.info/gems/gitlab/frames) |
 [gitlab-live](https://github.com/NARKOZ/gitlab-live)
 
-Gitlab is a Ruby wrapper and CLI for the [GitLab API](https://github.com/gitlabhq/gitlabhq/tree/master/doc/api#gitlab-api).
+Gitlab is a Ruby wrapper and CLI for the [GitLab API](https://docs.gitlab.com/ce/api/README.html).
 
 ## Installation
 
@@ -41,7 +41,7 @@ Gitlab.configure do |config|
 end
 ```
 
-(Note: If you are using Gitlab.com's hosted service, your endpoint will be `https://gitlab.com/api/v3`)
+(Note: If you are using GitLab.com's hosted service, your endpoint will be `https://gitlab.com/api/v3`)
 
 Usage examples:
 

--- a/lib/gitlab/client/branches.rb
+++ b/lib/gitlab/client/branches.rb
@@ -1,6 +1,6 @@
 class Gitlab::Client
   # Defines methods related to repositories.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/branches.md
+  # @see https://docs.gitlab.com/ce/api/branches.html
   module Branches
     # Gets a list of project repositiory branches.
     #

--- a/lib/gitlab/client/build_triggers.rb
+++ b/lib/gitlab/client/build_triggers.rb
@@ -1,6 +1,6 @@
 class Gitlab::Client
   # Defines methods related to builds.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/build_triggers.md
+  # @see https://docs.gitlab.com/ce/api/build_triggers.html
   module BuildTriggers
     # Gets a list of the project's build triggers
     #

--- a/lib/gitlab/client/build_variables.rb
+++ b/lib/gitlab/client/build_variables.rb
@@ -1,6 +1,6 @@
 class Gitlab::Client
   # Defines methods related to builds.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/build_variables.md
+  # @see https://docs.gitlab.com/ce/api/build_variables.html
   module BuildVariables
     # Gets a list of the project's build variables
     #

--- a/lib/gitlab/client/builds.rb
+++ b/lib/gitlab/client/builds.rb
@@ -1,6 +1,6 @@
 class Gitlab::Client
   # Defines methods related to builds.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/builds.md
+  # @see https://docs.gitlab.com/ce/api/builds.html
   module Builds
     # Gets a list of project builds.
     #

--- a/lib/gitlab/client/commits.rb
+++ b/lib/gitlab/client/commits.rb
@@ -1,6 +1,6 @@
 class Gitlab::Client
   # Defines methods related to repository commits.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/commits.md
+  # @see https://docs.gitlab.com/ce/api/commits.html
   module Commits
     # Gets a list of project commits.
     #

--- a/lib/gitlab/client/groups.rb
+++ b/lib/gitlab/client/groups.rb
@@ -1,6 +1,6 @@
 class Gitlab::Client
   # Defines methods related to groups.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/groups.md
+  # @see https://docs.gitlab.com/ce/api/groups.html
   module Groups
     # Gets a list of groups.
     #

--- a/lib/gitlab/client/issues.rb
+++ b/lib/gitlab/client/issues.rb
@@ -1,6 +1,6 @@
 class Gitlab::Client
   # Defines methods related to issues.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/issues.md
+  # @see https://docs.gitlab.com/ce/api/issues.html
   module Issues
     # Gets a list of user's issues.
     # Will return a list of project's issues if project ID passed.

--- a/lib/gitlab/client/labels.rb
+++ b/lib/gitlab/client/labels.rb
@@ -1,6 +1,6 @@
 class Gitlab::Client
   # Defines methods related to labels.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/labels.md
+  # @see https://docs.gitlab.com/ce/api/labels.html
   module Labels
     # Gets a list of project's labels.
     #

--- a/lib/gitlab/client/merge_requests.rb
+++ b/lib/gitlab/client/merge_requests.rb
@@ -1,6 +1,6 @@
 class Gitlab::Client
   # Defines methods related to merge requests.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/merge_requests.md
+  # @see https://docs.gitlab.com/ce/api/merge_requests.html
   module MergeRequests
     # Gets a list of project merge requests.
     #

--- a/lib/gitlab/client/milestones.rb
+++ b/lib/gitlab/client/milestones.rb
@@ -1,6 +1,6 @@
 class Gitlab::Client
   # Defines methods related to milestones.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/milestones.md
+  # @see https://docs.gitlab.com/ce/api/milestones.html
   module Milestones
     # Gets a list of project's milestones.
     #

--- a/lib/gitlab/client/namespaces.rb
+++ b/lib/gitlab/client/namespaces.rb
@@ -1,8 +1,9 @@
 class Gitlab::Client
   # Defines methods related to namespaces
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/namespaces.md
+  # @see https://docs.gitlab.com/ce/api/namespaces.html
   module Namespaces
     # Gets a list of namespaces.
+    # @see https://docs.gitlab.com/ce/api/namespaces.html#list-namespaces
     #
     # @example
     #   Gitlab.namespaces

--- a/lib/gitlab/client/notes.rb
+++ b/lib/gitlab/client/notes.rb
@@ -1,6 +1,6 @@
 class Gitlab::Client
   # Defines methods related to notes.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/notes.md
+  # @see https://docs.gitlab.com/ce/api/notes.html
   module Notes
     # Gets a list of projects notes.
     #

--- a/lib/gitlab/client/projects.rb
+++ b/lib/gitlab/client/projects.rb
@@ -1,6 +1,6 @@
 class Gitlab::Client
   # Defines methods related to projects.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/projects.md
+  # @see https://docs.gitlab.com/ce/api/projects.html
   module Projects
     # Gets a list of projects owned by the authenticated user.
     #
@@ -248,7 +248,7 @@ class Gitlab::Client
     end
 
     # Gets a project git hook.
-    # See: http://docs.gitlab.com/ee/api/projects.html#show-project-git-hooks
+    # @see https://docs.gitlab.com/ee/api/projects.html#show-project-git-hooks
     #
     # @example
     #   Gitlab.git_hook(42)
@@ -260,7 +260,7 @@ class Gitlab::Client
     end
 
     # Adds a project git hook.
-    # See: http://docs.gitlab.com/ee/api/projects.html#add-project-git-hook
+    # @see https://docs.gitlab.com/ee/api/projects.html#add-project-git-hook
     #
     # @example
     #   Gitlab.add_git_hook(42, { deny_delete_tag: false, commit_message_regex: '\\b[A-Z]{3}-[0-9]+\\b' })
@@ -275,7 +275,7 @@ class Gitlab::Client
     end
 
     # Updates a project git hook.
-    # See: http://docs.gitlab.com/ee/api/projects.html#edit-project-git-hook
+    # @see https://docs.gitlab.com/ee/api/projects.html#edit-project-git-hook
     #
     # @example
     #   Gitlab.edit_git_hook(42, { deny_delete_tag: false, commit_message_regex: '\\b[A-Z]{3}-[0-9]+\\b' })
@@ -290,7 +290,7 @@ class Gitlab::Client
     end
 
     # Deletes a git hook from a project.
-    # See: http://docs.gitlab.com/ee/api/projects.html#delete-project-git-hook
+    # @see https://docs.gitlab.com/ee/api/projects.html#delete-project-git-hook
     #
     # @example
     #   Gitlab.delete_git_hook(42)

--- a/lib/gitlab/client/repositories.rb
+++ b/lib/gitlab/client/repositories.rb
@@ -1,6 +1,6 @@
 class Gitlab::Client
   # Defines methods related to repositories.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/repositories.md
+  # @see https://docs.gitlab.com/ce/api/repositories.html
   module Repositories
     # Get the contents of a file
     #

--- a/lib/gitlab/client/repository_files.rb
+++ b/lib/gitlab/client/repository_files.rb
@@ -2,7 +2,7 @@ require 'base64'
 
 class Gitlab::Client
   # Defines methods related to repository files.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/repository_files.md
+  # @see https://docs.gitlab.com/ce/api/repository_files.html
   module RepositoryFiles
     # Gets a repository file.
     #

--- a/lib/gitlab/client/runners.rb
+++ b/lib/gitlab/client/runners.rb
@@ -1,10 +1,10 @@
 class Gitlab::Client
   # Defines methods related to runners.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+  # @see https://docs.gitlab.com/ce/api/runners.html
   module Runners
 
     # Get a list of specific runners available to the user.
-    # Full runner params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+    # @see https://docs.gitlab.com/ce/api/runners.html#list-owned-runners
     #
     # @example
     #   Gitlab.runners
@@ -19,7 +19,7 @@ class Gitlab::Client
     end
 
     # Get a list of all runners in the GitLab instance (specific and shared). Access is restricted to users with admin privileges.
-    # Full runner params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+    # @see https://docs.gitlab.com/ce/api/runners.html#list-all-runners
     #
     # @example
     #   Gitlab.all_runners
@@ -32,7 +32,7 @@ class Gitlab::Client
     end
 
     # Get details of a runner..
-    # Full runner params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+    # @see https://docs.gitlab.com/ce/api/runners.html#get-runners-details
     #
     # @example
     #   Gitlab.runner(42)
@@ -44,7 +44,7 @@ class Gitlab::Client
     end
 
     # Update details of a runner.
-    # Full runner params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+    # @see https://docs.gitlab.com/ce/api/runners.html#update-runners-details
     #
     # @example
     #   Gitlab.update_runner(42, { description: 'Awesome runner' })
@@ -61,7 +61,7 @@ class Gitlab::Client
     end
 
     # Remove a runner.
-    # Full runner params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+    # @see https://docs.gitlab.com/ce/api/runners.html#remove-a-runner
     #
     # @example
     #   Gitlab.delete_runner(42)
@@ -73,7 +73,7 @@ class Gitlab::Client
     end
 
     # List all runners (specific and shared) available in the project. Shared runners are listed if at least one shared runner is defined and shared runners usage is enabled in the project's settings.
-    # Full runner params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+    # @see https://docs.gitlab.com/ce/api/runners.html#list-projects-runners
     #
     # @example
     #   Gitlab.project_runners(42)
@@ -85,7 +85,7 @@ class Gitlab::Client
     end
 
     # Enable an available specific runner in the project.
-    # Full runner params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+    # @see https://docs.gitlab.com/ce/api/runners.html#enable-a-runner-in-project
     #
     # @example
     #   Gitlab.project_enable_runner(2, 42)
@@ -99,7 +99,7 @@ class Gitlab::Client
     end
 
     # Disable a specific runner from the project. It works only if the project isn't the only project associated with the specified runner.
-    # Full runner params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/runners.md
+    # @see https://docs.gitlab.com/ce/api/runners.html#disable-a-runner-from-project
     #
     # @example
     #   Gitlab.project_disable_runner(2, 42)

--- a/lib/gitlab/client/services.rb
+++ b/lib/gitlab/client/services.rb
@@ -1,4 +1,6 @@
 class Gitlab::Client
+  # Third party services connected to a project.
+  # @see https://docs.gitlab.com/ce/api/services.html
   module Services
     # Create/Edit service
     # Full service params documentation: https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/services.md

--- a/lib/gitlab/client/snippets.rb
+++ b/lib/gitlab/client/snippets.rb
@@ -1,6 +1,6 @@
 class Gitlab::Client
   # Defines methods related to snippets.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/project_snippets.md
+  # @see https://docs.gitlab.com/ce/api/project_snippets.html
   module Snippets
     # Gets a list of project's snippets.
     #

--- a/lib/gitlab/client/system_hooks.rb
+++ b/lib/gitlab/client/system_hooks.rb
@@ -1,6 +1,6 @@
 class Gitlab::Client
   # Defines methods related to system hooks.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/system_hooks.md
+  # @see https://docs.gitlab.com/ce/api/system_hooks.html
   module SystemHooks
     # Gets a list of system hooks.
     #

--- a/lib/gitlab/client/tags.rb
+++ b/lib/gitlab/client/tags.rb
@@ -1,6 +1,6 @@
 class Gitlab::Client
   # Defines methods related to tags.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/tags.md
+  # @see https://docs.gitlab.com/ce/api/tags.html
   module Tags
     # Gets a list of project repository tags.
     #

--- a/lib/gitlab/client/users.rb
+++ b/lib/gitlab/client/users.rb
@@ -1,7 +1,7 @@
 class Gitlab::Client
   # Defines methods related to users.
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/users.md
-  # @see https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/session.md
+  # @see https://docs.gitlab.com/ce/api/users.html
+  # @see https://docs.gitlab.com/ce/api/session.html
   module Users
     # Gets a list of users.
     #


### PR DESCRIPTION
Update relevant documentation links for the client classes to point to https://docs.gitlab.com instead of the GitHub mirror of the repository.