### PR TITLE
Add support for moving an issue

### DIFF
--- a/lib/gitlab/client/issues.rb
+++ b/lib/gitlab/client/issues.rb
@@ -133,5 +133,18 @@ class Gitlab::Client
     def delete_issue(project, id)
       delete("/projects/#{url_encode project}/issues/#{id}")
     end
+
+    # Move an issue.
+    #
+    # @example
+    #   Gitlab.move_issue(3, 42, { to_project_id: '4' })
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of an issue.
+    # @option options [String] :to_project_id The ID of the new project.
+    # @return [Gitlab::ObjectifiedHash] Information about moved issue.
+    def move_issue(project, id, options={})
+      post("/projects/#{url_encode project}/issues/#{id}/move", body: options)
+    end
   end
 end

--- a/spec/gitlab/client/issues_spec.rb
+++ b/spec/gitlab/client/issues_spec.rb
@@ -183,4 +183,21 @@ describe Gitlab::Client do
       expect(@issue.id).to eq(33)
     end
   end
+
+  describe ".move_issue" do
+    before do
+      stub_post("/projects/3/issues/33/move", "issue")
+      @issue = Gitlab.move_issue(3, 33, to_project_id: '4')
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/issues/33/move").
+        with(body: { to_project_id: '4' })).to have_been_made
+      end
+
+    it "should return information about the moved issue" do
+      expect(@issue.project_id).to eq(3)
+      expect(@issue.assignee.name).to eq("Jack Smith")
+    end
+  end
 end


### PR DESCRIPTION
This PR adds support for moving an issue based on http://docs.gitlab.com/ce/api/issues.html#move-an-issue.
It has been used at @trainline-eu.

Closes #227 