### PR TITLE
edit and delete methods for notes API

### DIFF
--- a/lib/gitlab/client/merge_requests.rb
+++ b/lib/gitlab/client/merge_requests.rb
@@ -82,65 +82,6 @@ class Gitlab::Client
       put("/projects/#{url_encode project}/merge_requests/#{id}/merge", body: options)
     end
 
-    # Adds a comment to a merge request.
-    #
-    # @example
-    #   Gitlab.create_merge_request_comment(5, 1, "Awesome merge!")
-    #   Gitlab.create_merge_request_comment('gitlab', 1, "Awesome merge!")
-    #
-    # @param  [Integer, String] project The ID or name of a project.
-    # @param  [Integer] id The ID of a merge request.
-    # @param  [String] note The content of a comment.
-    # @return [Gitlab::ObjectifiedHash] Information about created merge request comment.
-    def create_merge_request_comment(project, id, note)
-      post("/projects/#{url_encode project}/merge_requests/#{id}/notes", body: { body: note })
-    end
-
-    # Adds a comment to a merge request.
-    #
-    # @example
-    #   Gitlab.edit_merge_request_comment(5, 1,2, "Awesome merge!")
-    #   Gitlab.edit_merge_request_comment('gitlab', 1, 2, "Awesome merge!")
-    #
-    # @param  [Integer, String] project The ID or name of a project.
-    # @param  [Integer] id The ID of a merge request.
-    # @param  [Integer] id The ID of the merge-request comment
-    # @param  [String] note The content of a comment.
-    # @return [Gitlab::ObjectifiedHash] Information about created merge request comment.
-    def edit_merge_request_comment(project, id, note_id , note)
-      put("/projects/#{url_encode project}/merge_requests/#{id}/notes/#{note_id}", body: { body: note })
-    end
-
-    # Deletes a comment from a merge request.
-    #
-    # @example
-    #   Gitlab.delete_merge_request_comment(5, 1,2)
-    #   Gitlab.delete_merge_request_comment('gitlab', 1, 2)
-    #
-    # @param  [Integer, String] project The ID or name of a project.
-    # @param  [Integer] id The ID of a merge request.
-    # @param  [Integer] id The ID of the merge-request comment
-    # @return [Gitlab::ObjectifiedHash] Information about created merge request comment.
-    def delete_merge_request_comment(project, id, note_id)
-      delete("/projects/#{url_encode project}/merge_requests/#{id}/notes/#{note_id}")
-    end
-
-    # Gets the comments on a merge request.
-    #
-    # @example
-    #   Gitlab.merge_request_comments(5, 1)
-    #   Gitlab.merge_request_comments(5, 1, { per_page: 10, page: 2 })
-    #
-    # @param  [Integer, String] project The ID or name of a project.
-    # @param  [Integer] id The ID of a merge request.
-    # @param  [Hash] options A customizable set of options.
-    # @option options [Integer] :page The page number.
-    # @option options [Integer] :per_page The number of results per page.
-    # @return [Gitlab::ObjectifiedHash] The merge request's comments.
-    def merge_request_comments(project, id, options={})
-      get("/projects/#{url_encode project}/merge_requests/#{id}/notes", query: options)
-    end
-
     # Gets the changes of a merge request.
     #
     # @example

--- a/lib/gitlab/client/notes.rb
+++ b/lib/gitlab/client/notes.rb
@@ -56,6 +56,7 @@ class Gitlab::Client
     def merge_request_notes(project, merge_request, options={})
       get("/projects/#{url_encode project}/merge_requests/#{merge_request}/notes", query: options)
     end
+    alias_method :merge_request_comments, :merge_request_notes
 
     # Gets a single wall note.
     #
@@ -157,5 +158,110 @@ class Gitlab::Client
     def create_merge_request_note(project, merge_request, body)
       post("/projects/#{url_encode project}/merge_requests/#{merge_request}/notes", body: { body: body })
     end
+    alias_method :create_merge_request_comment, :create_merge_request_note
+
+    # Deletes a wall note.
+    #
+    # @example
+    #   Gitlab.delete_note(5, 15)
+    #
+    # @param [Integer] project The ID of a project.
+    # @param [Integer] id The ID of a note.
+    # @return [Gitlab::ObjectifiedHash]
+    def delete_note(project, id)
+      delete("/projects/#{url_encode project}/notes/#{id}")
+    end
+
+    # Deletes an issue note.
+    #
+    # @example
+    #   Gitlab.delete_issue_note(5, 10, 1)
+    #
+    # @param [Integer] project The ID of a project.
+    # @param [Integer] issue The ID of an issue.
+    # @param [Integer] id The ID of a note.
+    # @return [Gitlab::ObjectifiedHash]
+    def delete_issue_note(project, issue, id)
+      delete("/projects/#{url_encode project}/issues/#{issue}/notes/#{id}")
+    end
+
+    # Deletes a snippet note.
+    #
+    # @example
+    #   Gitlab.delete_snippet_note(5, 11, 3)
+    #
+    # @param [Integer] project The ID of a project.
+    # @param [Integer] snippet The ID of a snippet.
+    # @param [Integer] id The ID of a note.
+    # @return [Gitlab::ObjectifiedHash]
+    def delete_snippet_note(project, snippet, id)
+      delete("/projects/#{url_encode project}/snippets/#{snippet}/notes/#{id}")
+    end
+
+    # Deletes a merge_request note.
+    #
+    # @example
+    #   Gitlab.delete_merge_request_note(5, 11, 3)
+    #
+    # @param [Integer] project The ID of a project.
+    # @param [Integer] merge_request The ID of a merge_request.
+    # @param [Integer] id The ID of a note.
+    # @return [Gitlab::ObjectifiedHash]
+    def delete_merge_request_note(project, merge_request, id)
+      delete("/projects/#{url_encode project}/merge_requests/#{merge_request}/notes/#{id}")
+    end
+    alias_method :delete_merge_request_comment, :delete_merge_request_note
+
+    # Modifies a wall note.
+    #
+    # @example
+    #   Gitlab.edit_note(5, 15, 'This is an edited note')
+    #
+    # @param [Integer] project The ID of a project.
+    # @param [Integer] id The ID of a note.
+    # @return [Gitlab::ObjectifiedHash]
+    def edit_note(project, id, body)
+      put("/projects/#{url_encode project}/notes/#{id}", body: body)
+    end
+
+    # Modifies an issue note.
+    #
+    # @example
+    #   Gitlab.edit_issue_note(5, 10, 1, 'This is an edited issue note')
+    #
+    # @param [Integer] project The ID of a project.
+    # @param [Integer] issue The ID of an issue.
+    # @param [Integer] id The ID of a note.
+    # @return [Gitlab::ObjectifiedHash]
+    def edit_issue_note(project, issue, id, body)
+      put("/projects/#{url_encode project}/issues/#{issue}/notes/#{id}", body: body)
+    end
+
+    # Modifies a snippet note.
+    #
+    # @example
+    #   Gitlab.edit_snippet_note(5, 11, 3, 'This is an edited snippet note')
+    #
+    # @param [Integer] project The ID of a project.
+    # @param [Integer] snippet The ID of a snippet.
+    # @param [Integer] id The ID of a note.
+    # @return [Gitlab::ObjectifiedHash]
+    def edit_snippet_note(project, snippet, id, body)
+      put("/projects/#{url_encode project}/snippets/#{snippet}/notes/#{id}", body: body)
+    end
+
+    # Modifies a merge_request note.
+    #
+    # @example
+    #   Gitlab.edit_merge_request_note(5, 11, 3, 'This is an edited merge request note')
+    #
+    # @param [Integer] project The ID of a project.
+    # @param [Integer] merge_request The ID of a merge_request.
+    # @param [Integer] id The ID of a note.
+    # @return [Gitlab::ObjectifiedHash]
+    def edit_merge_request_note(project, merge_request, id, body)
+      put("/projects/#{url_encode project}/merge_requests/#{merge_request}/notes/#{id}", body: body)
+    end
+    alias_method :edit_merge_request_comment, :edit_merge_request_note
   end
 end

--- a/spec/gitlab/client/notes_spec.rb
+++ b/spec/gitlab/client/notes_spec.rb
@@ -202,4 +202,132 @@ describe Gitlab::Client do
       end
     end
   end
+
+  describe "delete note" do
+    context "when wall note" do
+      before do
+        stub_delete("/projects/3/notes/1201", "note")
+        @note = Gitlab.delete_note(3, 1201)
+      end
+
+      it "should get the correct resource" do
+        expect(a_delete("/projects/3/notes/1201")).to have_been_made
+      end
+
+      it "should return information about a deleted note" do
+        expect(@note.id).to eq(1201)
+      end
+    end
+
+    context "when issue note" do
+      before do
+        stub_delete("/projects/3/issues/7/notes/1201", "note")
+        @note = Gitlab.delete_issue_note(3, 7, 1201)
+      end
+
+      it "should get the correct resource" do
+        expect(a_delete("/projects/3/issues/7/notes/1201")).to have_been_made
+      end
+
+      it "should return information about a deleted issue note" do
+        expect(@note.id).to eq(1201)
+      end
+    end
+
+    context "when snippet note" do
+      before do
+        stub_delete("/projects/3/snippets/7/notes/1201", "note")
+        @note = Gitlab.delete_snippet_note(3, 7, 1201)
+      end
+
+      it "should get the correct resource" do
+        expect(a_delete("/projects/3/snippets/7/notes/1201")).to have_been_made
+      end
+
+      it "should return information about a deleted snippet note" do
+        expect(@note.id).to eq(1201)
+      end
+    end
+
+    context "when merge request note" do
+      before do
+        stub_delete("/projects/3/merge_requests/7/notes/1201", "note")
+        @note = Gitlab.delete_merge_request_note(3, 7, 1201)
+      end
+
+      it "should get the correct resource" do
+        expect(a_delete("/projects/3/merge_requests/7/notes/1201")).to have_been_made
+      end
+
+      it "should return information about a deleted merge request note" do
+        expect(@note.id).to eq(1201)
+      end
+    end
+  end
+
+  describe "modify note" do
+    context "when wall note" do
+      before do
+        stub_put("/projects/3/notes/1201", "note")
+        @note = Gitlab.edit_note(3, 1201, body: "edited wall note content")
+      end
+
+      it "should get the correct resource" do
+        expect(a_put("/projects/3/notes/1201").
+          with(body: {body: 'edited wall note content'})).to have_been_made
+      end
+
+      it "should return information about a modified note" do
+        expect(@note.id).to eq(1201)
+      end
+    end
+
+    context "when issue note" do
+      before do
+        stub_put("/projects/3/issues/7/notes/1201", "note")
+        @note = Gitlab.edit_issue_note(3, 7, 1201, body: "edited issue note content")
+      end
+
+      it "should get the correct resource" do
+        expect(a_put("/projects/3/issues/7/notes/1201").
+          with(body: {body: 'edited issue note content'})).to have_been_made
+      end
+
+      it "should return information about a modified issue note" do
+        expect(@note.id).to eq(1201)
+      end
+    end
+
+    context "when snippet note" do
+      before do
+        stub_put("/projects/3/snippets/7/notes/1201", "note")
+        @note = Gitlab.edit_snippet_note(3, 7, 1201, body: "edited snippet note content")
+      end
+
+      it "should get the correct resource" do
+        expect(a_put("/projects/3/snippets/7/notes/1201").
+          with(body: {body: 'edited snippet note content'})).to have_been_made
+      end
+
+      it "should return information about a modified snippet note" do
+        expect(@note.id).to eq(1201)
+      end
+    end
+
+    context "when merge request note" do
+      before do
+        stub_put("/projects/3/merge_requests/7/notes/1201", "note")
+        @note = Gitlab.edit_merge_request_note(3, 7, 1201, body: "edited merge request note content")
+      end
+
+      it "should get the correct resource" do
+        expect(a_put("/projects/3/merge_requests/7/notes/1201").
+          with(body: {body: 'edited merge request note content'})).to have_been_made
+      end
+
+      it "should return information about a modified request note" do
+        expect(@note.id).to eq(1201)
+      end
+    end
+  end
 end


### PR DESCRIPTION
1. Modify and delete wall notes, issue notes, snippet notes and MR notes methods added to notes.rb
2. Cleaning up duplicate MR comment methods in merge_requests.rb
3. Adding aliases for existing MR comment/note methods to notes.rb