### PR TITLE
Add support for group level variables

### DIFF
--- a/lib/gitlab/client/build_variables.rb
+++ b/lib/gitlab/client/build_variables.rb
@@ -1,6 +1,7 @@
 class Gitlab::Client
   # Defines methods related to builds.
   # @see https://docs.gitlab.com/ce/api/build_variables.html
+  # @see https://docs.gitlab.com/ee/api/group_level_variables.html
   module BuildVariables
     # Gets a list of the project's build variables
     #
@@ -16,7 +17,7 @@ class Gitlab::Client
     # Gets details of a project's specific build variable.
     #
     # @example
-    #   Gitlab.build(5, "TEST_VARIABLE_1")
+    #   Gitlab.variable(5, "TEST_VARIABLE_1")
     #
     # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] key The key of a variable.
@@ -41,7 +42,7 @@ class Gitlab::Client
     # Update a project's build variable.
     #
     # @example
-    #   Gitlab.create_variable(5, "NEW_VARIABLE", "updated value")
+    #   Gitlab.update_variable(5, "NEW_VARIABLE", "updated value")
     #
     # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] key The key of a variable
@@ -61,6 +62,67 @@ class Gitlab::Client
     # @return [Gitlab::ObjectifiedHash] The variable.
     def remove_variable(project, key)
       delete("/projects/#{url_encode project}/variables/#{key}")
+    end
+
+    # Gets a list of the group's build variables
+    #
+    # @example
+    #   Gitlab.group_variables(5)
+    #
+    # @param  [Integer, String] group The ID or name of a group.
+    # @return [Array<Gitlab::ObjectifiedHash>] The list of variables.
+    def group_variables(group)
+      get("/groups/#{url_encode group}/variables")
+    end
+
+    # Gets details of a group's specific build variable.
+    #
+    # @example
+    #   Gitlab.group_variable(5, "TEST_VARIABLE_1")
+    #
+    # @param  [Integer, String] group The ID or name of a group.
+    # @param  [String] key The key of a variable.
+    # @return [Gitlab::ObjectifiedHash] The variable.
+    def group_variable(group, key)
+      get("/groups/#{url_encode group}/variables/#{key}")
+    end
+
+    # Create a build variable for a group.
+    #
+    # @example
+    #   Gitlab.create_group_variable(5, "NEW_VARIABLE", "new value")
+    #
+    # @param  [Integer, String] group The ID or name of a group.
+    # @param  [String] key The key of a variable; must have no more than 255 characters; only `A-Z`, `a-z`, `0-9` and `_` are allowed
+    # @param  [String] value The value of a variable
+    # @return [Gitlab::ObjectifiedHash] The variable.
+    def create_group_variable(group, key, value)
+      post("/groups/#{url_encode group}/variables", body: { key: key, value: value })
+    end
+
+    # Update a group's build variable.
+    #
+    # @example
+    #   Gitlab.update_group_variable(5, "NEW_VARIABLE", "updated value")
+    #
+    # @param  [Integer, String] group The ID or name of a group.
+    # @param  [String] key The key of a variable
+    # @param  [String] value The value of a variable
+    # @return [Gitlab::ObjectifiedHash] The variable.
+    def update_group_variable(group, key, value)
+      put("/groups/#{url_encode group}/variables/#{key}", body: { value: value })
+    end
+
+    # Remove a group's build variable.
+    #
+    # @example
+    #   Gitlab.remove_group_variable(5, "VARIABLE_1")
+    #
+    # @param  [Integer, String] group The ID or name of a group.
+    # @param  [String] key The key of a variable.
+    # @return [Gitlab::ObjectifiedHash] The variable.
+    def remove_group_variable(group, key)
+      delete("/groups/#{url_encode group}/variables/#{key}")
     end
   end
 end

--- a/spec/gitlab/client/build_variables_spec.rb
+++ b/spec/gitlab/client/build_variables_spec.rb
@@ -83,4 +83,87 @@ describe Gitlab::Client do
       expect(@variable.value).to eq("the value")
     end
   end
+
+  describe ".group_variables" do
+    before do
+      stub_get("/groups/3/variables", "variables")
+      @variables = Gitlab.group_variables(3)
+    end
+
+    it "should get the correct resource" do
+      expect(a_get("/groups/3/variables")).to have_been_made
+    end
+
+    it "should return an array of group's variables" do
+      expect(@variables).to be_a Gitlab::PaginatedResponse
+      expect(@variables.first.key).to eq("TEST_VARIABLE_1")
+      expect(@variables.first.value).to eq("TEST_1")
+    end
+  end
+
+  describe ".group_variable" do
+    before do
+      stub_get("/groups/3/variables/VARIABLE", "variable")
+      @variable = Gitlab.group_variable(3, "VARIABLE")
+    end
+
+    it "should get the correct resource" do
+      expect(a_get("/groups/3/variables/VARIABLE")).to have_been_made
+    end
+
+    it "should return information about a variable" do
+      expect(@variable.key).to eq("VARIABLE")
+      expect(@variable.value).to eq("the value")
+    end
+  end
+
+  describe ".create_group_variable" do
+    before do
+      stub_post("/groups/3/variables", "variable")
+      @variable = Gitlab.create_group_variable(3, "NEW_VARIABLE", "new value")
+    end
+
+    it "should get the correct resource" do
+      body = { key: "NEW_VARIABLE", value: "new value" }
+      expect(a_post("/groups/3/variables").with(body: body)).to have_been_made
+    end
+
+    it "should return information about a new variable" do
+      expect(@variable.key).to eq("VARIABLE")
+      expect(@variable.value).to eq("the value")
+    end
+  end
+
+  describe ".update_group_variable" do
+    before do
+      stub_put("/groups/3/variables/UPD_VARIABLE", "variable")
+      @variable = Gitlab.update_group_variable(3, "UPD_VARIABLE", "updated value")
+    end
+
+    it "should put the correct resource" do
+      body = { value: "updated value" }
+      expect(a_put("/groups/3/variables/UPD_VARIABLE").with(body: body)).to have_been_made
+    end
+
+    it "should return information about an updated variable" do
+      expect(@variable.key).to eq("VARIABLE")
+      expect(@variable.value).to eq("the value")
+    end
+  end
+
+  describe ".remove_group_variable" do
+    before do
+      stub_delete("/groups/3/variables/DEL_VARIABLE", "variable")
+      @variable = Gitlab.remove_group_variable(3, "DEL_VARIABLE")
+    end
+
+    it "should get the correct resource" do
+      expect(a_delete("/groups/3/variables/DEL_VARIABLE")).to have_been_made
+    end
+
+    it "should return information about a deleted variable" do
+      expect(@variable.key).to eq("VARIABLE")
+      expect(@variable.value).to eq("the value")
+    end
+  end
 end

--- a/spec/gitlab/shell_spec.rb
+++ b/spec/gitlab/shell_spec.rb
@@ -55,7 +55,7 @@ describe Gitlab::Shell do
       it "should return an Array of matching commands" do
         completed_cmds = @comp.call 'group'
         expect(completed_cmds).to be_a Array
-        expect(completed_cmds.sort).to eq(%w(group group_member group_members group_projects group_search groups))
+        expect(completed_cmds.sort).to eq(%w(group group_member group_members group_projects group_search group_variable group_variables groups))
       end
     end
   end


### PR DESCRIPTION
Added support for group level variables as described here: https://docs.gitlab.com/ce/api/group_level_variables.html

Fixed a couple copy/paste errors in the documentation of variables and update_variable.