### PR TITLE
Subscribe and unsubscribe actions for labels

### DIFF
--- a/lib/gitlab/client/labels.rb
+++ b/lib/gitlab/client/labels.rb
@@ -53,5 +53,29 @@ class Gitlab::Client
     def delete_label(project, name)
       delete("/projects/#{url_encode project}/labels", body: { name: name })
     end
+
+    # Subscribes the user to a label to receive notifications
+    #
+    # @example
+    #   Gitlab.subscribe_to_label(2, 'Backlog')
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [String] name The name of a label.
+    # @return [Gitlab::ObjectifiedHash] Information about the label subscribed to. 
+    def subscribe_to_label(project, name)
+      post("/projects/#{url_encode project}/labels/#{url_encode name}/subscribe")
+    end
+
+    # Unsubscribes the user from a label to not receive notifications from it
+    #
+    # @example
+    #   Gitlab.unsubscribe_from_label(2, 'Backlog')
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [String] name The name of a label.
+    # @return [Gitlab::ObjectifiedHash] Information about the label unsubscribed from. 
+    def unsubscribe_from_label(project, name)
+      post("/projects/#{url_encode project}/labels/#{url_encode name}/unsubscribe")
+    end
   end
 end

--- a/spec/fixtures/label.json
+++ b/spec/fixtures/label.json
@@ -1,1 +1,1 @@
-{"name": "Backlog", "color": "#DD10AA"}
+{"name": "Backlog", "color": "#DD10AA", "subscribed": true}

--- a/spec/fixtures/label_unsubscribe.json
+++ b/spec/fixtures/label_unsubscribe.json
@@ -1,0 +1,1 @@
+{"name": "Backlog", "color": "#DD10AA", "subscribed": false}

--- a/spec/gitlab/client/labels_spec.rb
+++ b/spec/gitlab/client/labels_spec.rb
@@ -65,4 +65,36 @@ describe Gitlab::Client do
       expect(@label.color).to eq('#DD10AA')
     end
   end
+
+  describe ".subscribe_to_label" do
+    before do
+      stub_post("/projects/3/labels/Backlog/subscribe", "label")
+      @label = Gitlab.subscribe_to_label(3, 'Backlog')
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/labels/Backlog/subscribe")).to have_been_made
+    end
+
+    it "should return information about the label subscribed to" do
+      expect(@label.name).to eq('Backlog')
+      expect(@label.subscribed).to eq(true)
+    end
+  end
+
+  describe ".unsubscribe_from_label" do
+    before do
+      stub_post("/projects/3/labels/Backlog/unsubscribe", "label_unsubscribe")
+      @label = Gitlab.unsubscribe_from_label(3, 'Backlog')
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/labels/Backlog/unsubscribe")).to have_been_made
+    end
+
+    it "should return information about the label subscribed to" do
+      expect(@label.name).to eq('Backlog')
+      expect(@label.subscribed).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Two missing methods for the labels API:

  * `subscribe_to_label`: Subscribes the user to a label for notifications
  * `unsubscribe_from_label`: Unsubscribes the user from a label