### PR TITLE
Add User-Agent header to Gitalb::API

### DIFF
--- a/lib/gitlab/api.rb
+++ b/lib/gitlab/api.rb
@@ -14,6 +14,7 @@ module Gitlab
         send("#{key}=", options[key]) if options[key]
       end
       request_defaults(@sudo)
+      self.class.headers 'User-Agent' => user_agent
     end
   end
 end

--- a/spec/gitlab/api_spec.rb
+++ b/spec/gitlab/api_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Gitlab::API do
+  let(:default_headers) { subject.class.default_options[:headers] }
+
+  describe ".default_options[:headers]" do
+    it "has 'User-Agent'" do
+      expect(default_headers).to include('User-Agent' => Gitlab::Configuration::DEFAULT_USER_AGENT)
+    end
+  end
+end


### PR DESCRIPTION
This patch adds `User-Agent` header

Closes #338 

/cc: @axilleas 