### PR TITLE
Remove the Ruby 1.x support in the gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0
   - 2.1
   - 2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- Remove Ruby 1.x support from the project - (@orta)
 - Add `star_project` and `unstar_project` methods. (@connorshea)
 - Lock terminal-table to prevent build failures on Ruby 1.9/2.0. (@connorshea)
 - Update documentation to link to docs.gitlab.com instead of the GitHub mirror for GitLab CE. (@connorshea)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [documentation](http://rubydoc.info/gems/gitlab/frames) |
 [gitlab-live](https://github.com/NARKOZ/gitlab-live)
 
-Gitlab is a Ruby wrapper and CLI for the [GitLab API](https://docs.gitlab.com/ce/api/README.html).
+Gitlab is a Ruby wrapper and CLI for the [GitLab API](https://docs.gitlab.com/ce/api/README.html) for Ruby 2.0+.
 
 ## Installation
 

--- a/gitlab.gemspec
+++ b/gitlab.gemspec
@@ -19,12 +19,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license       = "BSD"
 
-  if RUBY_VERSION < '2.0'
-    gem.add_runtime_dependency 'httparty', '~> 0.13.0'
-  else
-    gem.add_runtime_dependency 'httparty'
-  end
+  gem.required_ruby_version = ">= 2.0.0"
 
+  gem.add_runtime_dependency 'httparty'
   gem.add_runtime_dependency 'terminal-table', '1.7.1'
 
   gem.add_development_dependency 'pry'


### PR DESCRIPTION
This is the result from the discussion in https://github.com/NARKOZ/gitlab/issues/217 👍 