### PR TITLE
Add methods to disable and enable deploy keys on projects.

### DIFF
--- a/lib/gitlab/client/projects.rb
+++ b/lib/gitlab/client/projects.rb
@@ -364,6 +364,30 @@ class Gitlab::Client
       post("/projects/#{project}/keys", body: { title: title, key: key })
     end
 
+    # Enables a deploy key at the project.
+    #
+    # @example
+    #   Gitlab.enable_deploy_key(42, 66)
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [Integer] key The ID of a deploy key.
+    # @return [Gitlab::ObjectifiedHash] Information about the enabled deploy key.
+    def enable_deploy_key(project, key)
+      post("/projects/#{project}/deploy_keys/#{key}/enable", body: { id: project, key_id: key })
+    end
+
+    # Disables a deploy key at the project.
+    #
+    # @example
+    #   Gitlab.disable_deploy_key(42, 66)
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [Integer] key The ID of a deploy key.
+    # @return [Gitlab::ObjectifiedHash] Information about the disabled deploy key.
+    def disable_deploy_key(project, key)
+      post("/projects/#{project}/deploy_keys/#{key}/disable", body: { id: project, key_id: key })
+    end
+
     # Deletes a deploy key from project.
     #
     # @example

--- a/spec/gitlab/client/projects_spec.rb
+++ b/spec/gitlab/client/projects_spec.rb
@@ -523,6 +523,38 @@ describe Gitlab::Client do
     end
   end
 
+  describe ".enable_deploy_key" do
+    before do
+      stub_post("/projects/42/deploy_keys/2/enable", "project_key")
+      @deploy_key = Gitlab.enable_deploy_key(42, 2)
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/42/deploy_keys/2/enable").
+          with(body: { id: '42', key_id: '2' })).to have_been_made
+    end
+
+    it "should return information about an enabled key" do
+      expect(@deploy_key.id).to eq(2)
+    end
+  end
+
+  describe ".disable_deploy_key" do
+    before do
+      stub_post("/projects/42/deploy_keys/2/disable", "project_key")
+      @deploy_key = Gitlab.disable_deploy_key(42, 2)
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/42/deploy_keys/2/disable").
+          with(body: { id: '42', key_id: '2' })).to have_been_made
+    end
+
+    it "should return information about a disabled key" do
+      expect(@deploy_key.id).to eq(2)
+    end
+  end
+
   describe ".share_project_with_group" do
     before do
       stub_post("/projects/3/share", "group")


### PR DESCRIPTION
While I was looking how to best transfer git repos from bitbucket to gitlab, I found this gem very useful.
I have to transfer a lot of repos, on the first repo, I have to create deploy keys, but then later on, I only needed to enable those already created deploy keys on the other repos.

I added two functions: enable_deploy_key and disable_deploy_key to the client/repositories.rb
file, to accompany the other deploy keys functions.
These parts of the API are described here:
https://docs.gitlab.com/ee/api/deploy_keys.html#enable-a-deploy-key

Further added spec tests for these new functions.
