### PR TITLE
Todo api

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -25,6 +25,7 @@ module Gitlab
     include Snippets
     include SystemHooks
     include Tags
+    include Todos
     include Users
     include Jobs
 

--- a/lib/gitlab/client/todos.rb
+++ b/lib/gitlab/client/todos.rb
@@ -1,0 +1,44 @@
+class Gitlab::Client
+  # Defines methods related to todos
+  # @see https://docs.gitlab.com/ce/api/todos.html 
+  module Todos
+    # Gets a list of todos.
+    #
+    # @example
+    #   Gitlab.todos
+    #   Gitlab.todos(action: 'assigned')
+    #   Gitlab.todos(state: 'pending')
+    #
+    # @param  [Hash] options A customizable set of options.
+    # @option options [Integer] :action The action to be filtered. Can be `assigned`, `mentioned`, `build_failed`, `marked`, or `approval_required`.
+    # @option options [Integer] :author_id The ID of an author
+    # @option options [Integer] :project_id The ID of a project
+    # @option options [Integer] :state The state of the todo. Can be either `pending` or `done`
+    # @option options [Integer] :type The type of a todo. Can be either `Issue` or `MergeRequest`
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def todos(options={})
+      get("/todos", query: options)
+    end
+
+    # Marks a single pending todo for the current user as done.
+    #
+    # @example
+    #   Gitlab.mark_todo_as_done(42)
+    #
+    # @param  [Integer] id The ID of the todo.
+    # @return [Gitlab::ObjectifiedHash]
+    def mark_todo_as_done(id)
+      post("/todos/#{id}/mark_as_done")
+    end
+
+    # Marks all todos for the current user as done
+    #
+    # @example
+    #   Gitlab.mark_all_todos_as_done
+    #
+    # @return [void]    This API call returns an empty response body.
+    def mark_all_todos_as_done
+      post("/todos/mark_as_done")
+    end
+  end
+end

--- a/lib/gitlab/client/todos.rb
+++ b/lib/gitlab/client/todos.rb
@@ -6,8 +6,8 @@ class Gitlab::Client
     #
     # @example
     #   Gitlab.todos
-    #   Gitlab.todos(action: 'assigned')
-    #   Gitlab.todos(state: 'pending')
+    #   Gitlab.todos({ action: 'assigned' })
+    #   Gitlab.todos({ state: 'pending' })
     #
     # @param  [Hash] options A customizable set of options.
     # @option options [Integer] :action The action to be filtered. Can be `assigned`, `mentioned`, `build_failed`, `marked`, or `approval_required`.
@@ -36,7 +36,7 @@ class Gitlab::Client
     # @example
     #   Gitlab.mark_all_todos_as_done
     #
-    # @return [void]    This API call returns an empty response body.
+    # @return [void] This API call returns an empty response body.
     def mark_all_todos_as_done
       post("/todos/mark_as_done")
     end

--- a/spec/fixtures/todo.json
+++ b/spec/fixtures/todo.json
@@ -1,0 +1,73 @@
+{
+    "id": 102,
+    "project": {
+      "id": 2,
+      "name": "Gitlab Ce",
+      "name_with_namespace": "Gitlab Org / Gitlab Ce",
+      "path": "gitlab-ce",
+      "path_with_namespace": "gitlab-org/gitlab-ce"
+    },
+    "author": {
+      "name": "Administrator",
+      "username": "root",
+      "id": 1,
+      "state": "active",
+      "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "https://gitlab.example.com/root"
+    },
+    "action_name": "marked",
+    "target_type": "MergeRequest",
+    "target": {
+      "id": 34,
+      "iid": 7,
+      "project_id": 2,
+      "title": "Dolores in voluptatem tenetur praesentium omnis repellendus voluptatem quaerat.",
+      "description": "Et ea et omnis illum cupiditate. Dolor aspernatur tenetur ducimus facilis est nihil. Quo esse cupiditate molestiae illo corrupti qui quidem dolor.",
+      "state": "opened",
+      "created_at": "2016-06-17T07:49:24.419Z",
+      "updated_at": "2016-06-17T07:52:43.484Z",
+      "target_branch": "tutorials_git_tricks",
+      "source_branch": "DNSBL_docs",
+      "upvotes": 0,
+      "downvotes": 0,
+      "author": {
+        "name": "Maxie Medhurst",
+        "username": "craig_rutherford",
+        "id": 12,
+        "state": "active",
+        "avatar_url": "http://www.gravatar.com/avatar/a0d477b3ea21970ce6ffcbb817b0b435?s=80&d=identicon",
+        "web_url": "https://gitlab.example.com/craig_rutherford"
+      },
+      "assignee": {
+        "name": "Administrator",
+        "username": "root",
+        "id": 1,
+        "state": "active",
+        "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+        "web_url": "https://gitlab.example.com/root"
+      },
+      "source_project_id": 2,
+      "target_project_id": 2,
+      "labels": [],
+      "work_in_progress": false,
+      "milestone": {
+        "id": 32,
+        "iid": 2,
+        "project_id": 2,
+        "title": "v1.0",
+        "description": "Assumenda placeat ea voluptatem voluptate qui.",
+        "state": "active",
+        "created_at": "2016-06-17T07:47:34.163Z",
+        "updated_at": "2016-06-17T07:47:34.163Z",
+        "due_date": null
+      },
+      "merge_when_pipeline_succeeds": false,
+      "merge_status": "cannot_be_merged",
+      "subscribed": true,
+      "user_notes_count": 7
+    },
+    "target_url": "https://gitlab.example.com/gitlab-org/gitlab-ce/merge_requests/7",
+    "body": "Dolores in voluptatem tenetur praesentium omnis repellendus voluptatem quaerat.",
+    "state": "done",
+    "created_at": "2016-06-17T07:52:35.225Z"
+}

--- a/spec/fixtures/todos.json
+++ b/spec/fixtures/todos.json
@@ -1,0 +1,148 @@
+[
+  {
+    "id": 102,
+    "project": {
+      "id": 2,
+      "name": "Gitlab Ce",
+      "name_with_namespace": "Gitlab Org / Gitlab Ce",
+      "path": "gitlab-ce",
+      "path_with_namespace": "gitlab-org/gitlab-ce"
+    },
+    "author": {
+      "name": "Administrator",
+      "username": "root",
+      "id": 1,
+      "state": "active",
+      "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "https://gitlab.example.com/root"
+    },
+    "action_name": "marked",
+    "target_type": "MergeRequest",
+    "target": {
+      "id": 34,
+      "iid": 7,
+      "project_id": 2,
+      "title": "Dolores in voluptatem tenetur praesentium omnis repellendus voluptatem quaerat.",
+      "description": "Et ea et omnis illum cupiditate. Dolor aspernatur tenetur ducimus facilis est nihil. Quo esse cupiditate molestiae illo corrupti qui quidem dolor.",
+      "state": "opened",
+      "created_at": "2016-06-17T07:49:24.419Z",
+      "updated_at": "2016-06-17T07:52:43.484Z",
+      "target_branch": "tutorials_git_tricks",
+      "source_branch": "DNSBL_docs",
+      "upvotes": 0,
+      "downvotes": 0,
+      "author": {
+        "name": "Maxie Medhurst",
+        "username": "craig_rutherford",
+        "id": 12,
+        "state": "active",
+        "avatar_url": "http://www.gravatar.com/avatar/a0d477b3ea21970ce6ffcbb817b0b435?s=80&d=identicon",
+        "web_url": "https://gitlab.example.com/craig_rutherford"
+      },
+      "assignee": {
+        "name": "Administrator",
+        "username": "root",
+        "id": 1,
+        "state": "active",
+        "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+        "web_url": "https://gitlab.example.com/root"
+      },
+      "source_project_id": 2,
+      "target_project_id": 2,
+      "labels": [],
+      "work_in_progress": false,
+      "milestone": {
+        "id": 32,
+        "iid": 2,
+        "project_id": 2,
+        "title": "v1.0",
+        "description": "Assumenda placeat ea voluptatem voluptate qui.",
+        "state": "active",
+        "created_at": "2016-06-17T07:47:34.163Z",
+        "updated_at": "2016-06-17T07:47:34.163Z",
+        "due_date": null
+      },
+      "merge_when_pipeline_succeeds": false,
+      "merge_status": "cannot_be_merged",
+      "subscribed": true,
+      "user_notes_count": 7
+    },
+    "target_url": "https://gitlab.example.com/gitlab-org/gitlab-ce/merge_requests/7",
+    "body": "Dolores in voluptatem tenetur praesentium omnis repellendus voluptatem quaerat.",
+    "state": "pending",
+    "created_at": "2016-06-17T07:52:35.225Z"
+  },
+  {
+    "id": 98,
+    "project": {
+      "id": 2,
+      "name": "Gitlab Ce",
+      "name_with_namespace": "Gitlab Org / Gitlab Ce",
+      "path": "gitlab-ce",
+      "path_with_namespace": "gitlab-org/gitlab-ce"
+    },
+    "author": {
+      "name": "Maxie Medhurst",
+      "username": "craig_rutherford",
+      "id": 12,
+      "state": "active",
+      "avatar_url": "http://www.gravatar.com/avatar/a0d477b3ea21970ce6ffcbb817b0b435?s=80&d=identicon",
+      "web_url": "https://gitlab.example.com/craig_rutherford"
+    },
+    "action_name": "assigned",
+    "target_type": "MergeRequest",
+    "target": {
+      "id": 34,
+      "iid": 7,
+      "project_id": 2,
+      "title": "Dolores in voluptatem tenetur praesentium omnis repellendus voluptatem quaerat.",
+      "description": "Et ea et omnis illum cupiditate. Dolor aspernatur tenetur ducimus facilis est nihil. Quo esse cupiditate molestiae illo corrupti qui quidem dolor.",
+      "state": "opened",
+      "created_at": "2016-06-17T07:49:24.419Z",
+      "updated_at": "2016-06-17T07:52:43.484Z",
+      "target_branch": "tutorials_git_tricks",
+      "source_branch": "DNSBL_docs",
+      "upvotes": 0,
+      "downvotes": 0,
+      "author": {
+        "name": "Maxie Medhurst",
+        "username": "craig_rutherford",
+        "id": 12,
+        "state": "active",
+        "avatar_url": "http://www.gravatar.com/avatar/a0d477b3ea21970ce6ffcbb817b0b435?s=80&d=identicon",
+        "web_url": "https://gitlab.example.com/craig_rutherford"
+      },
+      "assignee": {
+        "name": "Administrator",
+        "username": "root",
+        "id": 1,
+        "state": "active",
+        "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+        "web_url": "https://gitlab.example.com/root"
+      },
+      "source_project_id": 2,
+      "target_project_id": 2,
+      "labels": [],
+      "work_in_progress": false,
+      "milestone": {
+        "id": 32,
+        "iid": 2,
+        "project_id": 2,
+        "title": "v1.0",
+        "description": "Assumenda placeat ea voluptatem voluptate qui.",
+        "state": "active",
+        "created_at": "2016-06-17T07:47:34.163Z",
+        "updated_at": "2016-06-17T07:47:34.163Z",
+        "due_date": null
+      },
+      "merge_when_pipeline_succeeds": false,
+      "merge_status": "cannot_be_merged",
+      "subscribed": true,
+      "user_notes_count": 7
+    },
+    "target_url": "https://gitlab.example.com/gitlab-org/gitlab-ce/merge_requests/7",
+    "body": "Dolores in voluptatem tenetur praesentium omnis repellendus voluptatem quaerat.",
+    "state": "pending",
+    "created_at": "2016-06-17T07:49:24.624Z"
+  }
+]

--- a/spec/gitlab/client/todos_spec.rb
+++ b/spec/gitlab/client/todos_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe Gitlab::Client do
+  describe '.todos' do
+	  before do
+	  	stub_get("/todos", "todos")
+      @todos = Gitlab.todos
+	  end
+
+	  it "should get the correct resources" do
+      expect(a_get("/todos")).to have_been_made
+    end
+
+    it "should return a paginated response of user's todos" do
+      expect(@todos).to be_a Gitlab::PaginatedResponse 
+    end
+  end
+
+  describe '.mark_todo_as_done' do
+    before do
+      stub_post("/todos/102/mark_as_done", "todo")
+      @todo = Gitlab.mark_todo_as_done(102)
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/todos/102/mark_as_done")).to have_been_made
+    end
+
+    it "should return information about the todo marked as done" do
+      expect(@todo.id).to eq(102)
+      expect(@todo.state).to eq('done') 
+    end
+  end
+
+  describe '.mark_all_todos_as_done' do
+    before do
+      stub_post("/todos/mark_as_done", "todos")
+      @todos = Gitlab.mark_all_todos_as_done
+    end
+
+    it "should get the correct resources" do
+      expect(a_post("/todos/mark_as_done")).to have_been_made
+    end
+  end 
+end


### PR DESCRIPTION
Added 3 methods to deal with todos, only for the actions provided by the [official API](https://docs.gitlab.com/ce/api/todos.html).

  * `todos`: Gets a list of all or filtered todos
  * `mark_todo_as_done`: Marks a todo as done
  * `mark_all_todos_as_done`: Marks all todos as done