### PR TITLE
Mask the token when inspect the client object

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -24,5 +24,24 @@ module Gitlab
     include SystemHooks
     include Tags
     include Users
+
+    # Text representation of the client, masking private token.
+    #
+    # @return [String]
+    def inspect
+      inspected = super
+
+      if @private_token
+        inspected = inspected.sub! @private_token, only_show_last_four_chars(@private_token)
+      end
+
+      inspected
+    end
+
+    private
+
+    def only_show_last_four_chars(token)
+      "#{'*'*(token.size - 4)}#{token[-4..-1]}"
+    end
   end
 end

--- a/spec/gitlab/client/client_spec.rb
+++ b/spec/gitlab/client/client_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Gitlab::Client do
+  describe '#inspect' do
+    it 'masks tokens on inspect' do
+      client = described_class.new(private_token: 'ui3gIYf4MMzTx-Oh5cEBx')
+      inspected = client.inspect
+      expect(inspected).to include('****************cEBx')
+    end
+  end
+end


### PR DESCRIPTION
This PR masks the token when invoking `inspect` on gitlab client.

So when people do bug report, they won't accidentally pasted token information. [other client library](https://github.com/octokit/octokit.rb/blob/c1e66093eeb499c59e49212ca10c2a4efc356836/lib/octokit/client.rb#L118-L133) also does this.