### PR TITLE
Feature/230 note that project id can also be a string

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -39,6 +39,10 @@ module Gitlab
       inspected
     end
 
+    def url_encode(s)
+      ERB::Util.url_encode(s)
+    end
+
     private
 
     def only_show_last_four_chars(token)

--- a/lib/gitlab/client/branches.rb
+++ b/lib/gitlab/client/branches.rb
@@ -7,13 +7,13 @@ class Gitlab::Client
     # @example
     #   Gitlab.branches(42)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
     # @option options [Integer] :page The page number.
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def branches(project, options={})
-      get("/projects/#{project}/repository/branches", query: options)
+      get("/projects/#{url_encode project}/repository/branches", query: options)
     end
     alias_method :repo_branches, :branches
 
@@ -23,11 +23,11 @@ class Gitlab::Client
     #   Gitlab.branch(3, 'api')
     #   Gitlab.repo_branch(5, 'master')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] branch The name of the branch.
     # @return [Gitlab::ObjectifiedHash]
     def branch(project, branch)
-      get("/projects/#{project}/repository/branches/#{branch}")
+      get("/projects/#{url_encode project}/repository/branches/#{branch}")
     end
     alias_method :repo_branch, :branch
 
@@ -37,11 +37,11 @@ class Gitlab::Client
     #   Gitlab.protect_branch(3, 'api')
     #   Gitlab.repo_protect_branch(5, 'master')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] branch The name of the branch.
     # @return [Gitlab::ObjectifiedHash]
     def protect_branch(project, branch)
-      put("/projects/#{project}/repository/branches/#{branch}/protect")
+      put("/projects/#{url_encode project}/repository/branches/#{branch}/protect")
     end
     alias_method :repo_protect_branch, :protect_branch
 
@@ -51,11 +51,11 @@ class Gitlab::Client
     #   Gitlab.unprotect_branch(3, 'api')
     #   Gitlab.repo_unprotect_branch(5, 'master')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] branch The name of the branch.
     # @return [Gitlab::ObjectifiedHash]
     def unprotect_branch(project, branch)
-      put("/projects/#{project}/repository/branches/#{branch}/unprotect")
+      put("/projects/#{url_encode project}/repository/branches/#{branch}/unprotect")
     end
     alias_method :repo_unprotect_branch, :unprotect_branch
 
@@ -65,12 +65,12 @@ class Gitlab::Client
     #   Gitlab.create_branch(3, 'api')
     #   Gitlab.repo_create_branch(5, 'master')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] branch The name of the new branch.
     # @param  [String] ref Create branch from commit sha or existing branch
     # @return [Gitlab::ObjectifiedHash]
     def create_branch(project, branch, ref)
-      post("/projects/#{project}/repository/branches", body: { branch_name: branch, ref: ref })
+      post("/projects/#{url_encode project}/repository/branches", body: { branch_name: branch, ref: ref })
     end
     alias_method :repo_create_branch, :create_branch
 
@@ -80,11 +80,11 @@ class Gitlab::Client
     #   Gitlab.delete_branch(3, 'api')
     #   Gitlab.repo_delete_branch(5, 'master')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] branch The name of the branch to delete
     # @return [Gitlab::ObjectifiedHash]
     def delete_branch(project, branch)
-      delete("/projects/#{project}/repository/branches/#{branch}")
+      delete("/projects/#{url_encode project}/repository/branches/#{branch}")
     end
     alias_method :repo_delete_branch, :delete_branch
   end

--- a/lib/gitlab/client/build_triggers.rb
+++ b/lib/gitlab/client/build_triggers.rb
@@ -7,10 +7,10 @@ class Gitlab::Client
     # @example
     #   Gitlab.triggers(5)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @return [Array<Gitlab::ObjectifiedHash>] The list of triggers.
     def triggers(project)
-      get("/projects/#{project}/triggers")
+      get("/projects/#{url_encode project}/triggers")
     end
 
     # Gets details of project's build trigger.
@@ -18,11 +18,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.trigger(5, '7b9148c158980bbd9bcea92c17522d')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] token The token of a trigger.
     # @return [Gitlab::ObjectifiedHash] The trigger.
     def trigger(project, token)
-      get("/projects/#{project}/triggers/#{token}")
+      get("/projects/#{url_encode project}/triggers/#{token}")
     end
 
     # Create a build trigger for a project.
@@ -30,10 +30,10 @@ class Gitlab::Client
     # @example
     #   Gitlab.create_trigger(5)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @return [Gitlab::ObjectifiedHash] The trigger.
     def create_trigger(project)
-      post("/projects/#{project}/triggers")
+      post("/projects/#{url_encode project}/triggers")
     end
 
     # Remove a project's build trigger.
@@ -41,11 +41,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.remove_trigger(5, '7b9148c158980bbd9bcea92c17522d')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] token The token of a trigger.
     # @return [Gitlab::ObjectifiedHash] The trigger.
     def remove_trigger(project, token)
-      delete("/projects/#{project}/triggers/#{token}")
+      delete("/projects/#{url_encode project}/triggers/#{token}")
     end
   end
 end

--- a/lib/gitlab/client/build_variables.rb
+++ b/lib/gitlab/client/build_variables.rb
@@ -7,10 +7,10 @@ class Gitlab::Client
     # @example
     #   Gitlab.variables(5)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @return [Array<Gitlab::ObjectifiedHash>] The list of variables.
     def variables(project)
-      get("/projects/#{project}/variables")
+      get("/projects/#{url_encode project}/variables")
     end
 
     # Gets details of a project's specific build variable.
@@ -18,11 +18,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.build(5, "TEST_VARIABLE_1")
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] key The key of a variable.
     # @return [Gitlab::ObjectifiedHash] The variable.
     def variable(project, key)
-      get("/projects/#{project}/variables/#{key}")
+      get("/projects/#{url_encode project}/variables/#{key}")
     end
 
     # Create a build variable for a project.
@@ -30,12 +30,12 @@ class Gitlab::Client
     # @example
     #   Gitlab.create_variable(5, "NEW_VARIABLE", "new value")
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] key The key of a variable; must have no more than 255 characters; only `A-Z`, `a-z`, `0-9` and `_` are allowed
     # @param  [String] value The value of a variable
     # @return [Gitlab::ObjectifiedHash] The variable.
     def create_variable(project, key, value)
-      post("/projects/#{project}/variables", body: { key: key, value: value })
+      post("/projects/#{url_encode project}/variables", body: { key: key, value: value })
     end
 
     # Update a project's build variable.
@@ -43,12 +43,12 @@ class Gitlab::Client
     # @example
     #   Gitlab.create_variable(5, "NEW_VARIABLE", "updated value")
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] key The key of a variable
     # @param  [String] value The value of a variable
     # @return [Gitlab::ObjectifiedHash] The variable.
     def update_variable(project, key, value)
-      put("/projects/#{project}/variables/#{key}", body: { value: value })
+      put("/projects/#{url_encode project}/variables/#{key}", body: { value: value })
     end
 
     # Remove a project's build variable.
@@ -56,11 +56,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.remove_variable(5, "VARIABLE_1")
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] key The key of a variable.
     # @return [Gitlab::ObjectifiedHash] The variable.
     def remove_variable(project, key)
-      delete("/projects/#{project}/variables/#{key}")
+      delete("/projects/#{url_encode project}/variables/#{key}")
     end
   end
 end

--- a/lib/gitlab/client/builds.rb
+++ b/lib/gitlab/client/builds.rb
@@ -8,14 +8,14 @@ class Gitlab::Client
     #   Gitlab.builds(5)
     #   Gitlab.builds(5, { per_page: 10, page:  2 })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
     # @option options [Integer] :page The page number.
     # @option options [Integer] :per_page The number of results per page.
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def builds(project, options={})
-      get("/projects/#{project}/builds", query: options)
+      get("/projects/#{url_encode project}/builds", query: options)
     end
 
     # Gets a single build.
@@ -23,11 +23,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.build(5, 36)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a build.
     # @return [Gitlab::ObjectifiedHash]
     def build(project, id)
-      get("/projects/#{project}/builds/#{id}")
+      get("/projects/#{url_encode project}/builds/#{id}")
     end
 
     # Gets build artifacts.
@@ -35,11 +35,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.build_artifacts(1, 8)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a build.
     # @return [Gitlab::FileResponse]
     def build_artifacts(project, id)
-      get("/projects/#{project}/builds/#{id}/artifacts",
+      get("/projects/#{url_encode project}/builds/#{id}/artifacts",
            format: nil,
            headers: { Accept: 'application/octet-stream' },
            parser: proc { |body, _|
@@ -57,14 +57,14 @@ class Gitlab::Client
     #   Gitlab.commit_builds(5, 'asdf')
     #   Gitlab.commit_builds(5, 'asdf', { per_page: 10, page: 2 })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] sha The SHA checksum of a commit.
     # @param  [Hash] options A customizable set of options.
     # @option options [Integer] :page The page number.
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>] The list of builds.
     def commit_builds(project, sha, options={})
-      get("/projects/#{project}/repository/commits/#{sha}/builds", query: options)
+      get("/projects/#{url_encode project}/repository/commits/#{sha}/builds", query: options)
     end
 
     # Cancels a build.
@@ -72,11 +72,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.build_cancel(5, 1)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a build.
     # @return [Gitlab::ObjectifiedHash] The builds changes.
     def build_cancel(project, id)
-      post("/projects/#{project}/builds/#{id}/cancel")
+      post("/projects/#{url_encode project}/builds/#{id}/cancel")
     end
 
     # Retry a build.
@@ -84,11 +84,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.build_retry(5, 1)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a build.
     # @return [Array<Gitlab::ObjectifiedHash>] The builds changes.
     def build_retry(project, id)
-      post("/projects/#{project}/builds/#{id}/retry")
+      post("/projects/#{url_encode project}/builds/#{id}/retry")
     end
 
     # Erase a single build of a project (remove build artifacts and a build trace)
@@ -96,11 +96,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.build_erase(5, 1)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a build.
     # @return [Gitlab::ObjectifiedHash] The build's changes.
     def build_erase(project, id)
-      post("/projects/#{project}/builds/#{id}/erase")
+      post("/projects/#{url_encode project}/builds/#{id}/erase")
     end
   end
 end

--- a/lib/gitlab/client/commits.rb
+++ b/lib/gitlab/client/commits.rb
@@ -8,14 +8,14 @@ class Gitlab::Client
     #   Gitlab.commits('viking')
     #   Gitlab.repo_commits('gitlab', { ref_name: 'api' })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :ref_name The branch or tag name of a project repository.
     # @option options [Integer] :page The page number.
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def commits(project, options={})
-      get("/projects/#{project}/repository/commits", query: options)
+      get("/projects/#{url_encode project}/repository/commits", query: options)
     end
     alias_method :repo_commits, :commits
 
@@ -25,11 +25,11 @@ class Gitlab::Client
     #   Gitlab.commit(42, '6104942438c14ec7bd21c6cd5bd995272b3faff6')
     #   Gitlab.repo_commit(3, 'ed899a2f4b50b4370feeea94676502b42383c746')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] sha The commit hash or name of a repository branch or tag
     # @return [Gitlab::ObjectifiedHash]
     def commit(project, sha)
-      get("/projects/#{project}/repository/commits/#{sha}")
+      get("/projects/#{url_encode project}/repository/commits/#{sha}")
     end
     alias_method :repo_commit, :commit
 
@@ -39,11 +39,11 @@ class Gitlab::Client
     #   Gitlab.commit_diff(42, '6104942438c14ec7bd21c6cd5bd995272b3faff6')
     #   Gitlab.repo_commit_diff(3, 'ed899a2f4b50b4370feeea94676502b42383c746')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] sha The name of a repository branch or tag or if not given the default branch.
     # @return [Gitlab::ObjectifiedHash]
     def commit_diff(project, sha)
-      get("/projects/#{project}/repository/commits/#{sha}/diff")
+      get("/projects/#{url_encode project}/repository/commits/#{sha}/diff")
     end
     alias_method :repo_commit_diff, :commit_diff
 
@@ -58,7 +58,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def commit_comments(project, commit, options={})
-      get("/projects/#{project}/repository/commits/#{commit}/comments", query: options)
+      get("/projects/#{url_encode project}/repository/commits/#{commit}/comments", query: options)
     end
     alias_method :repo_commit_comments, :commit_comments
 
@@ -67,7 +67,7 @@ class Gitlab::Client
     # @example
     #   Gitlab.create_commit_comment(5, 'c9f9662a9b1116c838b523ed64c6abdb4aae4b8b', 'Nice work on this commit!')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] sha The commit hash or name of a repository branch or tag.
     # @param  [String] note The text of a comment.
     # @param  [Hash] options A customizable set of options.
@@ -76,7 +76,7 @@ class Gitlab::Client
     # @option options [String] :line_type The line type (new or old).
     # @return [Gitlab::ObjectifiedHash] Information about created comment.
     def create_commit_comment(project, commit, note, options={})
-      post("/projects/#{project}/repository/commits/#{commit}/comments", body: options.merge(note: note))
+      post("/projects/#{url_encode project}/repository/commits/#{commit}/comments", body: options.merge(note: note))
     end
     alias_method :repo_create_commit_comment, :create_commit_comment
 
@@ -87,7 +87,7 @@ class Gitlab::Client
     #   Gitlab.commit_status(42, '6104942438c14ec7bd21c6cd5bd995272b3faff6', { name: 'jenkins' })
     #   Gitlab.commit_status(42, '6104942438c14ec7bd21c6cd5bd995272b3faff6', { name: 'jenkins', all: true })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] sha The commit hash
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :ref Filter by ref name, it can be branch or tag
@@ -106,7 +106,7 @@ class Gitlab::Client
     #   Gitlab.update_commit_status(42, '6104942438c14ec7bd21c6cd5bd995272b3faff6', 'failed', { name: 'jenkins' })
     #   Gitlab.update_commit_status(42, '6104942438c14ec7bd21c6cd5bd995272b3faff6', 'canceled', { name: 'jenkins', target_url: 'http://example.com/builds/1' })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] sha The commit hash
     # @param  [String] state of the status. Can be: pending, running, success, failed, canceled
     # @param  [Hash] options A customizable set of options.

--- a/lib/gitlab/client/issues.rb
+++ b/lib/gitlab/client/issues.rb
@@ -10,7 +10,7 @@ class Gitlab::Client
     #   Gitlab.issues(5)
     #   Gitlab.issues({ per_page: 40 })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
     # @option options [Integer] :page The page number.
     # @option options [Integer] :per_page The number of results per page.
@@ -19,7 +19,7 @@ class Gitlab::Client
       if project.to_i.zero?
         get("/issues", query: options)
       else
-        get("/projects/#{project}/issues", query: options)
+        get("/projects/#{url_encode project}/issues", query: options)
       end
     end
 
@@ -28,11 +28,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.issue(5, 42)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of an issue.
     # @return [Gitlab::ObjectifiedHash]
     def issue(project, id)
-      get("/projects/#{project}/issues/#{id}")
+      get("/projects/#{url_encode project}/issues/#{id}")
     end
 
     # Creates a new issue.
@@ -41,7 +41,7 @@ class Gitlab::Client
     #   Gitlab.create_issue(5, 'New issue')
     #   Gitlab.create_issue(5, 'New issue', { description: 'This is a new issue', assignee_id: 42 })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] title The title of an issue.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :description The description of an issue.
@@ -51,7 +51,7 @@ class Gitlab::Client
     # @return [Gitlab::ObjectifiedHash] Information about created issue.
     def create_issue(project, title, options={})
       body = { title: title }.merge(options)
-      post("/projects/#{project}/issues", body: body)
+      post("/projects/#{url_encode project}/issues", body: body)
     end
 
     # Updates an issue.
@@ -59,7 +59,7 @@ class Gitlab::Client
     # @example
     #   Gitlab.edit_issue(6, 1, { title: 'Updated title' })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of an issue.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :title The title of an issue.
@@ -70,7 +70,7 @@ class Gitlab::Client
     # @option options [String] :state_event The state event of an issue ('close' or 'reopen').
     # @return [Gitlab::ObjectifiedHash] Information about updated issue.
     def edit_issue(project, id, options={})
-      put("/projects/#{project}/issues/#{id}", body: options)
+      put("/projects/#{url_encode project}/issues/#{id}", body: options)
     end
 
     # Closes an issue.
@@ -78,11 +78,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.close_issue(3, 42)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of an issue.
     # @return [Gitlab::ObjectifiedHash] Information about closed issue.
     def close_issue(project, id)
-      put("/projects/#{project}/issues/#{id}", body: { state_event: 'close' })
+      put("/projects/#{url_encode project}/issues/#{id}", body: { state_event: 'close' })
     end
 
     # Reopens an issue.
@@ -90,11 +90,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.reopen_issue(3, 42)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of an issue.
     # @return [Gitlab::ObjectifiedHash] Information about reopened issue.
     def reopen_issue(project, id)
-      put("/projects/#{project}/issues/#{id}", body: { state_event: 'reopen' })
+      put("/projects/#{url_encode project}/issues/#{id}", body: { state_event: 'reopen' })
     end
 
     # Deletes  an issue.
@@ -103,11 +103,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.delete_issue(3, 42)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of an issue.
     # @return [Gitlab::ObjectifiedHash] Information about deleted issue.
     def delete_issue(project, id)
-      delete("/projects/#{project}/issues/#{id}")
+      delete("/projects/#{url_encode project}/issues/#{id}")
     end
   end
 end

--- a/lib/gitlab/client/labels.rb
+++ b/lib/gitlab/client/labels.rb
@@ -7,10 +7,10 @@ class Gitlab::Client
     # @example
     #   Gitlab.labels(5)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def labels(project)
-      get("/projects/#{project}/labels")
+      get("/projects/#{url_encode project}/labels")
     end
 
     # Creates a new label.
@@ -18,12 +18,12 @@ class Gitlab::Client
     # @example
     #   Gitlab.create_label(42, "Backlog", '#DD10AA')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @option [String] name The name of a label.
     # @option [String] color The color of a label.
     # @return [Gitlab::ObjectifiedHash] Information about created label.
     def create_label(project, name, color)
-      post("/projects/#{project}/labels", body: { name: name, color: color })
+      post("/projects/#{url_encode project}/labels", body: { name: name, color: color })
     end
 
     # Updates a label.
@@ -32,14 +32,14 @@ class Gitlab::Client
     #   Gitlab.edit_label(42, "Backlog", { new_name: 'TODO' })
     #   Gitlab.edit_label(42, "Backlog", { new_name: 'TODO', color: '#DD10AA' })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] name The name of a label.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :new_name The new name of a label.
     # @option options [String] :color The color of a label.
     # @return [Gitlab::ObjectifiedHash] Information about updated label.
     def edit_label(project, name, options={})
-      put("/projects/#{project}/labels", body: options.merge(name: name))
+      put("/projects/#{url_encode project}/labels", body: options.merge(name: name))
     end
 
     # Deletes a label.
@@ -47,11 +47,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.delete_label(2, 'Backlog')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] name The name of a label.
     # @return [Gitlab::ObjectifiedHash] Information about deleted label.
     def delete_label(project, name)
-      delete("/projects/#{project}/labels", body: { name: name })
+      delete("/projects/#{url_encode project}/labels", body: { name: name })
     end
   end
 end

--- a/lib/gitlab/client/merge_requests.rb
+++ b/lib/gitlab/client/merge_requests.rb
@@ -8,13 +8,13 @@ class Gitlab::Client
     #   Gitlab.merge_requests(5)
     #   Gitlab.merge_requests({ per_page: 40 })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
     # @option options [Integer] :page The page number.
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def merge_requests(project, options={})
-      get("/projects/#{project}/merge_requests", query: options)
+      get("/projects/#{url_encode project}/merge_requests", query: options)
     end
 
     # Gets a single merge request.
@@ -22,11 +22,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.merge_request(5, 36)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a merge request.
     # @return <Gitlab::ObjectifiedHash]
     def merge_request(project, id)
-      get("/projects/#{project}/merge_request/#{id}")
+      get("/projects/#{url_encode project}/merge_request/#{id}")
     end
 
     # Creates a merge request.
@@ -37,7 +37,7 @@ class Gitlab::Client
     #   Gitlab.create_merge_request(5, 'New merge request',
     #     { source_branch: 'source_branch', target_branch: 'target_branch', assignee_id: 42 })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] title The title of a merge request.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :source_branch (required) The source branch name.
@@ -47,7 +47,7 @@ class Gitlab::Client
     # @return [Gitlab::ObjectifiedHash] Information about created merge request.
     def create_merge_request(project, title, options={})
       body = { title: title }.merge(options)
-      post("/projects/#{project}/merge_requests", body: body)
+      post("/projects/#{url_encode project}/merge_requests", body: body)
     end
 
     # Updates a merge request.
@@ -55,7 +55,7 @@ class Gitlab::Client
     # @example
     #   Gitlab.update_merge_request(5, 42, { title: 'New title' })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a merge request.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :title The title of a merge request.
@@ -65,7 +65,7 @@ class Gitlab::Client
     # @option options [String] :state_event New state (close|reopen|merge).
     # @return [Gitlab::ObjectifiedHash] Information about updated merge request.
     def update_merge_request(project, id, options={})
-      put("/projects/#{project}/merge_request/#{id}", body: options)
+      put("/projects/#{url_encode project}/merge_request/#{id}", body: options)
     end
 
     # Accepts a merge request.
@@ -73,13 +73,13 @@ class Gitlab::Client
     # @example
     #   Gitlab.accept_merge_request(5, 42, { merge_commit_message: 'Nice!' })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a merge request.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :merge_commit_message Custom merge commit message
     # @return [Gitlab::ObjectifiedHash] Information about updated merge request.
     def accept_merge_request(project, id, options={})
-      put("/projects/#{project}/merge_request/#{id}/merge", body: options)
+      put("/projects/#{url_encode project}/merge_request/#{id}/merge", body: options)
     end
 
     # Adds a comment to a merge request.
@@ -88,12 +88,12 @@ class Gitlab::Client
     #   Gitlab.create_merge_request_comment(5, 1, "Awesome merge!")
     #   Gitlab.create_merge_request_comment('gitlab', 1, "Awesome merge!")
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a merge request.
     # @param  [String] note The content of a comment.
     # @return [Gitlab::ObjectifiedHash] Information about created merge request comment.
     def create_merge_request_comment(project, id, note)
-      post("/projects/#{project}/merge_requests/#{id}/notes", body: { body: note })
+      post("/projects/#{url_encode project}/merge_requests/#{id}/notes", body: { body: note })
     end
 
     # Adds a comment to a merge request.
@@ -102,13 +102,13 @@ class Gitlab::Client
     #   Gitlab.edit_merge_request_comment(5, 1,2, "Awesome merge!")
     #   Gitlab.edit_merge_request_comment('gitlab', 1, 2, "Awesome merge!")
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a merge request.
     # @param  [Integer] id The ID of the merge-request comment
     # @param  [String] note The content of a comment.
     # @return [Gitlab::ObjectifiedHash] Information about created merge request comment.
     def edit_merge_request_comment(project, id, note_id , note)
-      put("/projects/#{project}/merge_requests/#{id}/notes/#{note_id}", body: { body: note })
+      put("/projects/#{url_encode project}/merge_requests/#{id}/notes/#{note_id}", body: { body: note })
     end
 
     # Deletes a comment from a merge request.
@@ -117,12 +117,12 @@ class Gitlab::Client
     #   Gitlab.delete_merge_request_comment(5, 1,2)
     #   Gitlab.delete_merge_request_comment('gitlab', 1, 2)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a merge request.
     # @param  [Integer] id The ID of the merge-request comment
     # @return [Gitlab::ObjectifiedHash] Information about created merge request comment.
     def delete_merge_request_comment(project, id, note_id)
-      delete("/projects/#{project}/merge_requests/#{id}/notes/#{note_id}")
+      delete("/projects/#{url_encode project}/merge_requests/#{id}/notes/#{note_id}")
     end
     
     # Gets the comments on a merge request.
@@ -131,14 +131,14 @@ class Gitlab::Client
     #   Gitlab.merge_request_comments(5, 1)
     #   Gitlab.merge_request_comments(5, 1, { per_page: 10, page: 2 })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a merge request.
     # @param  [Hash] options A customizable set of options.
     # @option options [Integer] :page The page number.
     # @option options [Integer] :per_page The number of results per page.
     # @return [Gitlab::ObjectifiedHash] The merge request's comments.
     def merge_request_comments(project, id, options={})
-      get("/projects/#{project}/merge_requests/#{id}/notes", query: options)
+      get("/projects/#{url_encode project}/merge_requests/#{id}/notes", query: options)
     end
 
     # Gets the changes of a merge request.
@@ -146,11 +146,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.merge_request_changes(5, 1)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a merge request.
     # @return [Gitlab::ObjectifiedHash] The merge request's changes.
     def merge_request_changes(project, id)
-      get("/projects/#{project}/merge_request/#{id}/changes")
+      get("/projects/#{url_encode project}/merge_request/#{id}/changes")
     end
 
     # Gets the commits of a merge request.
@@ -158,11 +158,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.merge_request_commits(5, 1)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a merge request.
     # @return [Array<Gitlab::ObjectifiedHash>] The merge request's commits.
     def merge_request_commits(project, id)
-      get("/projects/#{project}/merge_request/#{id}/commits")
+      get("/projects/#{url_encode project}/merge_request/#{id}/commits")
     end
   end
 end

--- a/lib/gitlab/client/milestones.rb
+++ b/lib/gitlab/client/milestones.rb
@@ -7,13 +7,13 @@ class Gitlab::Client
     # @example
     #   Gitlab.milestones(5)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
     # @option options [Integer] :page The page number.
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def milestones(project, options={})
-      get("/projects/#{project}/milestones", query: options)
+      get("/projects/#{url_encode project}/milestones", query: options)
     end
 
     # Gets a single milestone.
@@ -21,11 +21,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.milestone(5, 36)
     #
-    # @param  [Integer, String] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a milestone.
     # @return [Gitlab::ObjectifiedHash]
     def milestone(project, id)
-      get("/projects/#{project}/milestones/#{id}")
+      get("/projects/#{url_encode project}/milestones/#{id}")
     end
 
     # Gets the issues of a given milestone.
@@ -33,13 +33,13 @@ class Gitlab::Client
     # @example
     #   Gitlab.milestone_issues(5, 2)
     #
-    # @param  [Integer, String] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer, String] milestone The ID of a milestone.
     # @option options [Integer] :page The page number.
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def milestone_issues(project, milestone, options={})
-      get("/projects/#{project}/milestones/#{milestone}/issues", query: options)
+      get("/projects/#{url_encode project}/milestones/#{milestone}/issues", query: options)
     end
 
     # Creates a new milestone.
@@ -47,7 +47,7 @@ class Gitlab::Client
     # @example
     #   Gitlab.create_milestone(5, 'v1.0')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] title The title of a milestone.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :description The description of a milestone.
@@ -55,7 +55,7 @@ class Gitlab::Client
     # @return [Gitlab::ObjectifiedHash] Information about created milestone.
     def create_milestone(project, title, options={})
       body = { title: title }.merge(options)
-      post("/projects/#{project}/milestones", body: body)
+      post("/projects/#{url_encode project}/milestones", body: body)
     end
 
     # Updates a milestone.
@@ -63,7 +63,7 @@ class Gitlab::Client
     # @example
     #   Gitlab.edit_milestone(5, 2, { state_event: 'activate' })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a milestone.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :title The title of a milestone.
@@ -72,7 +72,7 @@ class Gitlab::Client
     # @option options [String] :state_event The state of a milestone ('close' or 'activate').
     # @return [Gitlab::ObjectifiedHash] Information about updated milestone.
     def edit_milestone(project, id, options={})
-      put("/projects/#{project}/milestones/#{id}", body: options)
+      put("/projects/#{url_encode project}/milestones/#{id}", body: options)
     end
   end
 end

--- a/lib/gitlab/client/notes.rb
+++ b/lib/gitlab/client/notes.rb
@@ -12,7 +12,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def notes(project, options={})
-      get("/projects/#{project}/notes", query: options)
+      get("/projects/#{url_encode project}/notes", query: options)
     end
 
     # Gets a list of notes for a issue.
@@ -26,7 +26,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def issue_notes(project, issue, options={})
-      get("/projects/#{project}/issues/#{issue}/notes", query: options)
+      get("/projects/#{url_encode project}/issues/#{issue}/notes", query: options)
     end
 
     # Gets a list of notes for a snippet.
@@ -40,7 +40,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def snippet_notes(project, snippet, options={})
-      get("/projects/#{project}/snippets/#{snippet}/notes", query: options)
+      get("/projects/#{url_encode project}/snippets/#{snippet}/notes", query: options)
     end
 
     # Gets a list of notes for a merge request.
@@ -54,7 +54,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def merge_request_notes(project, merge_request, options={})
-      get("/projects/#{project}/merge_requests/#{merge_request}/notes", query: options)
+      get("/projects/#{url_encode project}/merge_requests/#{merge_request}/notes", query: options)
     end
 
     # Gets a single wall note.
@@ -66,7 +66,7 @@ class Gitlab::Client
     # @param [Integer] id The ID of a note.
     # @return [Gitlab::ObjectifiedHash]
     def note(project, id)
-      get("/projects/#{project}/notes/#{id}")
+      get("/projects/#{url_encode project}/notes/#{id}")
     end
 
     # Gets a single issue note.
@@ -79,7 +79,7 @@ class Gitlab::Client
     # @param [Integer] id The ID of a note.
     # @return [Gitlab::ObjectifiedHash]
     def issue_note(project, issue, id)
-      get("/projects/#{project}/issues/#{issue}/notes/#{id}")
+      get("/projects/#{url_encode project}/issues/#{issue}/notes/#{id}")
     end
 
     # Gets a single snippet note.
@@ -92,7 +92,7 @@ class Gitlab::Client
     # @param [Integer] id The ID of a note.
     # @return [Gitlab::ObjectifiedHash]
     def snippet_note(project, snippet, id)
-      get("/projects/#{project}/snippets/#{snippet}/notes/#{id}")
+      get("/projects/#{url_encode project}/snippets/#{snippet}/notes/#{id}")
     end
 
     # Gets a single merge_request note.
@@ -105,7 +105,7 @@ class Gitlab::Client
     # @param [Integer] id The ID of a note.
     # @return [Gitlab::ObjectifiedHash]
     def merge_request_note(project, merge_request, id)
-      get("/projects/#{project}/merge_requests/#{merge_request}/notes/#{id}")
+      get("/projects/#{url_encode project}/merge_requests/#{merge_request}/notes/#{id}")
     end
 
     # Creates a new wall note.
@@ -113,11 +113,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.create_note(5, 'This is a wall note!')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] body The body of a note.
     # @return [Gitlab::ObjectifiedHash] Information about created note.
     def create_note(project, body)
-      post("/projects/#{project}/notes", body: { body: body })
+      post("/projects/#{url_encode project}/notes", body: { body: body })
     end
 
     # Creates a new issue note.
@@ -125,12 +125,12 @@ class Gitlab::Client
     # @example
     #   Gitlab.create_issue_note(6, 1, 'Adding a note to my issue.')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] issue The ID of an issue.
     # @param  [String] body The body of a note.
     # @return [Gitlab::ObjectifiedHash] Information about created note.
     def create_issue_note(project, issue, body)
-      post("/projects/#{project}/issues/#{issue}/notes", body: { body: body })
+      post("/projects/#{url_encode project}/issues/#{issue}/notes", body: { body: body })
     end
 
     # Creates a new snippet note.
@@ -138,12 +138,12 @@ class Gitlab::Client
     # @example
     #   Gitlab.create_snippet_note(3, 2, 'Look at this awesome snippet!')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] snippet The ID of a snippet.
     # @param  [String] body The body of a note.
     # @return [Gitlab::ObjectifiedHash] Information about created note.
     def create_snippet_note(project, snippet, body)
-      post("/projects/#{project}/snippets/#{snippet}/notes", body: { body: body })
+      post("/projects/#{url_encode project}/snippets/#{snippet}/notes", body: { body: body })
     end
 
     # Creates a new note for a single merge request.
@@ -155,7 +155,7 @@ class Gitlab::Client
     # @param [Integer] merge_request The ID of a merge request.
     # @param [String] body The content of a note.
     def create_merge_request_note(project, merge_request, body)
-      post("/projects/#{project}/merge_requests/#{merge_request}/notes", body: { body: body })
+      post("/projects/#{url_encode project}/merge_requests/#{merge_request}/notes", body: { body: body })
     end
   end
 end

--- a/lib/gitlab/client/pipelines.rb
+++ b/lib/gitlab/client/pipelines.rb
@@ -8,13 +8,13 @@ class Gitlab::Client
     #   Gitlab.pipelines(5)
     #   Gitlab.pipelines(5, { per_page: 10, page:  2 })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
     # @option options [Integer] :page The page number.
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def pipelines(project, options={})
-      get("/projects/#{project}/pipelines", query: options)
+      get("/projects/#{url_encode project}/pipelines", query: options)
     end
 
     # Gets a single pipeline.
@@ -22,11 +22,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.pipeline(5, 36)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a pipeline.
     # @return [Gitlab::ObjectifiedHash]
     def pipeline(project, id)
-      get("/projects/#{project}/pipelines/#{id}")
+      get("/projects/#{url_encode project}/pipelines/#{id}")
     end
 
     # Create a pipeline.
@@ -34,11 +34,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.create_pipeline(5, 'master')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] ref Reference to commit.
     # @return [Gitlab::ObjectifiedHash] The pipelines changes.
     def create_pipeline(project, ref)
-      post("/projects/#{project}/pipeline?ref=#{ref}")
+      post("/projects/#{url_encode project}/pipeline?ref=#{ref}")
     end
 
     # Cancels a pipeline.
@@ -46,11 +46,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.cancel_pipeline(5, 1)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a pipeline.
     # @return [Gitlab::ObjectifiedHash] The pipelines changes.
     def cancel_pipeline(project, id)
-      post("/projects/#{project}/pipelines/#{id}/cancel")
+      post("/projects/#{url_encode project}/pipelines/#{id}/cancel")
     end
 
     # Retry a pipeline.
@@ -58,11 +58,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.retry_pipeline(5, 1)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a pipeline.
     # @return [Array<Gitlab::ObjectifiedHash>] The pipelines changes.
     def retry_pipeline(project, id)
-      post("/projects/#{project}/pipelines/#{id}/retry")
+      post("/projects/#{url_encode project}/pipelines/#{id}/retry")
     end
   end
 end

--- a/lib/gitlab/client/projects.rb
+++ b/lib/gitlab/client/projects.rb
@@ -47,7 +47,7 @@ class Gitlab::Client
     # @param  [Integer, String] id The ID or name of a project.
     # @return [Gitlab::ObjectifiedHash]
     def project(id)
-      get("/projects/#{id}")
+      get("/projects/#{url_encode id}")
     end
 
     # Gets a list of project events.
@@ -62,7 +62,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def project_events(project, options={})
-      get("/projects/#{project}/events", query: options)
+      get("/projects/#{url_encode project}/events", query: options)
     end
 
     # Creates a new project.
@@ -114,7 +114,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def team_members(project, options={})
-      get("/projects/#{project}/members", query: options)
+      get("/projects/#{url_encode project}/members", query: options)
     end
 
     # Gets a project team member.
@@ -126,7 +126,7 @@ class Gitlab::Client
     # @param  [Integer] id The ID of a project team member.
     # @return [Gitlab::ObjectifiedHash]
     def team_member(project, id)
-      get("/projects/#{project}/members/#{id}")
+      get("/projects/#{url_encode project}/members/#{id}")
     end
 
     # Adds a user to project team.
@@ -140,7 +140,7 @@ class Gitlab::Client
     # @param  [Hash] options A customizable set of options.
     # @return [Gitlab::ObjectifiedHash] Information about added team member.
     def add_team_member(project, id, access_level)
-      post("/projects/#{project}/members", body: { user_id: id, access_level: access_level })
+      post("/projects/#{url_encode project}/members", body: { user_id: id, access_level: access_level })
     end
 
     # Updates a team member's project access level.
@@ -154,7 +154,7 @@ class Gitlab::Client
     # @param  [Hash] options A customizable set of options.
     # @return [Array<Gitlab::ObjectifiedHash>] Information about updated team member.
     def edit_team_member(project, id, access_level)
-      put("/projects/#{project}/members/#{id}", body: { access_level: access_level })
+      put("/projects/#{url_encode project}/members/#{id}", body: { access_level: access_level })
     end
 
     # Removes a user from project team.
@@ -167,7 +167,7 @@ class Gitlab::Client
     # @param  [Hash] options A customizable set of options.
     # @return [Gitlab::ObjectifiedHash] Information about removed team member.
     def remove_team_member(project, id)
-      delete("/projects/#{project}/members/#{id}")
+      delete("/projects/#{url_encode project}/members/#{id}")
     end
 
     # Gets a list of project hooks.
@@ -182,7 +182,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def project_hooks(project, options={})
-      get("/projects/#{project}/hooks", query: options)
+      get("/projects/#{url_encode project}/hooks", query: options)
     end
 
     # Gets a project hook.
@@ -195,7 +195,7 @@ class Gitlab::Client
     # @param  [Integer] id The ID of a hook.
     # @return [Gitlab::ObjectifiedHash]
     def project_hook(project, id)
-      get("/projects/#{project}/hooks/#{id}")
+      get("/projects/#{url_encode project}/hooks/#{id}")
     end
 
     # Adds a new hook to the project.
@@ -213,7 +213,7 @@ class Gitlab::Client
     # @return [Gitlab::ObjectifiedHash] Information about added hook.
     def add_project_hook(project, url, options={})
       body = { url: url }.merge(options)
-      post("/projects/#{project}/hooks", body: body)
+      post("/projects/#{url_encode project}/hooks", body: body)
     end
 
     # Updates a project hook URL.
@@ -232,7 +232,7 @@ class Gitlab::Client
     # @return [Gitlab::ObjectifiedHash] Information about updated hook.
     def edit_project_hook(project, id, url, options={})
       body = { url: url }.merge(options)
-      put("/projects/#{project}/hooks/#{id}", body: body)
+      put("/projects/#{url_encode project}/hooks/#{id}", body: body)
     end
 
     # Deletes a hook from project.
@@ -244,7 +244,7 @@ class Gitlab::Client
     # @param  [String] id The ID of the hook.
     # @return [Gitlab::ObjectifiedHash] Information about deleted hook.
     def delete_project_hook(project, id)
-      delete("/projects/#{project}/hooks/#{id}")
+      delete("/projects/#{url_encode project}/hooks/#{id}")
     end
 
     # Gets a project git hook.
@@ -310,7 +310,7 @@ class Gitlab::Client
     # @param  [Integer] id The ID of the project it is forked from.
     # @return [Gitlab::ObjectifiedHash] Information about the forked project.
     def make_forked_from(project, id)
-      post("/projects/#{project}/fork/#{id}")
+      post("/projects/#{url_encode project}/fork/#{id}")
     end
 
     # Remove a forked_from relationship for a project.
@@ -322,7 +322,7 @@ class Gitlab::Client
     # @param  [Integer] project The ID of the project it is forked from
     # @return [Gitlab::ObjectifiedHash] Information about the forked project.
     def remove_forked(project)
-      delete("/projects/#{project}/fork")
+      delete("/projects/#{url_encode project}/fork")
     end
 
     # Gets a project deploy keys.
@@ -330,13 +330,13 @@ class Gitlab::Client
     # @example
     #   Gitlab.deploy_keys(42)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
     # @option options [Integer] :page The page number.
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def deploy_keys(project, options={})
-      get("/projects/#{project}/keys", query: options)
+      get("/projects/#{url_encode project}/keys", query: options)
     end
 
     # Gets a single project deploy key.
@@ -344,11 +344,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.deploy_key(42, 1)
     #
-    # @param  [Integer, String] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a deploy key.
     # @return [Gitlab::ObjectifiedHash]
     def deploy_key(project, id)
-      get("/projects/#{project}/keys/#{id}")
+      get("/projects/#{url_encode project}/keys/#{id}")
     end
 
     # Creates a new deploy key.
@@ -356,12 +356,12 @@ class Gitlab::Client
     # @example
     #   Gitlab.create_deploy_key(42, 'My Key', 'Key contents')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] title The title of a deploy key.
     # @param  [String] key The content of a deploy key.
     # @return [Gitlab::ObjectifiedHash] Information about created deploy key.
     def create_deploy_key(project, title, key)
-      post("/projects/#{project}/keys", body: { title: title, key: key })
+      post("/projects/#{url_encode project}/keys", body: { title: title, key: key })
     end
 
     # Enables a deploy key at the project.
@@ -369,11 +369,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.enable_deploy_key(42, 66)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] key The ID of a deploy key.
     # @return [Gitlab::ObjectifiedHash] Information about the enabled deploy key.
     def enable_deploy_key(project, key)
-      post("/projects/#{project}/deploy_keys/#{key}/enable", body: { id: project, key_id: key })
+      post("/projects/#{url_encode project}/deploy_keys/#{key}/enable", body: { id: project, key_id: key })
     end
 
     # Disables a deploy key at the project.
@@ -381,11 +381,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.disable_deploy_key(42, 66)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] key The ID of a deploy key.
     # @return [Gitlab::ObjectifiedHash] Information about the disabled deploy key.
     def disable_deploy_key(project, key)
-      post("/projects/#{project}/deploy_keys/#{key}/disable", body: { id: project, key_id: key })
+      post("/projects/#{url_encode project}/deploy_keys/#{key}/disable", body: { id: project, key_id: key })
     end
 
     # Deletes a deploy key from project.
@@ -393,11 +393,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.delete_deploy_key(42, 1)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a deploy key.
     # @return [Gitlab::ObjectifiedHash] Information about deleted deploy key.
     def delete_deploy_key(project, id)
-      delete("/projects/#{project}/keys/#{id}")
+      delete("/projects/#{url_encode project}/keys/#{id}")
     end
 
     # Forks a project into the user namespace.
@@ -406,7 +406,7 @@ class Gitlab::Client
     #   Gitlab.create_fork(42)
     #   Gitlab.create_fork(42, { sudo: 'another_username' })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :sudo The username the project will be forked for
     # @return [Gitlab::ObjectifiedHash] Information about the forked project.
@@ -420,7 +420,7 @@ class Gitlab::Client
     #   Gitlab.edit_project(42)
     #   Gitlab.edit_project(42, { name: 'project_name' })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :name The name of a project
     # @option options [String] :path The name of a project
@@ -439,7 +439,7 @@ class Gitlab::Client
     # @param  [Integer] id The ID of a group.
     # @param  [Integer] group_access The access level to project.
     def share_project_with_group(project, id, group_access)
-      post("/projects/#{project}/share", body: { group_id: id, group_access: group_access })
+      post("/projects/#{url_encode project}/share", body: { group_id: id, group_access: group_access })
     end
 
     # Stars a project.

--- a/lib/gitlab/client/repositories.rb
+++ b/lib/gitlab/client/repositories.rb
@@ -8,13 +8,13 @@ class Gitlab::Client
     #   Gitlab.file_contents(42, 'Gemfile')
     #   Gitlab.repo_file_contents(3, 'Gemfile', 'ed899a2f4b50b4370feeea94676502b42383c746')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] filepath The relative path of the file in the repository
     # @param  [String] ref The name of a repository branch or tag or if not given the default branch.
     # @return [String]
     def file_contents(project, filepath, ref='master')
       ref = URI.encode(ref, /\W/)
-      get "/projects/#{project}/repository/blobs/#{ref}?filepath=#{filepath}",
+      get "/projects/#{url_encode project}/repository/blobs/#{ref}?filepath=#{filepath}",
           format: nil,
           headers: { Accept: 'text/plain' },
           parser: ::Gitlab::Request::Parser
@@ -27,13 +27,13 @@ class Gitlab::Client
     #   Gitlab.tree(42)
     #   Gitlab.tree(42, { path: 'Gemfile' })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :path The path inside repository.
     # @option options [String] :ref_name The name of a repository branch or tag.
     # @return [Gitlab::ObjectifiedHash]
     def tree(project, options={})
-      get("/projects/#{project}/repository/tree", query: options)
+      get("/projects/#{url_encode project}/repository/tree", query: options)
     end
     alias_method :repo_tree, :tree
 
@@ -43,11 +43,11 @@ class Gitlab::Client
     #   Gitlab.repo_archive(42)
     #   Gitlab.repo_archive(42, 'deadbeef')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] ref The commit sha, branch, or tag to download.
     # @return [Gitlab::FileResponse]
     def repo_archive(project, ref = 'master')
-      get("/projects/#{project}/repository/archive",
+      get("/projects/#{url_encode project}/repository/archive",
           format: nil,
           headers: { Accept: 'application/octet-stream' },
           query: { sha: ref },
@@ -71,7 +71,7 @@ class Gitlab::Client
     # @param [String] to The commit SHA or branch name of to branch.
     # @return [Gitlab::ObjectifiedHash]
     def compare(project, from, to)
-      get("/projects/#{project}/repository/compare", query: { from: from, to: to })
+      get("/projects/#{url_encode project}/repository/compare", query: { from: from, to: to })
     end
     alias_method :repo_compare, :compare
   end

--- a/lib/gitlab/client/repository_files.rb
+++ b/lib/gitlab/client/repository_files.rb
@@ -9,12 +9,12 @@ class Gitlab::Client
     # @example
     #   Gitlab.get_file(42, "README.md", "master")
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] file_path The full path of the file.
     # @param  [String] ref The name of branch, tag or commit.
     # @return [Gitlab::ObjectifiedHash]
     def get_file(project, file_path, ref)
-      get("/projects/#{project}/repository/files", query: {
+      get("/projects/#{url_encode project}/repository/files", query: {
             file_path: file_path,
             ref: ref
           })
@@ -25,14 +25,14 @@ class Gitlab::Client
     # @example
     #   Gitlab.create_file(42, "path", "branch", "content", "commit message")
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] full path to new file.
     # @param  [String] the name of the branch.
     # @param  [String] file content.
     # @param  [String] commit message.
     # @return [Gitlab::ObjectifiedHash]
     def create_file(project, path, branch, content, commit_message)
-      post("/projects/#{project}/repository/files", body: {
+      post("/projects/#{url_encode project}/repository/files", body: {
         file_path: path,
         branch_name: branch,
         commit_message: commit_message
@@ -44,14 +44,14 @@ class Gitlab::Client
     # @example
     #   Gitlab.edit_file(42, "path", "branch", "content", "commit message")
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] full path to new file.
     # @param  [String] the name of the branch.
     # @param  [String] file content.
     # @param  [String] commit message.
     # @return [Gitlab::ObjectifiedHash]
     def edit_file(project, path, branch, content, commit_message)
-      put("/projects/#{project}/repository/files", body: {
+      put("/projects/#{url_encode project}/repository/files", body: {
         file_path: path,
         branch_name: branch,
         commit_message: commit_message
@@ -63,13 +63,13 @@ class Gitlab::Client
     # @example
     #   Gitlab.remove_file(42, "path", "branch", "commit message")
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] full path to new file.
     # @param  [String] the name of the branch.
     # @param  [String] commit message.
     # @return [Gitlab::ObjectifiedHash]
     def remove_file(project, path, branch, commit_message)
-      delete("/projects/#{project}/repository/files", body: {
+      delete("/projects/#{url_encode project}/repository/files", body: {
                file_path: path,
                branch_name: branch,
                commit_message: commit_message

--- a/lib/gitlab/client/runners.rb
+++ b/lib/gitlab/client/runners.rb
@@ -78,10 +78,10 @@ class Gitlab::Client
     # @example
     #   Gitlab.project_runners(42)
     #
-    # @param  [Integer, String] id The ID of a project.
+    # @param  [Integer, String] id The ID or name of a project.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def project_runners(project_id)
-      get("/projects/#{project_id}/runners")
+      get("/projects/#{url_encode project_id}/runners")
     end
 
     # Enable an available specific runner in the project.
@@ -90,12 +90,12 @@ class Gitlab::Client
     # @example
     #   Gitlab.project_enable_runner(2, 42)
     #
-    # @param  [Integer, String] id The ID of a project.
+    # @param  [Integer, String] id The ID or name of a project.
     # @param  [Integer, String] id The ID of a runner.
     # @return <Gitlab::ObjectifiedHash>
     def project_enable_runner(project_id, id)
       body = { runner_id: id }
-      post("/projects/#{project_id}/runners", body: body)
+      post("/projects/#{url_encode project_id}/runners", body: body)
     end
 
     # Disable a specific runner from the project. It works only if the project isn't the only project associated with the specified runner.
@@ -104,11 +104,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.project_disable_runner(2, 42)
     #
-    # @param  [Integer, String] id The ID of a project.
+    # @param  [Integer, String] id The ID or name of a project.
     # @param  [Integer, String] runner_id The ID of a runner.
     # @return <Gitlab::ObjectifiedHash>
     def project_disable_runner(id, runner_id)
-      delete("/projects/#{id}/runners/#{runner_id}")
+      delete("/projects/#{url_encode id}/runners/#{runner_id}")
     end
 
   end

--- a/lib/gitlab/client/services.rb
+++ b/lib/gitlab/client/services.rb
@@ -10,12 +10,12 @@ class Gitlab::Client
     #                                         project_url: 'https://example.com/projects/test_project/issues',
     #                                         issues_url: 'https://example.com/issues/:id' })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] service A service code name.
     # @param  [Hash] params A service parameters.
     # @return [Boolean]
     def change_service(project, service, params)
-      put("/projects/#{project}/services/#{correct_service_name(service)}", body: params)
+      put("/projects/#{url_encode project}/services/#{correct_service_name(service)}", body: params)
     end
 
     # Delete service
@@ -23,11 +23,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.delete_service(42, :redmine)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] service A service code name.
     # @return [Boolean]
     def delete_service(project, service)
-      delete("/projects/#{project}/services/#{correct_service_name(service)}")
+      delete("/projects/#{url_encode project}/services/#{correct_service_name(service)}")
     end
 
     # Get service
@@ -35,11 +35,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.service(42, :redmine)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] service A service code name.
     # @return [Gitlab::ObjectifiedHash]
     def service(project, service)
-      get("/projects/#{project}/services/#{correct_service_name(service)}")
+      get("/projects/#{url_encode project}/services/#{correct_service_name(service)}")
     end
 
     private

--- a/lib/gitlab/client/snippets.rb
+++ b/lib/gitlab/client/snippets.rb
@@ -7,13 +7,13 @@ class Gitlab::Client
     # @example
     #   Gitlab.snippets(42)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
     # @option options [Integer] :page The page number.
     # @option options [Integer] :per_page The number of results per page.
     # @return [Gitlab::ObjectifiedHash]
     def snippets(project, options={})
-      get("/projects/#{project}/snippets", query: options)
+      get("/projects/#{url_encode project}/snippets", query: options)
     end
 
     # Gets information about a snippet.
@@ -21,11 +21,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.snippet(2, 14)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a snippet.
     # @return [Gitlab::ObjectifiedHash]
     def snippet(project, id)
-      get("/projects/#{project}/snippets/#{id}")
+      get("/projects/#{url_encode project}/snippets/#{id}")
     end
 
     # Creates a new snippet.
@@ -33,7 +33,7 @@ class Gitlab::Client
     # @example
     #   Gitlab.create_snippet(42, { title: 'REST', file_name: 'api.rb', code: 'some code' })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :title (required) The title of a snippet.
     # @option options [String] :file_name (required) The name of a snippet file.
@@ -41,7 +41,7 @@ class Gitlab::Client
     # @option options [String] :lifetime (optional) The expiration date of a snippet.
     # @return [Gitlab::ObjectifiedHash] Information about created snippet.
     def create_snippet(project, options={})
-      post("/projects/#{project}/snippets", body: options)
+      post("/projects/#{url_encode project}/snippets", body: options)
     end
 
     # Updates a snippet.
@@ -49,7 +49,7 @@ class Gitlab::Client
     # @example
     #   Gitlab.edit_snippet(42, 34, { file_name: 'README.txt' })
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a snippet.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :title The title of a snippet.
@@ -58,7 +58,7 @@ class Gitlab::Client
     # @option options [String] :lifetime The expiration date of a snippet.
     # @return [Gitlab::ObjectifiedHash] Information about updated snippet.
     def edit_snippet(project, id, options={})
-      put("/projects/#{project}/snippets/#{id}", body: options)
+      put("/projects/#{url_encode project}/snippets/#{id}", body: options)
     end
 
     # Deletes a snippet.
@@ -66,11 +66,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.delete_snippet(2, 14)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a snippet.
     # @return [Gitlab::ObjectifiedHash] Information about deleted snippet.
     def delete_snippet(project, id)
-      delete("/projects/#{project}/snippets/#{id}")
+      delete("/projects/#{url_encode project}/snippets/#{id}")
     end
 
     # Returns raw project snippet content as plain text.
@@ -78,11 +78,11 @@ class Gitlab::Client
     # @example
     #   Gitlab.snippet_content(2, 14)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a snippet.
     # @return [Gitlab::ObjectifiedHash] Information about deleted snippet.
     def snippet_content(project, id)
-      get("/projects/#{project}/snippets/#{id}/raw",
+      get("/projects/#{url_encode project}/snippets/#{id}/raw",
           format: nil,
           headers: { Accept: 'text/plain' },
           parser: ::Gitlab::Request::Parser)

--- a/lib/gitlab/client/tags.rb
+++ b/lib/gitlab/client/tags.rb
@@ -7,13 +7,13 @@ class Gitlab::Client
     # @example
     #   Gitlab.tags(42)
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
     # @option options [Integer] :page The page number.
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def tags(project, options={})
-      get("/projects/#{project}/repository/tags", query: options)
+      get("/projects/#{url_encode project}/repository/tags", query: options)
     end
     alias_method :repo_tags, :tags
 
@@ -23,14 +23,14 @@ class Gitlab::Client
     #   Gitlab.create_tag(42, 'new_tag', 'master')
     #   Gitlab.create_tag(42, 'v1.0', 'master', 'Release 1.0')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String]  tag_name The name of the new tag.
     # @param  [String]  ref The ref (commit sha, branch name, or another tag) the tag will point to.
     # @param  [String]  message Optional message for tag, creates annotated tag if specified.
     # @param  [String]  description Optional release notes for tag.
     # @return [Gitlab::ObjectifiedHash]
     def create_tag(project, tag_name, ref, message='', description=nil)
-      post("/projects/#{project}/repository/tags", body: { tag_name: tag_name, ref: ref, message: message, description: description })
+      post("/projects/#{url_encode project}/repository/tags", body: { tag_name: tag_name, ref: ref, message: message, description: description })
     end
     alias_method :repo_create_tag, :create_tag
 
@@ -40,11 +40,11 @@ class Gitlab::Client
     #   Gitlab.tag(3, 'api')
     #   Gitlab.repo_tag(5, 'master')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] tag The name of the tag.
     # @return [Gitlab::ObjectifiedHash]
     def tag(project, tag)
-      get("/projects/#{project}/repository/tags/#{tag}")
+      get("/projects/#{url_encode project}/repository/tags/#{tag}")
     end
     alias_method :repo_tag, :tag
 
@@ -54,11 +54,11 @@ class Gitlab::Client
     #   Gitlab.delete_tag(3, 'api')
     #   Gitlab.repo_delete_tag(5, 'master')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] tag The name of the tag to delete
     # @return [Gitlab::ObjectifiedHash]
     def delete_tag(project, tag)
-      delete("/projects/#{project}/repository/tags/#{tag}")
+      delete("/projects/#{url_encode project}/repository/tags/#{tag}")
     end
     alias_method :repo_delete_tag, :delete_tag
 
@@ -68,12 +68,12 @@ class Gitlab::Client
     #   Gitlab.create_release(3, '1.0.0', 'This is ready for production')
     #   Gitlab.repo_create_release(5, '1.0.0', 'This is ready for production')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] tag The name of the new tag.
     # @param  [String] description Release notes with markdown support
     # @return [Gitlab::ObjectifiedHash]
     def create_release(project, tag, description)
-      post("/projects/#{project}/repository/tags/#{tag}/release", body: { description: description })
+      post("/projects/#{url_encode project}/repository/tags/#{tag}/release", body: { description: description })
     end
     alias_method :repo_create_release, :create_release
 
@@ -83,12 +83,12 @@ class Gitlab::Client
     #   Gitlab.update_release(3, '1.0.0', 'This is even more ready for production')
     #   Gitlab.repo_update_release(5, '1.0.0', 'This is even more ready for production')
     #
-    # @param  [Integer] project The ID of a project.
+    # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] tag The name of the new tag.
     # @param  [String] description Release notes with markdown support
     # @return [Gitlab::ObjectifiedHash]
     def update_release(project, tag, description)
-      put("/projects/#{project}/repository/tags/#{tag}/release", body: { description: description })
+      put("/projects/#{url_encode project}/repository/tags/#{tag}/release", body: { description: description })
     end
     alias_method :repo_update_release, :update_release
 

--- a/spec/gitlab/cli_spec.rb
+++ b/spec/gitlab/cli_spec.rb
@@ -106,5 +106,14 @@ describe Gitlab::CLI do
         expect(@output).to_not include('created_at')
       end
     end
+
+    context "fetch project with namespace/repo" do
+      it "should encode delimiter" do
+        stub_get("/projects/gitlab-org%2Fgitlab-ce", "project")
+        args = ['project', 'gitlab-org/gitlab-ce']
+        @output = capture_output { Gitlab::CLI.start(args) }
+        expect(@output).to include('id')
+      end
+    end
   end
 end


### PR DESCRIPTION
Make it possible to use NAMESPACE/PROJECT_NAME on all methods that uses project ID

ex.
  gitlab project gitlab-org/gitlab-ce
  gitlab milestones gitlab-org/gitlab-ce
  gitlab tree gitlab-org/gitlab-ce
  gitlab tags gitlab-org/gitlab-ce
  ...

Closes #230 