### PR TITLE
Add time tracking for issues

### DIFF
--- a/lib/gitlab/client/issues.rb
+++ b/lib/gitlab/client/issues.rb
@@ -146,5 +146,63 @@ class Gitlab::Client
     def move_issue(project, id, options={})
       post("/projects/#{url_encode project}/issues/#{id}/move", body: options)
     end
+    
+    # Sets an estimated time of work for an issue.
+    #
+    # @example
+    #   Gitlab.estimate_time_of_issue(3, 42, '3h30m')
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of an issue.
+    # @param  [String] duration The duration in human format. e.g: 3h30m
+    def estimate_time_of_issue(project, id, duration)
+      post("/projects/#{url_encode project}/issues/#{id}/time_estimate", body: { duration: url_encode(duration) })
+    end
+    
+    # Resets the estimated time for an issue to 0 seconds.  
+    #
+    # @example
+    #   Gitlab.reset_time_estimate_of_issue(3, 42)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of an issue.
+    def reset_time_estimate_of_issue(project, id)
+      post("/projects/#{url_encode project}/issues/#{id}/reset_time_estimate")
+    end
+    
+    # Adds spent time for an issue
+    #
+    # @example
+    #   Gitlab.estimate_time_of_issue(3, 42, '3h30m')
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of an issue.
+    # @param  [String] duration The time spent in human format. e.g: 3h30m
+    def add_time_spent_on_issue(project, id, duration)
+      post("/projects/#{url_encode project}/issues/#{id}/add_spent_time", body: { duration: url_encode(duration) })
+    end
+    
+    # Resets the total spent time for this issue to 0 seconds.
+    #
+    # @example
+    #   Gitlab.reset_time_spent_on_issue(3, 42)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of an issue.
+    def reset_time_spent_on_issue(project, id)
+      post("/projects/#{url_encode project}/issues/#{id}/reset_spent_time")
+    end
+    
+    # Get time tracking stats for an issue
+    #
+    # @example
+    #   @gitlab.time_stats_for_issue(3, 42)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of an issue.
+    def time_stats_for_issue(project, id)
+      get("/projects/#{url_encode project}/issues/#{id}/time_stats")
+    end
+    
   end
 end

--- a/spec/gitlab/client/issues_spec.rb
+++ b/spec/gitlab/client/issues_spec.rb
@@ -200,4 +200,86 @@ describe Gitlab::Client do
       expect(@issue.assignee.name).to eq("Jack Smith")
     end
   end
+
+  describe ".estimate_time_of_issue" do
+    before do
+      stub_post("/projects/3/issues/33/time_estimate", "issue")
+      @issue = Gitlab.estimate_time_of_issue(3, 33, '3h30m')
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/issues/33/time_estimate").
+        with(body: { duration: '3h30m' })).to have_been_made
+      end
+
+    it "should return information about the estimated issue" do
+      expect(@issue.project_id).to eq(3)
+      expect(@issue.assignee.name).to eq("Jack Smith")
+    end
+  end
+  
+  describe ".reset_time_estimate_of_issue" do
+    before do
+      stub_post("/projects/3/issues/33/reset_time_estimate", "issue")
+      @issue = Gitlab.reset_time_estimate_of_issue(3, 33)
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/issues/33/reset_time_estimate")).to have_been_made
+    end
+
+    it "should return information about the estimated issue" do
+      expect(@issue.project_id).to eq(3)
+      expect(@issue.assignee.name).to eq("Jack Smith")
+    end
+  end
+  
+  describe ".add_time_spent_on_issue" do
+    before do
+      stub_post("/projects/3/issues/33/add_spent_time", "issue")
+      @issue = Gitlab.add_time_spent_on_issue(3, 33, '3h30m')
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/issues/33/add_spent_time").
+        with(body: { duration: '3h30m' })).to have_been_made
+      end
+
+    it "should return information about the estimated issue" do
+      expect(@issue.project_id).to eq(3)
+      expect(@issue.assignee.name).to eq("Jack Smith")
+    end
+  end
+  
+  describe ".reset_time_spent_on_issue" do
+    before do
+      stub_post("/projects/3/issues/33/reset_spent_time", "issue")
+      @issue = Gitlab.reset_time_spent_on_issue(3, 33)
+    end
+
+    it "should get the correct resource" do
+      expect(a_post("/projects/3/issues/33/reset_spent_time")).to have_been_made
+    end
+
+    it "should return information about the estimated issue" do
+      expect(@issue.project_id).to eq(3)
+      expect(@issue.assignee.name).to eq("Jack Smith")
+    end
+  end
+  
+  describe ".time_stats_for_issue" do
+    before do
+      stub_get("/projects/3/issues/33/time_stats", "issue")
+      @issue = Gitlab.time_stats_for_issue(3, 33)
+    end
+
+    it "should get the correct resource" do
+      expect(a_get("/projects/3/issues/33/time_stats")).to have_been_made
+    end
+
+    it "should return information about the issue" do
+      expect(@issue.project_id).to eq(3)
+      expect(@issue.assignee.name).to eq("Jack Smith")
+    end
+  end
 end


### PR DESCRIPTION
Hello,

This PR adds the Time Tracking features (set/reset time estimate, set/reset time spent, display time stats) for an Issue.

Cf https://docs.gitlab.com/ee/api/issues.html#set-a-time-estimate-for-an-issue

I hope this helps! This is my 1st contribution here, let me know if something is missing!
