### PR TITLE
Support pipeline

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -15,6 +15,7 @@ module Gitlab
     include Milestones
     include Namespaces
     include Notes
+    include Pipelines
     include Projects
     include Repositories
     include RepositoryFiles

--- a/lib/gitlab/client/pipelines.rb
+++ b/lib/gitlab/client/pipelines.rb
@@ -32,36 +32,36 @@ class Gitlab::Client
     # Create a pipeline.
     #
     # @example
-    #   Gitlab.pipeline_create(5, 'master')
+    #   Gitlab.create_pipeline(5, 'master')
     #
     # @param  [Integer] project The ID of a project.
     # @param  [String] ref Reference to commit.
     # @return [Gitlab::ObjectifiedHash] The pipelines changes.
-    def pipeline_create(project, ref)
+    def create_pipeline(project, ref)
       post("/projects/#{project}/pipeline?ref=#{ref}")
     end
 
     # Cancels a pipeline.
     #
     # @example
-    #   Gitlab.pipeline_cancel(5, 1)
+    #   Gitlab.cancel_pipeline(5, 1)
     #
     # @param  [Integer] project The ID of a project.
     # @param  [Integer] id The ID of a pipeline.
     # @return [Gitlab::ObjectifiedHash] The pipelines changes.
-    def pipeline_cancel(project, id)
+    def cancel_pipeline(project, id)
       post("/projects/#{project}/pipelines/#{id}/cancel")
     end
 
     # Retry a pipeline.
     #
     # @example
-    #   Gitlab.pipeline_retry(5, 1)
+    #   Gitlab.retry_pipeline(5, 1)
     #
     # @param  [Integer] project The ID of a project.
     # @param  [Integer] id The ID of a pipeline.
     # @return [Array<Gitlab::ObjectifiedHash>] The pipelines changes.
-    def pipeline_retry(project, id)
+    def retry_pipeline(project, id)
       post("/projects/#{project}/pipelines/#{id}/retry")
     end
   end

--- a/lib/gitlab/client/pipelines.rb
+++ b/lib/gitlab/client/pipelines.rb
@@ -1,0 +1,68 @@
+class Gitlab::Client
+  # Defines methods related to pipelines.
+  # @see https://docs.gitlab.com/ce/api/pipelines.html
+  module Pipelines
+    # Gets a list of project pipelines.
+    #
+    # @example
+    #   Gitlab.pipelines(5)
+    #   Gitlab.pipelines(5, { per_page: 10, page:  2 })
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [Hash] options A customizable set of options.
+    # @option options [Integer] :page The page number.
+    # @option options [Integer] :per_page The number of results per page.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def pipelines(project, options={})
+      get("/projects/#{project}/pipelines", query: options)
+    end
+
+    # Gets a single pipeline.
+    #
+    # @example
+    #   Gitlab.pipeline(5, 36)
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [Integer] id The ID of a pipeline.
+    # @return [Gitlab::ObjectifiedHash]
+    def pipeline(project, id)
+      get("/projects/#{project}/pipelines/#{id}")
+    end
+
+    # Create a pipeline.
+    #
+    # @example
+    #   Gitlab.pipeline_create(5, 'master')
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [String] ref Reference to commit.
+    # @return [Gitlab::ObjectifiedHash] The pipelines changes.
+    def pipeline_create(project, ref)
+      post("/projects/#{project}/pipeline?ref=#{ref}")
+    end
+
+    # Cancels a pipeline.
+    #
+    # @example
+    #   Gitlab.pipeline_cancel(5, 1)
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [Integer] id The ID of a pipeline.
+    # @return [Gitlab::ObjectifiedHash] The pipelines changes.
+    def pipeline_cancel(project, id)
+      post("/projects/#{project}/pipelines/#{id}/cancel")
+    end
+
+    # Retry a pipeline.
+    #
+    # @example
+    #   Gitlab.pipeline_retry(5, 1)
+    #
+    # @param  [Integer] project The ID of a project.
+    # @param  [Integer] id The ID of a pipeline.
+    # @return [Array<Gitlab::ObjectifiedHash>] The pipelines changes.
+    def pipeline_retry(project, id)
+      post("/projects/#{project}/pipelines/#{id}/retry")
+    end
+  end
+end

--- a/spec/fixtures/pipeline.json
+++ b/spec/fixtures/pipeline.json
@@ -1,0 +1,23 @@
+{
+  "id": 46,
+  "status": "success",
+  "ref": "master",
+  "sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+  "before_sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+  "tag": false,
+  "yaml_errors": null,
+  "user": {
+    "name": "Administrator",
+    "username": "root",
+    "id": 1,
+    "state": "active",
+    "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+    "web_url": "http://localhost:3000/root"
+  },
+  "created_at": "2016-08-11T11:28:34.085Z",
+  "updated_at": "2016-08-11T11:32:35.169Z",
+  "started_at": null,
+  "finished_at": "2016-08-11T11:32:35.145Z",
+  "committed_at": null,
+  "duration": null
+}

--- a/spec/fixtures/pipeline_cancel.json
+++ b/spec/fixtures/pipeline_cancel.json
@@ -1,0 +1,23 @@
+{
+  "id": 46,
+  "status": "canceled",
+  "ref": "master",
+  "sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+  "before_sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+  "tag": false,
+  "yaml_errors": null,
+  "user": {
+    "name": "Administrator",
+    "username": "root",
+    "id": 1,
+    "state": "active",
+    "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+    "web_url": "http://localhost:3000/root"
+  },
+  "created_at": "2016-08-11T11:28:34.085Z",
+  "updated_at": "2016-08-11T11:32:35.169Z",
+  "started_at": null,
+  "finished_at": "2016-08-11T11:32:35.145Z",
+  "committed_at": null,
+  "duration": null
+}

--- a/spec/fixtures/pipeline_create.json
+++ b/spec/fixtures/pipeline_create.json
@@ -1,0 +1,23 @@
+{
+  "id": 61,
+  "sha": "384c444e840a515b23f21915ee5766b87068a70d",
+  "ref": "master",
+  "status": "pending",
+  "before_sha": "0000000000000000000000000000000000000000",
+  "tag": false,
+  "yaml_errors": null,
+  "user": {
+    "name": "Administrator",
+    "username": "root",
+    "id": 1,
+    "state": "active",
+    "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+    "web_url": "http://localhost:3000/root"
+  },
+  "created_at": "2016-11-04T09:36:13.747Z",
+  "updated_at": "2016-11-04T09:36:13.977Z",
+  "started_at": null,
+  "finished_at": null,
+  "committed_at": null,
+  "duration": null
+}

--- a/spec/fixtures/pipeline_retry.json
+++ b/spec/fixtures/pipeline_retry.json
@@ -1,0 +1,23 @@
+{
+  "id": 46,
+  "status": "pending",
+  "ref": "master",
+  "sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+  "before_sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+  "tag": false,
+  "yaml_errors": null,
+  "user": {
+    "name": "Administrator",
+    "username": "root",
+    "id": 1,
+    "state": "active",
+    "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+    "web_url": "http://localhost:3000/root"
+  },
+  "created_at": "2016-08-11T11:28:34.085Z",
+  "updated_at": "2016-08-11T11:32:35.169Z",
+  "started_at": null,
+  "finished_at": "2016-08-11T11:32:35.145Z",
+  "committed_at": null,
+  "duration": null
+}

--- a/spec/fixtures/pipelines.json
+++ b/spec/fixtures/pipelines.json
@@ -1,0 +1,48 @@
+[
+  {
+    "id": 47,
+    "status": "pending",
+    "ref": "new-pipeline",
+    "sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+    "before_sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+    "tag": false,
+    "yaml_errors": null,
+    "user": {
+      "name": "Administrator",
+      "username": "root",
+      "id": 1,
+      "state": "active",
+      "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://localhost:3000/root"
+    },
+    "created_at": "2016-08-16T10:23:19.007Z",
+    "updated_at": "2016-08-16T10:23:19.216Z",
+    "started_at": null,
+    "finished_at": null,
+    "committed_at": null,
+    "duration": null
+  },
+  {
+    "id": 48,
+    "status": "pending",
+    "ref": "new-pipeline",
+    "sha": "eb94b618fb5865b26e80fdd8ae531b7a63ad851a",
+    "before_sha": "eb94b618fb5865b26e80fdd8ae531b7a63ad851a",
+    "tag": false,
+    "yaml_errors": null,
+    "user": {
+      "name": "Administrator",
+      "username": "root",
+      "id": 1,
+      "state": "active",
+      "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://localhost:3000/root"
+    },
+    "created_at": "2016-08-16T10:23:21.184Z",
+    "updated_at": "2016-08-16T10:23:21.314Z",
+    "started_at": null,
+    "finished_at": null,
+    "committed_at": null,
+    "duration": null
+  }
+]

--- a/spec/gitlab/client/pipelines_spec.rb
+++ b/spec/gitlab/client/pipelines_spec.rb
@@ -36,10 +36,10 @@ describe Gitlab::Client do
     end
   end
 
-  describe ".pipeline_cancel" do
+  describe ".cancel_pipeline" do
     before do
       stub_post("/projects/3/pipelines/46/cancel", "pipeline_cancel")
-      @pipeline_cancel = Gitlab.pipeline_cancel(3, 46)
+      @pipeline_cancel = Gitlab.cancel_pipeline(3, 46)
     end
     
     it "should get the correct resource" do
@@ -55,10 +55,10 @@ describe Gitlab::Client do
     end
   end
   
-  describe ".pipeline_retry" do
+  describe ".retry_pipeline" do
     before do
       stub_post("/projects/3/pipelines/46/retry", "pipeline_retry")
-      @pipeline_retry = Gitlab.pipeline_retry(3, 46)
+      @pipeline_retry = Gitlab.retry_pipeline(3, 46)
     end
     
     it "should get the correct resource" do

--- a/spec/gitlab/client/pipelines_spec.rb
+++ b/spec/gitlab/client/pipelines_spec.rb
@@ -36,6 +36,25 @@ describe Gitlab::Client do
     end
   end
 
+  describe ".create_pipeline" do
+    before do
+      stub_post("/projects/3/pipeline?ref=master", "pipeline_create")
+      @pipeline_create = Gitlab.create_pipeline(3, 'master')
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/pipeline?ref=master")).to have_been_made
+    end
+
+    it "should return a single pipeline" do
+      expect(@pipeline_create).to be_a Gitlab::ObjectifiedHash
+    end
+
+    it "should return information about a pipeline" do
+      expect(@pipeline_create.user.name).to eq("Administrator")
+    end
+  end
+
   describe ".cancel_pipeline" do
     before do
       stub_post("/projects/3/pipelines/46/cancel", "pipeline_cancel")

--- a/spec/gitlab/client/pipelines_spec.rb
+++ b/spec/gitlab/client/pipelines_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe Gitlab::Client do
+  describe ".pipelines" do
+    before do
+      stub_get("/projects/3/pipelines", "pipelines")
+      @pipelines = Gitlab.pipelines(3)
+    end
+
+    it "should get the correct resource" do
+      expect(a_get("/projects/3/pipelines")).to have_been_made
+    end
+
+    it "should return a paginated response of project's pipelines" do
+      expect(@pipelines).to be_a Gitlab::PaginatedResponse
+    end
+  end
+  
+  describe ".pipeline" do
+    before do
+      stub_get("/projects/3/pipelines/46", "pipeline")
+      @pipeline = Gitlab.pipeline(3, 46)
+    end
+    
+    it "should get the correct resource" do
+      expect(a_get("/projects/3/pipelines/46")).to have_been_made
+    end
+
+    it "should return a single pipeline" do
+      expect(@pipeline).to be_a Gitlab::ObjectifiedHash
+    end
+    
+    it "should return information about a pipeline" do
+      expect(@pipeline.id).to eq(46)
+      expect(@pipeline.user.name).to eq("Administrator")
+    end
+  end
+
+  describe ".pipeline_cancel" do
+    before do
+      stub_post("/projects/3/pipelines/46/cancel", "pipeline_cancel")
+      @pipeline_cancel = Gitlab.pipeline_cancel(3, 46)
+    end
+    
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/pipelines/46/cancel")).to have_been_made
+    end
+
+    it "should return a single pipeline" do
+      expect(@pipeline_cancel).to be_a Gitlab::ObjectifiedHash
+    end
+    
+    it "should return information about a pipeline" do
+      expect(@pipeline_cancel.user.name).to eq("Administrator")
+    end
+  end
+  
+  describe ".pipeline_retry" do
+    before do
+      stub_post("/projects/3/pipelines/46/retry", "pipeline_retry")
+      @pipeline_retry = Gitlab.pipeline_retry(3, 46)
+    end
+    
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/pipelines/46/retry")).to have_been_made
+    end
+
+    it "should return a single pipeline" do
+      expect(@pipeline_retry).to be_a Gitlab::ObjectifiedHash
+    end
+    
+    it "should return information about a pipeline" do
+      expect(@pipeline_retry.user.name).to eq("Administrator")
+    end
+  end
+end


### PR DESCRIPTION
Implements the pipeline API from https://docs.gitlab.com/ce/api/pipelines.html

- list pipelines
- get a single pipeline
- create a new pipeline
- retry failed builds in a pipeline
- cancel a pipelines builds

closes #248 