### PR TITLE
Replace `projects/search/{query}` by `projects?search={query}`

### DIFF
--- a/lib/gitlab/client/projects.rb
+++ b/lib/gitlab/client/projects.rb
@@ -34,7 +34,7 @@ class Gitlab::Client
     # @option options [String] :sort Return requests sorted in asc or desc order
     # @return [Array<Gitlab::ObjectifiedHash>]
     def project_search(query, options={})
-      get("/projects?search=#{query}", query: options)
+      get("/projects", query: options.merge(search:query))
     end
     alias_method :search_projects, :project_search
 

--- a/lib/gitlab/client/projects.rb
+++ b/lib/gitlab/client/projects.rb
@@ -34,7 +34,7 @@ class Gitlab::Client
     # @option options [String] :sort Return requests sorted in asc or desc order
     # @return [Array<Gitlab::ObjectifiedHash>]
     def project_search(query, options={})
-      get("/projects/search/#{query}", query: options)
+      get("/projects?search=#{query}", query: options)
     end
     alias_method :search_projects, :project_search
 

--- a/spec/gitlab/client/projects_spec.rb
+++ b/spec/gitlab/client/projects_spec.rb
@@ -22,12 +22,12 @@ describe Gitlab::Client do
 
   describe ".project_search" do
     before do
-      stub_get("/projects/search/Gitlab", "project_search")
+      stub_get("/projects?search=Gitlab", "project_search")
       @project_search = Gitlab.project_search("Gitlab")
     end
 
     it "should get the correct resource" do
-      expect(a_get("/projects/search/Gitlab")).to have_been_made
+      expect(a_get("/projects?search=Gitlab")).to have_been_made
     end
 
     it "should return a paginated response of projects found" do


### PR DESCRIPTION
Current method `project_search` doesn't work.

Indeed, the APIv4 is now using query parameter to this.

I made the modifications according to this new behavior.