### PR TITLE
Adds ability to create commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Change Log
 
 ### Unreleased
-
+- Adds ability to create commits in a repository - (@logicminds)
 - Remove Ruby 1.x support from the project - (@orta)
 - Add `star_project` and `unstar_project` methods. (@connorshea)
 - Lock terminal-table to prevent build failures on Ruby 1.9/2.0. (@connorshea)

--- a/lib/gitlab/client/commits.rb
+++ b/lib/gitlab/client/commits.rb
@@ -117,5 +117,30 @@ class Gitlab::Client
       post("/projects/#{id}/statuses/#{sha}", query: options.merge(state: state))
     end
     alias_method :repo_update_commit_status, :update_commit_status
+
+    # Creates a single commit with one or more changes
+    #
+    # @see https://docs.gitlab.com/ce/api/commits.html#create-a-commit-with-multiple-files-and-actions
+    # Introduced in Gitlab 8.13
+    #
+    # @example
+    # Gitlab.create_commit(2726132, 'master', 'refactors everything', [{action: 'create', file_path: '/foo.txt', content: 'bar'}])
+    # Gitlab.create_commit(2726132, 'master', 'refactors everything', [{action: 'delete', file_path: '/foo.txt'}])
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param [String] branch the branch name you wish to commit to
+    # @param [String] message the commit message
+    # @param [Array[Hash]] An array of action hashes to commit as a batch. See the next table for what attributes it can take.
+    # @option options [String] :author_email the email address of the author
+    # @option options [String] :author_name the name of the author
+    # @return [Gitlab::ObjectifiedHash] hash of commit related data
+    def create_commit(project, branch, message, actions, options={})
+      payload = {
+          branch_name: branch,
+          commit_message: message,
+          actions: actions,
+      }.merge(options)
+      post("/projects/#{url_encode project}/repository/commits", query: payload)
+    end
   end
 end

--- a/spec/fixtures/project_commit_create.json
+++ b/spec/fixtures/project_commit_create.json
@@ -1,0 +1,22 @@
+{
+  "id": "ed899a2f4b50b4370feeea94676502b42383c746",
+  "short_id": "ed899a2f4b5",
+  "title": "some commit message",
+  "author_name": "Dmitriy Zaporozhets",
+  "author_email": "dzaporozhets@sphereconsultinginc.com",
+  "committer_name": "Dmitriy Zaporozhets",
+  "committer_email": "dzaporozhets@sphereconsultinginc.com",
+  "created_at": "2016-09-20T09:26:24.000-07:00",
+  "message": "some commit message",
+  "parent_ids": [
+    "ae1d9fb46aa2b07ee9836d49862ec4e2c46fbbba"
+  ],
+  "committed_date": "2016-09-20T09:26:24.000-07:00",
+  "authored_date": "2016-09-20T09:26:24.000-07:00",
+  "stats": {
+    "additions": 2,
+    "deletions": 2,
+    "total": 4
+  },
+  "status": null
+}

--- a/spec/gitlab/client/commits_spec.rb
+++ b/spec/gitlab/client/commits_spec.rb
@@ -134,4 +134,35 @@ describe Gitlab::Client do
       expect(@status.ref).to eq('decreased-spec')
     end
   end
+
+  describe ".create_commit" do
+    let(:actions) do
+      [
+        {
+          action: "create",
+          file_path: "foo/bar",
+          content: "some content"
+        }
+      ]
+    end
+
+    let(:query) do
+      {
+        branch_name: 'dev',
+        commit_message: 'refactors everything',
+        actions: actions,
+        author_email: 'joe@sample.org',
+        author_name: 'Joe Sample'
+      }
+    end
+
+    before do
+      stub_post("/projects/6/repository/commits", 'project_commit_create').with(query: query)
+      @commit = Gitlab.create_commit(6, 'dev', 'refactors everything', actions, {author_email: 'joe@sample.org', author_name: 'Joe Sample'})
+    end
+
+    it "should return id of a created commit" do
+      expect(@commit.id).to eq('ed899a2f4b50b4370feeea94676502b42383c746')
+    end
+  end
 end


### PR DESCRIPTION
   * the user can now create commits through the gem by posting
     one or more file changes (file content).  This can be extremely
     useful in situations where you don't want to distribute ssh keys,
     and use api tokens instead with CI systems.