### PR TITLE
Update repository files endpoint for APIv4

### DIFF
--- a/lib/gitlab/client/repository_files.rb
+++ b/lib/gitlab/client/repository_files.rb
@@ -52,7 +52,7 @@ class Gitlab::Client
     # @return [Gitlab::ObjectifiedHash]
     def create_file(project, path, branch, content, commit_message)
       post("/projects/#{url_encode project}/repository/files/#{url_encode path}", body: {
-        branch_name: branch,
+        branch: branch,
         commit_message: commit_message
       }.merge(encoded_content_attributes(content)))
     end
@@ -70,7 +70,7 @@ class Gitlab::Client
     # @return [Gitlab::ObjectifiedHash]
     def edit_file(project, path, branch, content, commit_message)
       put("/projects/#{url_encode project}/repository/files/#{url_encode path}", body: {
-        branch_name: branch,
+        branch: branch,
         commit_message: commit_message
       }.merge(encoded_content_attributes(content)))
     end
@@ -87,7 +87,7 @@ class Gitlab::Client
     # @return [Gitlab::ObjectifiedHash]
     def remove_file(project, path, branch, commit_message)
       delete("/projects/#{url_encode project}/repository/files/#{url_encode path}", body: {
-               branch_name: branch,
+               branch: branch,
                commit_message: commit_message
              })
     end

--- a/lib/gitlab/client/repository_files.rb
+++ b/lib/gitlab/client/repository_files.rb
@@ -45,16 +45,19 @@ class Gitlab::Client
     #   Gitlab.create_file(42, "path", "branch", "content", "commit message")
     #
     # @param  [Integer, String] project The ID or name of a project.
-    # @param  [String] full path to new file.
-    # @param  [String] the name of the branch.
-    # @param  [String] file content.
-    # @param  [String] commit message.
+    # @param  [String] path full path to new file.
+    # @param  [String] branch the name of the branch.
+    # @param  [String] content file content.
+    # @param  [String] commit_message ...commit message.
+    # @param  [Hash] options Optional additional details for commit
+    # @option options [String] :author_name Commit author's name
+    # @option options [String] :author_email Commit author's email address
     # @return [Gitlab::ObjectifiedHash]
-    def create_file(project, path, branch, content, commit_message)
+    def create_file(project, path, branch, content, commit_message, options = {})
       post("/projects/#{url_encode project}/repository/files/#{url_encode path}", body: {
         branch: branch,
         commit_message: commit_message
-      }.merge(encoded_content_attributes(content)))
+      }.merge(options).merge(encoded_content_attributes(content)))
     end
 
     # Edits an existing repository file.
@@ -63,16 +66,19 @@ class Gitlab::Client
     #   Gitlab.edit_file(42, "path", "branch", "content", "commit message")
     #
     # @param  [Integer, String] project The ID or name of a project.
-    # @param  [String] full path to new file.
-    # @param  [String] the name of the branch.
-    # @param  [String] file content.
-    # @param  [String] commit message.
+    # @param  [String] path full path of file to update.
+    # @param  [String] branch the name of the branch to commit changes to.
+    # @param  [String] content new file content.
+    # @param  [String] commit_message ...commit message.
+    # @param  [Hash] options Optional additional details for commit
+    # @option options [String] :author_name Commit author's name
+    # @option options [String] :author_email Commit author's email address
     # @return [Gitlab::ObjectifiedHash]
-    def edit_file(project, path, branch, content, commit_message)
+    def edit_file(project, path, branch, content, commit_message, options = {})
       put("/projects/#{url_encode project}/repository/files/#{url_encode path}", body: {
         branch: branch,
         commit_message: commit_message
-      }.merge(encoded_content_attributes(content)))
+      }.merge(options).merge(encoded_content_attributes(content)))
     end
 
     # Removes an existing repository file.
@@ -81,15 +87,18 @@ class Gitlab::Client
     #   Gitlab.remove_file(42, "path", "branch", "commit message")
     #
     # @param  [Integer, String] project The ID or name of a project.
-    # @param  [String] full path to new file.
-    # @param  [String] the name of the branch.
-    # @param  [String] commit message.
+    # @param  [String] path full path of file to delete.
+    # @param  [String] branch the name of the branch to commit the deletion to.
+    # @param  [String] commit_message ...a commit message ;)
+    # @param  [Hash] options Optional additional details for commit
+    # @option options [String] :author_name Commit author's name
+    # @option options [String] :author_email Commit author's email address
     # @return [Gitlab::ObjectifiedHash]
-    def remove_file(project, path, branch, commit_message)
+    def remove_file(project, path, branch, commit_message, options = {})
       delete("/projects/#{url_encode project}/repository/files/#{url_encode path}", body: {
                branch: branch,
                commit_message: commit_message
-             })
+             }.merge(options))
     end
 
     private

--- a/lib/gitlab/client/repository_files.rb
+++ b/lib/gitlab/client/repository_files.rb
@@ -51,8 +51,7 @@ class Gitlab::Client
     # @param  [String] commit message.
     # @return [Gitlab::ObjectifiedHash]
     def create_file(project, path, branch, content, commit_message)
-      post("/projects/#{url_encode project}/repository/files", body: {
-        file_path: path,
+      post("/projects/#{url_encode project}/repository/files/#{url_encode path}", body: {
         branch_name: branch,
         commit_message: commit_message
       }.merge(encoded_content_attributes(content)))
@@ -70,8 +69,7 @@ class Gitlab::Client
     # @param  [String] commit message.
     # @return [Gitlab::ObjectifiedHash]
     def edit_file(project, path, branch, content, commit_message)
-      put("/projects/#{url_encode project}/repository/files", body: {
-        file_path: path,
+      put("/projects/#{url_encode project}/repository/files/#{url_encode path}", body: {
         branch_name: branch,
         commit_message: commit_message
       }.merge(encoded_content_attributes(content)))
@@ -88,8 +86,7 @@ class Gitlab::Client
     # @param  [String] commit message.
     # @return [Gitlab::ObjectifiedHash]
     def remove_file(project, path, branch, commit_message)
-      delete("/projects/#{url_encode project}/repository/files", body: {
-               file_path: path,
+      delete("/projects/#{url_encode project}/repository/files/#{url_encode path}", body: {
                branch_name: branch,
                commit_message: commit_message
              })

--- a/spec/gitlab/client/repository_files_spec.rb
+++ b/spec/gitlab/client/repository_files_spec.rb
@@ -22,7 +22,7 @@ describe Gitlab::Client do
       @file = Gitlab.get_file(3, 'README.md', 'master')
     end
 
-    it "should create the correct resource" do
+    it "should get the correct resource" do
       expect(a_get("/projects/3/repository/files/README%2Emd?ref=master")).to have_been_made
     end
 
@@ -34,7 +34,7 @@ describe Gitlab::Client do
   end
 
   describe ".create_file" do
-    let!(:request_stub) { stub_post("/projects/3/repository/files", "repository_file") }
+    let!(:request_stub) { stub_post("/projects/3/repository/files/path", "repository_file") }
     let!(:file) { Gitlab.create_file(3, "path", "branch", "content", "commit message") }
 
     it "should create the correct resource" do
@@ -48,10 +48,10 @@ describe Gitlab::Client do
   end
 
   describe ".edit_file" do
-    let!(:request_stub) { stub_put("/projects/3/repository/files", "repository_file") }
+    let!(:request_stub) { stub_put("/projects/3/repository/files/path", "repository_file") }
     let!(:file) { Gitlab.edit_file(3, "path", "branch", "content", "commit message") }
 
-    it "should create the correct resource" do
+    it "should update the correct resource" do
       expect(request_stub).to have_been_made
     end
 
@@ -62,10 +62,10 @@ describe Gitlab::Client do
   end
 
   describe ".remove_file" do
-    let!(:request_stub) { stub_delete("/projects/3/repository/files", "repository_file") }
+    let!(:request_stub) { stub_delete("/projects/3/repository/files/path", "repository_file") }
     let!(:file) { Gitlab.remove_file(3, "path", "branch", "commit message") }
 
-    it "should create the correct resource" do
+    it "should update the correct resource" do
       expect(request_stub).to have_been_made
     end
 

--- a/spec/gitlab/client/repository_files_spec.rb
+++ b/spec/gitlab/client/repository_files_spec.rb
@@ -34,11 +34,17 @@ describe Gitlab::Client do
   end
 
   describe ".create_file" do
-    let!(:request_stub) { stub_post("/projects/3/repository/files/path", "repository_file") }
-    let!(:file) { Gitlab.create_file(3, "path", "branch", "content", "commit message") }
+    let(:api_path) { "/projects/3/repository/files/path" }
+    let!(:request_stub) { stub_post(api_path, "repository_file") }
+    let!(:file) { Gitlab.create_file(3, "path", "branch", "content", "commit message", author_name: "joe") }
 
     it "should create the correct resource" do
-      expect(request_stub).to have_been_made
+      expected_parameters = {
+        author_name: "joe",
+        branch: "branch",
+        commit_message: "commit message"
+      }
+      expect(a_post(api_path).with(body: hash_including(expected_parameters))).to have_been_made
     end
 
     it "should return information about the new file" do
@@ -48,11 +54,17 @@ describe Gitlab::Client do
   end
 
   describe ".edit_file" do
-    let!(:request_stub) { stub_put("/projects/3/repository/files/path", "repository_file") }
-    let!(:file) { Gitlab.edit_file(3, "path", "branch", "content", "commit message") }
+    let(:api_path) { "/projects/3/repository/files/path" }
+    let!(:request_stub) { stub_put(api_path, "repository_file") }
+    let!(:file) { Gitlab.edit_file(3, "path", "branch", "content", "commit message", author_name: "joe") }
 
     it "should update the correct resource" do
-      expect(request_stub).to have_been_made
+      expected_parameters = {
+        author_name: "joe",
+        branch: "branch",
+        commit_message: "commit message"
+      }
+      expect(a_put(api_path).with(body: hash_including(expected_parameters))).to have_been_made
     end
 
     it "should return information about the new file" do
@@ -62,11 +74,17 @@ describe Gitlab::Client do
   end
 
   describe ".remove_file" do
-    let!(:request_stub) { stub_delete("/projects/3/repository/files/path", "repository_file") }
-    let!(:file) { Gitlab.remove_file(3, "path", "branch", "commit message") }
+    let(:api_path) { "/projects/3/repository/files/path" }
+    let!(:request_stub) { stub_delete(api_path, "repository_file") }
+    let!(:file) { Gitlab.remove_file(3, "path", "branch", "commit message", author_name: "joe") }
 
     it "should update the correct resource" do
-      expect(request_stub).to have_been_made
+      expected_parameters = {
+        author_name: "joe",
+        branch: "branch",
+        commit_message: "commit message"
+      }
+      expect(a_delete(api_path).with(body: hash_including(expected_parameters))).to have_been_made
     end
 
     it "should return information about the new file" do


### PR DESCRIPTION
New path for all endpoints is `repository/files/:file_path` (instead of passing file_path as a parameter)