### PR TITLE
Lock terminal-table version to provide support for Ruby 1.9 and 2.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0
-  - 2.1
-  - 2.2
-  - 2.3.0
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
 before_install: gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.1
+  - 2.2
+  - 2.3
 before_install: gem update bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change Log
 
+### Unreleased
+
+- Lock terminal-table to prevent build failures on Ruby 1.9/2.0. (@connorshea)
+
 ### 3.7.0 (16/08/2016)
 
 - Add in GitlabCI Runner support (@davidcollum)

--- a/gitlab.gemspec
+++ b/gitlab.gemspec
@@ -24,7 +24,8 @@ Gem::Specification.new do |gem|
   else
     gem.add_runtime_dependency 'httparty'
   end
-  gem.add_runtime_dependency 'terminal-table'
+
+  gem.add_runtime_dependency 'terminal-table', '1.7.1'
 
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
1.9.x and 2.0.x are both EOL, they're no longer supported with security releases. Travis builds were failing due to terminal-table releasing a breaking change for old Ruby versions in a patch version.