### PR TITLE
Use body parameter to send post data

### DIFF
--- a/lib/gitlab/client/commits.rb
+++ b/lib/gitlab/client/commits.rb
@@ -140,7 +140,7 @@ class Gitlab::Client
           commit_message: message,
           actions: actions,
       }.merge(options)
-      post("/projects/#{url_encode project}/repository/commits", query: payload)
+      post("/projects/#{url_encode project}/repository/commits", body: payload)
     end
   end
 end

--- a/spec/gitlab/client/commits_spec.rb
+++ b/spec/gitlab/client/commits_spec.rb
@@ -157,7 +157,7 @@ describe Gitlab::Client do
     end
 
     before do
-      stub_post("/projects/6/repository/commits", 'project_commit_create').with(query: query)
+      stub_post("/projects/6/repository/commits", 'project_commit_create').with(body: query)
       @commit = Gitlab.create_commit(6, 'dev', 'refactors everything', actions, {author_email: 'joe@sample.org', author_name: 'Joe Sample'})
     end
 


### PR DESCRIPTION
Currently when creating a commit the POST data is send via the query parameter. This leads to the Gitlab API to respond with 414 URI too long once there are several documents part of the commit.

This can be fixed when sending the data via the POST body attribute.