### PR TITLE
Rename branch_name parameter to branch in create_commit method

### DIFF
--- a/lib/gitlab/client/commits.rb
+++ b/lib/gitlab/client/commits.rb
@@ -136,7 +136,7 @@ class Gitlab::Client
     # @return [Gitlab::ObjectifiedHash] hash of commit related data
     def create_commit(project, branch, message, actions, options={})
       payload = {
-          branch_name: branch,
+          branch: branch,
           commit_message: message,
           actions: actions,
       }.merge(options)

--- a/spec/gitlab/client/commits_spec.rb
+++ b/spec/gitlab/client/commits_spec.rb
@@ -148,7 +148,7 @@ describe Gitlab::Client do
 
     let(:query) do
       {
-        branch_name: 'dev',
+        branch: 'dev',
         commit_message: 'refactors everything',
         actions: actions,
         author_email: 'joe@sample.org',


### PR DESCRIPTION
The `branch_name` parameter for the `create_commit` was renamed to `branch` in Gitlab 9.0.

This pull request changes the parameter in the client.