### PR TITLE
(Un)subscribe to issues and merge_requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Add method `share_project_with_group` (@danhalligan)
 - Allow to retrieve `ssh_keys` for a specific user(@dirker)
 - Allow issues to use NAMESPACE/REPO identifier (@brodock)
+- Add issues subscribe/unsubscribe (@newellista)
+- Add merge_requests subscribe/unsubscribe (@newellista)
 
 ### 3.7.0 (16/08/2016)
 

--- a/lib/gitlab/client/issues.rb
+++ b/lib/gitlab/client/issues.rb
@@ -97,6 +97,30 @@ class Gitlab::Client
       put("/projects/#{url_encode project}/issues/#{id}", body: { state_event: 'reopen' })
     end
 
+    # Subscribe to an issue.
+    #
+    # @example
+    #   Gitlab.subscribe_to_issue(3, 42)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of an issue.
+    # @return [Gitlab::ObjectifiedHash] Information about subscribed issue.
+    def subscribe_to_issue(project, id)
+      post("/projects/#{url_encode project}/issues/#{id}/subscribe")
+    end
+
+    # Unsubscribe from an issue.
+    #
+    # @example
+    #   Gitlab.unsubscribe_from_issue(3, 42)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of an issue.
+    # @return [Gitlab::ObjectifiedHash] Information about unsubscribed issue.
+    def unsubscribe_from_issue(project, id)
+      post("/projects/#{url_encode project}/issues/#{id}/unsubscribe")
+    end
+
     # Deletes  an issue.
     # Only for admins and project owners
     #

--- a/lib/gitlab/client/merge_requests.rb
+++ b/lib/gitlab/client/merge_requests.rb
@@ -26,7 +26,7 @@ class Gitlab::Client
     # @param  [Integer] id The ID of a merge request.
     # @return <Gitlab::ObjectifiedHash]
     def merge_request(project, id)
-      get("/projects/#{url_encode project}/merge_request/#{id}")
+      get("/projects/#{url_encode project}/merge_requests/#{id}")
     end
 
     # Creates a merge request.
@@ -65,7 +65,7 @@ class Gitlab::Client
     # @option options [String] :state_event New state (close|reopen|merge).
     # @return [Gitlab::ObjectifiedHash] Information about updated merge request.
     def update_merge_request(project, id, options={})
-      put("/projects/#{url_encode project}/merge_request/#{id}", body: options)
+      put("/projects/#{url_encode project}/merge_requests/#{id}", body: options)
     end
 
     # Accepts a merge request.
@@ -79,7 +79,7 @@ class Gitlab::Client
     # @option options [String] :merge_commit_message Custom merge commit message
     # @return [Gitlab::ObjectifiedHash] Information about updated merge request.
     def accept_merge_request(project, id, options={})
-      put("/projects/#{url_encode project}/merge_request/#{id}/merge", body: options)
+      put("/projects/#{url_encode project}/merge_requests/#{id}/merge", body: options)
     end
 
     # Adds a comment to a merge request.
@@ -124,7 +124,7 @@ class Gitlab::Client
     def delete_merge_request_comment(project, id, note_id)
       delete("/projects/#{url_encode project}/merge_requests/#{id}/notes/#{note_id}")
     end
-    
+
     # Gets the comments on a merge request.
     #
     # @example
@@ -150,7 +150,7 @@ class Gitlab::Client
     # @param  [Integer] id The ID of a merge request.
     # @return [Gitlab::ObjectifiedHash] The merge request's changes.
     def merge_request_changes(project, id)
-      get("/projects/#{url_encode project}/merge_request/#{id}/changes")
+      get("/projects/#{url_encode project}/merge_requests/#{id}/changes")
     end
 
     # Gets the commits of a merge request.
@@ -162,7 +162,7 @@ class Gitlab::Client
     # @param  [Integer] id The ID of a merge request.
     # @return [Array<Gitlab::ObjectifiedHash>] The merge request's commits.
     def merge_request_commits(project, id)
-      get("/projects/#{url_encode project}/merge_request/#{id}/commits")
+      get("/projects/#{url_encode project}/merge_requests/#{id}/commits")
     end
   end
 end

--- a/lib/gitlab/client/merge_requests.rb
+++ b/lib/gitlab/client/merge_requests.rb
@@ -164,5 +164,31 @@ class Gitlab::Client
     def merge_request_commits(project, id)
       get("/projects/#{url_encode project}/merge_requests/#{id}/commits")
     end
+
+    # Subscribes to a merge request.
+    #
+    # @example
+    #   Gitlab.subscribe_to_merge_request(5, 1)
+    #   Gitlab.subscribe_to_merge_request('gitlab', 1)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of a merge request.
+    # @return [Gitlab::ObjectifiedHash] Information about subscribed merge request.
+    def subscribe_to_merge_request(project, id)
+      post("/projects/#{url_encode project}/merge_requests/#{id}/subscribe")
+    end
+
+    # Unsubscribes from a merge request.
+    #
+    # @example
+    #   Gitlab.unsubscribe_from_merge_request(5, 1)
+    #   Gitlab.unsubscribe_from_merge_request('gitlab', 1)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of a merge request.
+    # @return [Gitlab::ObjectifiedHash] Information about unsubscribed merge request.
+    def unsubscribe_from_merge_request(project, id)
+      post("/projects/#{url_encode project}/merge_requests/#{id}/unsubscribe")
+    end
   end
 end

--- a/spec/gitlab/client/issues_spec.rb
+++ b/spec/gitlab/client/issues_spec.rb
@@ -136,6 +136,38 @@ describe Gitlab::Client do
     end
   end
 
+  describe ".subscribe_to_issue" do
+    before do
+      stub_post("/projects/3/issues/33/subscribe", "issue")
+      @issue = Gitlab.subscribe_to_issue(3, 33)
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/issues/33/subscribe")).to have_been_made
+    end
+
+    it "should return information about the subscribed issue" do
+      expect(@issue.project_id).to eq(3)
+      expect(@issue.assignee.name).to eq("Jack Smith")
+    end
+  end
+
+  describe ".unsubscribe_from_issue" do
+    before do
+      stub_post("/projects/3/issues/33/unsubscribe", "issue")
+      @issue = Gitlab.unsubscribe_from_issue(3, 33)
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/issues/33/unsubscribe")).to have_been_made
+    end
+
+    it "should return information about the unsubscribed issue" do
+      expect(@issue.project_id).to eq(3)
+      expect(@issue.assignee.name).to eq("Jack Smith")
+    end
+  end
+
   describe ".delete_issue" do
     before do
       stub_delete("/projects/3/issues/33", "issue")

--- a/spec/gitlab/client/merge_requests_spec.rb
+++ b/spec/gitlab/client/merge_requests_spec.rb
@@ -174,4 +174,34 @@ describe Gitlab::Client do
       expect(@mr_commits[1].title).to eq "hoge"
     end
   end
+
+  describe ".subscribe_to_merge_request" do
+    before do
+      stub_post("/projects/3/merge_requests/2/subscribe", "merge_request")
+      @merge_request = Gitlab.subscribe_to_merge_request(3, 2)
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/merge_requests/2/subscribe")).to have_been_made
+    end
+
+    it "should return information about a merge request" do
+      expect(@merge_request.project_id).to eq(3)
+    end
+  end
+
+  describe ".unsubscribe_from_merge_request" do
+    before do
+      stub_post("/projects/3/merge_requests/2/unsubscribe", "merge_request")
+      @merge_request = Gitlab.unsubscribe_from_merge_request(3, 2)
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/merge_requests/2/unsubscribe")).to have_been_made
+    end
+
+    it "should return information about a merge request" do
+      expect(@merge_request.project_id).to eq(3)
+    end
+  end
 end

--- a/spec/gitlab/client/merge_requests_spec.rb
+++ b/spec/gitlab/client/merge_requests_spec.rb
@@ -19,12 +19,12 @@ describe Gitlab::Client do
 
   describe ".merge_request" do
     before do
-      stub_get("/projects/3/merge_request/1", "merge_request")
+      stub_get("/projects/3/merge_requests/1", "merge_request")
       @merge_request = Gitlab.merge_request(3, 1)
     end
 
     it "should get the correct resource" do
-      expect(a_get("/projects/3/merge_request/1")).to have_been_made
+      expect(a_get("/projects/3/merge_requests/1")).to have_been_made
     end
 
     it "should return information about a merge request" do
@@ -50,7 +50,7 @@ describe Gitlab::Client do
 
   describe ".update_merge_request" do
     before do
-      stub_put("/projects/3/merge_request/2", "merge_request").
+      stub_put("/projects/3/merge_requests/2", "merge_request").
         with(body: {
                assignee_id: '1',
                target_branch: 'master',
@@ -64,7 +64,7 @@ describe Gitlab::Client do
     end
 
     it "should get the correct resource" do
-      expect(a_put("/projects/3/merge_request/2").
+      expect(a_put("/projects/3/merge_requests/2").
         with(body: {
                assignee_id: '1',
                target_branch: 'master',
@@ -80,13 +80,13 @@ describe Gitlab::Client do
 
   describe ".accept_merge_request" do
     before do
-      stub_put("/projects/5/merge_request/42/merge", "merge_request").
+      stub_put("/projects/5/merge_requests/42/merge", "merge_request").
         with(body: { merge_commit_message: 'Nice!' })
       @merge_request = Gitlab.accept_merge_request(5, 42, merge_commit_message: 'Nice!')
     end
 
     it "should get the correct resource" do
-      expect(a_put("/projects/5/merge_request/42/merge").
+      expect(a_put("/projects/5/merge_requests/42/merge").
         with(body: { merge_commit_message: 'Nice!' })).to have_been_made
     end
 
@@ -134,12 +134,12 @@ describe Gitlab::Client do
 
   describe ".merge_request_changes" do
     before do
-      stub_get("/projects/3/merge_request/2/changes", "merge_request_changes")
+      stub_get("/projects/3/merge_requests/2/changes", "merge_request_changes")
       @mr_changes = Gitlab.merge_request_changes(3, 2)
     end
 
     it "should get the correct resource" do
-      expect(a_get("/projects/3/merge_request/2/changes")).to have_been_made
+      expect(a_get("/projects/3/merge_requests/2/changes")).to have_been_made
     end
 
     it "should return the merge request changes" do
@@ -154,12 +154,12 @@ describe Gitlab::Client do
 
   describe ".merge_request_commits" do
     before do
-      stub_get("/projects/3/merge_request/2/commits", "merge_request_commits")
+      stub_get("/projects/3/merge_requests/2/commits", "merge_request_commits")
       @mr_commits = Gitlab.merge_request_commits(3, 2)
     end
 
     it "should get the correct resource" do
-      expect(a_get("/projects/3/merge_request/2/commits")).to have_been_made
+      expect(a_get("/projects/3/merge_requests/2/commits")).to have_been_made
     end
 
     it "should return the merge request commits" do


### PR DESCRIPTION
This resolves #221

Note that the documentation in the issue is incorrect wrt to the
unsubscribe endpoints.  Latest Gitlab documentation indicates that a
`POST` to `.../unsubscribe` is the correct method, rather than `DELETE`.
Also, verbs are `subscribe`/`unsubscribe` rather than `subscription`
