### PR TITLE
Add #response_message accessor to GitLab::Error::ResponseError

### DIFF
--- a/lib/gitlab/error.rb
+++ b/lib/gitlab/error.rb
@@ -23,6 +23,13 @@ module Gitlab
         @response.code
       end
 
+      # Body content returned in the HTTP response
+      #
+      # @return [String]
+      def response_message
+        @response.parsed_response.message
+      end
+
       private
 
       # Human friendly message.

--- a/lib/gitlab/error.rb
+++ b/lib/gitlab/error.rb
@@ -16,7 +16,7 @@ module Gitlab
         super(build_error_message)
       end
 
-      # Status code returned in the http response.
+      # Status code returned in the HTTP response.
       #
       # @return [Integer]
       def response_status

--- a/spec/gitlab/error_spec.rb
+++ b/spec/gitlab/error_spec.rb
@@ -1,72 +1,68 @@
 require "spec_helper"
+require "stringio"
 
 describe Gitlab::Error do
+  let(:request_object)  { HTTParty::Request.new(Net::HTTP::Get, '/') }
+  let(:response_object) { Net::HTTPOK.new('1.1', 200, 'OK') }
+  let(:body)            { StringIO.new("{foo:'bar'}") }
+  let(:parsed_response) { lambda { body } }
+
+  let(:response) {
+    HTTParty::Response.new(
+      request_object,
+      response_object,
+      parsed_response,
+      body: body,
+    )
+  }
+
+  let(:error) { Gitlab::Error::ResponseError.new(response) }
+  let(:date)  { Date.new(2010, 1, 15).to_s }
+
+  before do
+    def body.message; self.string; end
+
+    response_object['last-modified']  = date
+    response_object['content-length'] = "1024"
+  end
+
   describe "#handle_message" do
-		require "stringio"
-
-    before do
-      request_object  = HTTParty::Request.new(Net::HTTP::Get, '/')
-      response_object = Net::HTTPOK.new('1.1', 200, 'OK')
-      body = StringIO.new("{foo:'bar'}")
-      def body.message; self.string; end
-
-      parsed_response = lambda { body }
-      response_object['last-modified'] = Date.new(2010, 1, 15).to_s
-      response_object['content-length'] = "1024"
-
-      response = HTTParty::Response.new(request_object, response_object, parsed_response, body: body)
-      @error = Gitlab::Error::ResponseError.new(response)
-
-      @array = Array.new(['First message.', 'Second message.'])
-      @obj_h = Gitlab::ObjectifiedHash.new(user: ['not set'],
-                                           password: ['too short'],
-                                           embed_entity: { foo: ['bar'], sna: ['fu'] })
-    end
+    let(:array) { Array.new(['First message.', 'Second message.']) }
+    let(:obj_h) {
+      Gitlab::ObjectifiedHash.new(
+        user:         ['not set'],
+        password:     ['too short'],
+        embed_entity: { foo: ['bar'], sna: ['fu'] },
+      )
+    }
 
     context "when passed an ObjectifiedHash" do
       it "should return a joined string of error messages sorted by key" do
-        expect(@error.send(:handle_message, @obj_h)).to eq("'embed_entity' (foo: bar) (sna: fu), 'password' too short, 'user' not set")
+        expect(error.send(:handle_message, obj_h)).
+          to eq(
+            "'embed_entity' (foo: bar) (sna: fu), 'password' too short, 'user' not set"
+          )
       end
     end
 
     context "when passed an Array" do
       it "should return a joined string of messages" do
-        expect(@error.send(:handle_message, @array)).to eq("First message. Second message.")
+        expect(error.send(:handle_message, array)).
+          to eq("First message. Second message.")
       end
     end
 
     context "when passed a String" do
       it "should return the String untouched" do
-        error = 'this is an error string'
-        expect(@error.send(:handle_message, error)).to eq('this is an error string')
+        error_str = 'this is an error string'
+
+        expect(error.send(:handle_message, error_str)).
+          to eq(error_str)
       end
     end
   end
 
   describe "#response_message" do
-    let(:request_object) { HTTParty::Request.new(Net::HTTP::Get, '/') }
-    let(:response_object) { Net::HTTPOK.new('1.1', 200, 'OK') }
-    let(:body) { StringIO.new("{foo:'bar'}") }
-    let(:parsed_response) { lambda { body } }
-
-    let(:response) {
-      HTTParty::Response.new(
-        request_object,
-        response_object,
-        parsed_response,
-        body: body,
-      )
-    }
-
-    let(:error){ Gitlab::Error::ResponseError.new(response) }
-
-    before do
-      def body.message; self.string; end
-
-      response_object['last-modified'] = Date.new(2010, 1, 15).to_s
-      response_object['content-length'] = "1024"
-    end
-
     it "should return the message of the parsed_response" do
       expect(error.response_message).to eq(body.string)
     end


### PR DESCRIPTION
I came across an issue using this gem where I needed the response returned by the error'd HTTP request. Rather than dig into the ivars or private methods, this exposes the `parsed_response#message` itself. The PR also includes a lump of cleanup work on the spec.