### PR TITLE
Error 404 not found when requesting branch, containing slash ('/'), from API

### DIFF
--- a/lib/gitlab/client/branches.rb
+++ b/lib/gitlab/client/branches.rb
@@ -27,7 +27,7 @@ class Gitlab::Client
     # @param  [String] branch The name of the branch.
     # @return [Gitlab::ObjectifiedHash]
     def branch(project, branch)
-      get("/projects/#{url_encode project}/repository/branches/#{branch}")
+      get("/projects/#{url_encode project}/repository/branches/#{url_encode branch}")
     end
     alias_method :repo_branch, :branch
 
@@ -47,7 +47,7 @@ class Gitlab::Client
     # @option options [Boolean] :developers_can_merge True to allow developers to merge into the branch (default = false)
     # @return [Gitlab::ObjectifiedHash] Details about the branch
     def protect_branch(project, branch, options = {})
-      put("/projects/#{url_encode project}/repository/branches/#{branch}/protect", body: options)
+      put("/projects/#{url_encode project}/repository/branches/#{url_encode branch}/protect", body: options)
     end
     alias_method :repo_protect_branch, :protect_branch
 
@@ -61,7 +61,7 @@ class Gitlab::Client
     # @param  [String] branch The name of the branch.
     # @return [Gitlab::ObjectifiedHash] Details about the branch
     def unprotect_branch(project, branch)
-      put("/projects/#{url_encode project}/repository/branches/#{branch}/unprotect")
+      put("/projects/#{url_encode project}/repository/branches/#{url_encode branch}/unprotect")
     end
     alias_method :repo_unprotect_branch, :unprotect_branch
 
@@ -89,7 +89,7 @@ class Gitlab::Client
     # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] branch The name of the branch to delete
     def delete_branch(project, branch)
-      delete("/projects/#{url_encode project}/repository/branches/#{branch}")
+      delete("/projects/#{url_encode project}/repository/branches/#{url_encode branch}")
     end
     alias_method :repo_delete_branch, :delete_branch
   end


### PR DESCRIPTION
Getting 404 error from gitlab when requesting branch from API:

```ruby
Gitlab.branch(project_id, branch_name)
```

It happen when `branch` variable contains slash in it.

I found that latest gitlab releases require to encode branch name in its request url.

Example:

1. 404 Not Found
  https://gitlab.com/api/v4/projects/14022/repository/branches/feature/gitaly-feature-flag

2. 200 OK (when logged in)
  https://gitlab.com/api/v4/projects/14022/repository/branches/feature%2Fgitaly-feature-flag

[Here is](https://gitlab.com/gitlab-org/gitlab-ce/issues/24471) related issue on gitlab project.
And one more [related issue](https://github.com/NARKOZ/gitlab/issues/289) on this project.

But even if it may be considered as a bug in gitlab, I think it's better to encode branch names when doing such api requests.