### PR TITLE
Add appropriate Content-Type header

### DIFF
--- a/lib/gitlab/request.rb
+++ b/lib/gitlab/request.rb
@@ -6,7 +6,7 @@ module Gitlab
   class Request
     include HTTParty
     format :json
-    headers 'Accept' => 'application/json'
+    headers 'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'
     parser proc { |body, _| parse(body) }
 
     attr_accessor :private_token, :endpoint

--- a/spec/gitlab/request_spec.rb
+++ b/spec/gitlab/request_spec.rb
@@ -15,7 +15,7 @@ describe Gitlab::Request do
       expect(default_options).to be_a Hash
       expect(default_options[:parser]).to be_a Proc
       expect(default_options[:format]).to eq(:json)
-      expect(default_options[:headers]).to eq('Accept' => 'application/json')
+      expect(default_options[:headers]).to eq('Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded')
       expect(default_options[:default_params]).to be_nil
     end
   end


### PR DESCRIPTION
This makes it easier to tests using a rack-based Gitlab mock API. (Sinatra in my case)

Rack will assume POST requests include `www-form-urlencoded` data, but it won't assume the same of PUT or PATCH requests, and therefore won't parse the body unless a header is present.  Granted, this header is obviously not required for Gitlab to accept the request, but it's the right way to construct the request in general, which should make it more reusable/compatible with testing frameworks, etc.

It seems like `HTTParty` or even `Net::HTTP` is making the decision to encode the data as form-encoded data, so why it doesn't automatically attach that header, I'm not sure.  But that's further than I have time to investigate/fix at the moment :)

Note: I have not yet tested this patch with an actual Gitlab instance, but if all the requests are sent as form-encoded data (and as far as I know they all are, or the data is included in the query-string), it shouldn't cause any problems.