### PR TITLE
Rename branch_name parameter to branch in create_branch method

### DIFF
--- a/lib/gitlab/client/branches.rb
+++ b/lib/gitlab/client/branches.rb
@@ -70,7 +70,7 @@ class Gitlab::Client
     # @param  [String] ref Create branch from commit sha or existing branch
     # @return [Gitlab::ObjectifiedHash]
     def create_branch(project, branch, ref)
-      post("/projects/#{url_encode project}/repository/branches", body: { branch_name: branch, ref: ref })
+      post("/projects/#{url_encode project}/repository/branches", body: { branch: branch, ref: ref })
     end
     alias_method :repo_create_branch, :create_branch
 


### PR DESCRIPTION
In Gitlab 9.0 the `branch_name` parameter for the `create_branch` method was renamed to `branch` (see: https://gitlab.com/gitlab-org/gitlab-ce/issues/22132)

This pull request renames the parameter for the client.