### PR TITLE
Fixes #222, using deploy_keys endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Allow issues to use NAMESPACE/REPO identifier (@brodock)
 - Add issues subscribe/unsubscribe (@newellista)
 - Add merge_requests subscribe/unsubscribe (@newellista)
+- Updated `deploy_key` endpoints (@epintozzi)
 
 ### 3.7.0 (16/08/2016)
 

--- a/lib/gitlab/client/projects.rb
+++ b/lib/gitlab/client/projects.rb
@@ -336,7 +336,7 @@ class Gitlab::Client
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def deploy_keys(project, options={})
-      get("/projects/#{url_encode project}/keys", query: options)
+      get("/projects/#{url_encode project}/deploy_keys", query: options)
     end
 
     # Gets a single project deploy key.
@@ -348,7 +348,7 @@ class Gitlab::Client
     # @param  [Integer] id The ID of a deploy key.
     # @return [Gitlab::ObjectifiedHash]
     def deploy_key(project, id)
-      get("/projects/#{url_encode project}/keys/#{id}")
+      get("/projects/#{url_encode project}/deploy_keys/#{id}")
     end
 
     # Creates a new deploy key.
@@ -361,7 +361,7 @@ class Gitlab::Client
     # @param  [String] key The content of a deploy key.
     # @return [Gitlab::ObjectifiedHash] Information about created deploy key.
     def create_deploy_key(project, title, key)
-      post("/projects/#{url_encode project}/keys", body: { title: title, key: key })
+      post("/projects/#{url_encode project}/deploy_keys", body: { title: title, key: key })
     end
 
     # Enables a deploy key at the project.
@@ -397,7 +397,7 @@ class Gitlab::Client
     # @param  [Integer] id The ID of a deploy key.
     # @return [Gitlab::ObjectifiedHash] Information about deleted deploy key.
     def delete_deploy_key(project, id)
-      delete("/projects/#{url_encode project}/keys/#{id}")
+      delete("/projects/#{url_encode project}/deploy_keys/#{id}")
     end
 
     # Forks a project into the user namespace.

--- a/spec/gitlab/client/projects_spec.rb
+++ b/spec/gitlab/client/projects_spec.rb
@@ -475,12 +475,12 @@ describe Gitlab::Client do
 
   describe ".deploy_keys" do
     before do
-      stub_get("/projects/42/keys", "project_keys")
+      stub_get("/projects/42/deploy_keys", "project_keys")
       @deploy_keys = Gitlab.deploy_keys(42)
     end
 
     it "should get the correct resource" do
-      expect(a_get("/projects/42/keys")).to have_been_made
+      expect(a_get("/projects/42/deploy_keys")).to have_been_made
     end
 
     it "should return project deploy keys" do
@@ -493,12 +493,12 @@ describe Gitlab::Client do
 
   describe ".deploy_key" do
     before do
-      stub_get("/projects/42/keys/2", "project_key")
+      stub_get("/projects/42/deploy_keys/2", "project_key")
       @deploy_key = Gitlab.deploy_key(42, 2)
     end
 
     it "should get the correct resource" do
-      expect(a_get("/projects/42/keys/2")).to have_been_made
+      expect(a_get("/projects/42/deploy_keys/2")).to have_been_made
     end
 
     it "should return project deploy key" do
@@ -510,12 +510,12 @@ describe Gitlab::Client do
 
   describe ".delete_deploy_key" do
     before do
-      stub_delete("/projects/42/keys/2", "project_key")
+      stub_delete("/projects/42/deploy_keys/2", "project_key")
       @deploy_key = Gitlab.delete_deploy_key(42, 2)
     end
 
     it "should get the correct resource" do
-      expect(a_delete("/projects/42/keys/2")).to have_been_made
+      expect(a_delete("/projects/42/deploy_keys/2")).to have_been_made
     end
 
     it "should return information about a deleted key" do


### PR DESCRIPTION
This PR resolves issue #222. The `deploy_keys` endpoints have been updated from `keys`. `disable_deploy_key` was already updated.

This has been tested against <https://gitlab.com/api/v3> and is confirmed working. This does not address backwards compatibility with versions prior to 8.10.