### PR TITLE
Send create commit data via post body

### DIFF
--- a/lib/gitlab/client/branches.rb
+++ b/lib/gitlab/client/branches.rb
@@ -70,7 +70,7 @@ class Gitlab::Client
     # @param  [String] ref Create branch from commit sha or existing branch
     # @return [Gitlab::ObjectifiedHash]
     def create_branch(project, branch, ref)
-      post("/projects/#{url_encode project}/repository/branches", body: { branch_name: branch, ref: ref })
+      post("/projects/#{url_encode project}/repository/branches", body: { branch: branch, ref: ref })
     end
     alias_method :repo_create_branch, :create_branch
 

--- a/lib/gitlab/client/commits.rb
+++ b/lib/gitlab/client/commits.rb
@@ -140,7 +140,7 @@ class Gitlab::Client
           commit_message: message,
           actions: actions,
       }.merge(options)
-      post("/projects/#{url_encode project}/repository/commits", query: payload)
+      post("/projects/#{url_encode project}/repository/commits", body: payload)
     end
   end
 end


### PR DESCRIPTION
Currently when creating a commit the POST data is send via the query parameter. This leads to the Gitlab API to respond with 414 URI too long once there are several documents part of the commit.

This can be fixed when sending the data via the POST body attribute.