### PR TITLE
Allow issues to use NAMESPACE/REPO identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Update documentation to link to docs.gitlab.com instead of the GitHub mirror for GitLab CE. (@connorshea)
 - Add method `share_project_with_group` (@danhalligan)
 - Allow to retrieve `ssh_keys` for a specific user(@dirker)
+- Allow issues to use NAMESPACE/REPO identifier (@brodock)
 
 ### 3.7.0 (16/08/2016)
 

--- a/lib/gitlab/client/issues.rb
+++ b/lib/gitlab/client/issues.rb
@@ -16,7 +16,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def issues(project=nil, options={})
-      if project.to_i.zero?
+      if project.to_s.empty? && project.to_i.zero?
         get("/issues", query: options)
       else
         get("/projects/#{project}/issues", query: options)

--- a/spec/gitlab/client/issues_spec.rb
+++ b/spec/gitlab/client/issues_spec.rb
@@ -18,6 +18,22 @@ describe Gitlab::Client do
       end
     end
 
+    context 'with literal project ID passed' do
+      before do
+        stub_get("/projects/gitlab-org%2Fgitlab-ce/issues", "project_issues")
+        @issues = Gitlab.issues('gitlab-org%2Fgitlab-ce')
+      end
+
+      it "should get the correct resource" do
+        expect(a_get("/projects/gitlab-org%2Fgitlab-ce/issues")).to have_been_made
+      end
+
+      it "should return a paginated response of project's issues" do
+        expect(@issues).to be_a Gitlab::PaginatedResponse
+        expect(@issues.first.project_id).to eq(3)
+      end
+    end
+
     context "without project ID passed" do
       before do
         stub_get("/issues", "issues")


### PR DESCRIPTION
You can use `int` based ID to identify a project, or you can use `NAMESPACE/REPO` according to the API documentation: https://docs.gitlab.com/ce/api/projects.html#get-single-project

The advantage of using `NAMESPACE/REPO` everywhere, is that you don't need to first load the repository to get the numeric ID so you can use it on other places.

The gem itself already allows the use of the "literal" identification, but there is one check in the issues getter that prevents it's use. This PR fixes that.

cc @NARKOZ @connorshea @asedge 