### PR TITLE
client: add support for the keys resource

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -10,6 +10,7 @@ module Gitlab
     include Commits
     include Groups
     include Issues
+    include Keys
     include Labels
     include MergeRequests
     include Milestones

--- a/lib/gitlab/client/keys.rb
+++ b/lib/gitlab/client/keys.rb
@@ -1,0 +1,16 @@
+class Gitlab::Client
+  # Defines methods related to keys.
+  # @see https://docs.gitlab.com/ce/api/keys.html
+  module Keys
+    # Gets information about a key.
+    #
+    # @example
+    #   Gitlab.key(1)
+    #
+    # @param  [Integer] id The ID of a key.
+    # @return [Gitlab::ObjectifiedHash]
+    def key(id)
+      get("/keys/#{id}")
+    end
+  end
+end

--- a/spec/gitlab/client/keys_spec.rb
+++ b/spec/gitlab/client/keys_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Gitlab::Client do
+  describe ".key" do
+    before do
+      stub_get("/keys/1", "key")
+      @key = Gitlab.key(1)
+    end
+
+    it "should get the correct resource" do
+      expect(a_get("/keys/1")).to have_been_made
+    end
+
+    it "should return information about a key" do
+      expect(@key.id).to eq(1)
+      expect(@key.title).to eq("narkoz@helium")
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds support for the keys resource: https://docs.gitlab.com/ce/api/keys.html.