### PR TITLE
CLI Output record as list and simple key value format

### DIFF
--- a/lib/gitlab/cli.rb
+++ b/lib/gitlab/cli.rb
@@ -46,10 +46,7 @@ class Gitlab::CLI
     when 'shell'
       Gitlab::Shell.start
     else
-      if args.include? '--json'
-        @json_output = true
-        args.delete '--json'
-      end
+      @output_format = extract_output_format(args)
 
       unless valid_command?(cmd)
         puts "Unknown command. Run `gitlab help` for a list of available commands."
@@ -80,8 +77,13 @@ class Gitlab::CLI
   # Helper method that checks whether we want to get the output as json
   # @return [nil]
   def self.render_output(cmd, args, data)
-    if @json_output
+    case @output_format
+    when :json
       output_json(cmd, args, data)
+    when :list
+      output_list(cmd, args, data)
+    when :simple
+      output_simple(cmd, args, data)
     else
       output_table(cmd, args, data)
     end

--- a/spec/gitlab/cli_spec.rb
+++ b/spec/gitlab/cli_spec.rb
@@ -90,6 +90,43 @@ describe Gitlab::CLI do
       end
     end
 
+    context "when command with list output" do
+      before do
+        stub_get("/users", "users")
+        args = ['users', '--list']
+        @output = capture_output { Gitlab::CLI.start(args) }
+      end
+
+      it "should render output as list" do
+        expect(@output).to match(/\|\sid\s+\|\s1\s+\|/)
+        expect(@output).to match(/\|\semail\s+\|\sjohn@example.com\s+\|/)
+        expect(@output).to match(/\|\semail\s+\|\sjack@example.com\s+\|/)
+      end
+    end
+
+    context "when command with simple output" do
+      it "should render output as list" do
+        stub_get("/users", "users")
+        args = ['users', '--simple']
+        @output = capture_output { Gitlab::CLI.start(args) }
+
+        expect(@output).to include('id=1')
+        expect(@output).to include('email=john@example.com')
+        expect(@output).to include('email=jack@example.com')
+      end
+
+      it "should render output only value" do
+        stub_get('/users', 'users')
+        args = ['users', '--simple', '--only=email']
+        @output = capture_output { Gitlab::CLI.start(args) }
+
+        expect(@output).to_not include('id=1')
+        expect(@output).to_not include('email=john@example.com')
+        expect(@output).to include('john@example.com')
+        expect(@output).to include('jack@example.com')
+      end
+    end
+
     context "when command with required fields" do
       before do
         stub_get("/user", "user")


### PR DESCRIPTION
Option: --list
For data with many keys a table output is not a god match,
this change makes it possible to output data in list format

Option --simple
This format output each record as lines of key=value, if you
only fetch one field it will only print value.
The goal is to have a format that's simple to parse