### PR TITLE
Allow to retrieve ssh_keys for a specific user

### DIFF
--- a/lib/gitlab/client/users.rb
+++ b/lib/gitlab/client/users.rb
@@ -127,13 +127,20 @@ class Gitlab::Client
     #
     # @example
     #   Gitlab.ssh_keys
+    #   Gitlab.ssh_keys({ user_id: 2 })
     #
     # @param  [Hash] options A customizable set of options.
     # @option options [Integer] :page The page number.
     # @option options [Integer] :per_page The number of results per page.
+    # @option options [Integer] :user_id The ID of the user to retrieve the keys for.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def ssh_keys(options={})
-      get("/user/keys", query: options)
+      user_id = options.delete :user_id
+      if user_id.to_i.zero?
+        get("/user/keys", query: options)
+      else
+        get("/users/#{user_id}/keys", query: options)
+      end
     end
 
     # Gets information about SSH key.

--- a/spec/gitlab/client/users_spec.rb
+++ b/spec/gitlab/client/users_spec.rb
@@ -201,18 +201,36 @@ describe Gitlab::Client do
   end
 
   describe ".ssh_keys" do
-    before do
-      stub_get("/user/keys", "keys")
-      @keys = Gitlab.ssh_keys
+    context "with user ID passed" do
+      before do
+        stub_get("/users/1/keys", "keys")
+        @keys = Gitlab.ssh_keys({ user_id: 1 })
+      end
+
+      it "should get the correct resource" do
+        expect(a_get("/users/1/keys")).to have_been_made
+      end
+
+      it "should return a paginated response of SSH keys" do
+        expect(@keys).to be_a Gitlab::PaginatedResponse
+        expect(@keys.first.title).to eq("narkoz@helium")
+      end
     end
 
-    it "should get the correct resource" do
-      expect(a_get("/user/keys")).to have_been_made
-    end
+    context "without user ID passed" do
+      before do
+        stub_get("/user/keys", "keys")
+        @keys = Gitlab.ssh_keys
+      end
 
-    it "should return a paginated response of SSH keys" do
-      expect(@keys).to be_a Gitlab::PaginatedResponse
-      expect(@keys.first.title).to eq("narkoz@helium")
+      it "should get the correct resource" do
+        expect(a_get("/user/keys")).to have_been_made
+      end
+
+      it "should return a paginated response of SSH keys" do
+        expect(@keys).to be_a Gitlab::PaginatedResponse
+        expect(@keys.first.title).to eq("narkoz@helium")
+      end
     end
   end
 


### PR DESCRIPTION
This pull request implements the API call for https://docs.gitlab.com/ce/api/users.html#list-ssh-keys-for-user.