### PR TITLE
Fixing Branches.create_branch

### DIFF
--- a/lib/gitlab/client/branches.rb
+++ b/lib/gitlab/client/branches.rb
@@ -70,7 +70,7 @@ class Gitlab::Client
     # @param  [String] ref Create branch from commit sha or existing branch
     # @return [Gitlab::ObjectifiedHash]
     def create_branch(project, branch, ref)
-      post("/projects/#{url_encode project}/repository/branches", body: { branch_name: branch, ref: ref })
+      post("/projects/#{url_encode project}/repository/branches", body: { branch_name: branch, branch: branch, ref: ref })
     end
     alias_method :repo_create_branch, :create_branch
 


### PR DESCRIPTION
It looks like, despite the [documentation](https://docs.gitlab.com/ee/api/branches.html#create-repository-branch), the branch parameter is named `branch` and not `branch_name`. I left the old `branch_name` in for backward compatibility. I don't know if the parameter was named `branch_name` before.