### PR TITLE
Added subgroups and group_edit methods

### DIFF
--- a/lib/gitlab/client/groups.rb
+++ b/lib/gitlab/client/groups.rb
@@ -159,6 +159,13 @@ class Gitlab::Client
     #
     # @param [Integer] id the ID of a group
     # @param [Hash] options A customizable set of options.
+    # @option options [String] :skip_groups Skip the group IDs passed.
+    # @option options [String] :all_available Show all the groups you have access to (defaults to false for authenticated users).
+    # @option options [String] :search Return the list of authorized groups matching the search criteria.
+    # @option options [String] :order_by Order groups by name or path. Default is name.
+    # @option options [String] :sort Order groups in asc or desc order. Default is asc.
+    # @option options [String] :statistics Include group statistics (admins only).
+    # @option options [String] :owned Limit to groups owned by the current user.
     # @return [Array<Gitlab::ObjectifiedHash>] List of subgroups under a group
     def group_subgroups(id, options={})
       get("/groups/#{id}/subgroups", query: options)
@@ -169,10 +176,15 @@ class Gitlab::Client
     # @example
     #   Gitlab.edit_group(42)
     #   Gitlab.edit_group(42, { name: 'Group Name' })
-    #   Gitlab.edit_group('group-name', { name: 'New Group Name', path: 'new-group-patth' })
     #
-    # @param  [Integer] group The ID or path of a group.
+    # @param  [Integer] group The ID.
     # @param  [Hash] options A customizable set of options
+    # @option options [String] :name The name of the group.
+    # @option options [String] :path The path of the group.
+    # @option options [String] :description The description of the group.
+    # @option options [String] :visibility The visibility level of the group. Can be private, internal, or public
+    # @option options [String] :lfs_enabled Enable/disable Large File Storage (LFS) for the projects in this groupr.
+    # @option options [String] :request_access_enabled Allow users to request member access.
     # @return [Gitlab::ObjectifiedHash] Information about the edited group.
     def edit_group(id, options={})
       put("/groups/#{id}", body: options)

--- a/lib/gitlab/client/groups.rb
+++ b/lib/gitlab/client/groups.rb
@@ -152,5 +152,32 @@ class Gitlab::Client
     def group_projects(id, options={})
       get("/groups/#{id}/projects", query: options)
     end
+
+    # Get a list of subgroups under a group
+    # @example
+    #   Gitlab.group_projects(1)
+    #
+    # @param [Integer] id the ID of a group
+    # @param [Hash] options A customizable set of options.
+    # @return [Array<Gitlab::ObjectifiedHash>] List of subgroups under a group
+    def group_subgroups(id, options={})
+      get("/groups/#{id}/subgroups", query: options)
+    end
+
+    # Updates an existing group.
+    #
+    # @example
+    #   Gitlab.edit_group(42)
+    #   Gitlab.edit_group(42, { name: 'Project Name' })
+    #   Gitlab.edit_group('group-name', { name: 'New Group Name', path: 'new-group-patth' })
+    #
+    # @param  [Integer, String] group The ID or path of a group.
+    # @param  [Hash] options A customizable set of options
+    # @return [Gitlab::ObjectifiedHash] Information about the edited group.
+    def edit_group(id, options={})
+      put("/groups/#{url_encode id}", body: options)
+    end
+
+
   end
 end

--- a/lib/gitlab/client/groups.rb
+++ b/lib/gitlab/client/groups.rb
@@ -155,7 +155,7 @@ class Gitlab::Client
 
     # Get a list of subgroups under a group
     # @example
-    #   Gitlab.group_projects(1)
+    #   Gitlab.group_subgroups(1)
     #
     # @param [Integer] id the ID of a group
     # @param [Hash] options A customizable set of options.

--- a/lib/gitlab/client/groups.rb
+++ b/lib/gitlab/client/groups.rb
@@ -175,7 +175,7 @@ class Gitlab::Client
     # @param  [Hash] options A customizable set of options
     # @return [Gitlab::ObjectifiedHash] Information about the edited group.
     def edit_group(id, options={})
-      put("/groups/#{url_encode id}", body: options)
+      put("/groups/#{id}", body: options)
     end
 
 

--- a/lib/gitlab/client/groups.rb
+++ b/lib/gitlab/client/groups.rb
@@ -168,16 +168,14 @@ class Gitlab::Client
     #
     # @example
     #   Gitlab.edit_group(42)
-    #   Gitlab.edit_group(42, { name: 'Project Name' })
+    #   Gitlab.edit_group(42, { name: 'Group Name' })
     #   Gitlab.edit_group('group-name', { name: 'New Group Name', path: 'new-group-patth' })
     #
-    # @param  [Integer, String] group The ID or path of a group.
+    # @param  [Integer] group The ID or path of a group.
     # @param  [Hash] options A customizable set of options
     # @return [Gitlab::ObjectifiedHash] Information about the edited group.
     def edit_group(id, options={})
       put("/groups/#{id}", body: options)
     end
-
-
   end
 end

--- a/lib/gitlab/version.rb
+++ b/lib/gitlab/version.rb
@@ -1,3 +1,3 @@
 module Gitlab
-  VERSION = '4.2.1'.freeze
+  VERSION = '4.2.0'.freeze
 end

--- a/lib/gitlab/version.rb
+++ b/lib/gitlab/version.rb
@@ -1,3 +1,3 @@
 module Gitlab
-  VERSION = '4.2.0'.freeze
+  VERSION = '4.2.1'.freeze
 end

--- a/spec/fixtures/group_edit.json
+++ b/spec/fixtures/group_edit.json
@@ -1,0 +1,14 @@
+{
+  "id": 1,
+  "name": "Foobar Group",
+  "path": "foo-bar",
+  "description": "An interesting group",
+  "visibility": "public",
+  "lfs_enabled": true,
+  "avatar_url": "http://gitlab.example.com/uploads/group/avatar/1/foo.jpg",
+  "web_url": "http://gitlab.example.com/groups/foo-bar",
+  "request_access_enabled": false,
+  "full_name": "Foobar Group",
+  "full_path": "foo-bar",
+  "parent_id": 123
+}

--- a/spec/fixtures/group_subgroups.json
+++ b/spec/fixtures/group_subgroups.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 1,
+    "name": "Foobar Group",
+    "path": "foo-bar",
+    "description": "An interesting group",
+    "visibility": "public",
+    "lfs_enabled": true,
+    "avatar_url": "http://gitlab.example.com/uploads/group/avatar/1/foo.jpg",
+    "web_url": "http://gitlab.example.com/groups/foo-bar",
+    "request_access_enabled": false,
+    "full_name": "Foobar Group",
+    "full_path": "foo-bar",
+    "parent_id": 123
+  }
+]

--- a/spec/gitlab/client/groups_spec.rb
+++ b/spec/gitlab/client/groups_spec.rb
@@ -225,6 +225,22 @@ describe Gitlab::Client do
       expect(@subgroups.size).to eq(1)
       expect(@subgroups[0].name).to eq("Foobar Group")
     end
+  end
 
+  describe ".edit_group" do
+    context "using group ID" do
+      before do
+        stub_put("/groups/1", "group_edit").with(body: { description: "An interesting group" })
+        @edited_project = Gitlab.edit_group(1, description: "An interesting group")
+      end
+
+      it "gets the correct resource" do
+        expect(a_put("/groups/1").with(body: { description: "An interesting group" })).to have_been_made
+      end
+
+      it "returns information about an edited group" do
+        expect(@edited_project.description).to eq("An interesting group")
+      end
+    end
   end
 end

--- a/spec/gitlab/client/groups_spec.rb
+++ b/spec/gitlab/client/groups_spec.rb
@@ -209,4 +209,22 @@ describe Gitlab::Client do
       expect(@groups.last.id).to eq(8)
     end
   end
+
+  describe ".group_subgroups" do
+    before do
+      stub_get("/groups/4/subgroups", "group_subgroups")
+      @subgroups = Gitlab.group_subgroups(4)
+    end
+
+    it "gets the list of subroups" do
+      expect(a_get("/groups/4/subgroups")).to have_been_made
+    end
+
+    it "returns an array of subgroups under a group" do
+      expect(@subgroups).to be_a Gitlab::PaginatedResponse
+      expect(@subgroups.size).to eq(1)
+      expect(@subgroups[0].name).to eq("Foobar Group")
+    end
+
+  end
 end

--- a/spec/gitlab/shell_spec.rb
+++ b/spec/gitlab/shell_spec.rb
@@ -55,7 +55,7 @@ describe Gitlab::Shell do
       it "returns an Array of matching commands" do
         completed_cmds = @comp.call 'group'
         expect(completed_cmds).to be_a Array
-        expect(completed_cmds.sort).to eq(%w(group group_member group_members group_projects group_search group_variable group_variables groups))
+        expect(completed_cmds.sort).to eq(%w(group group_member group_members group_projects group_search group_subgroups group_variable group_variables groups))
       end
     end
   end


### PR DESCRIPTION
Hi there,

First of all thanks for the hard work, this week I've tried use the gem and i've found that are missing some api methods at groups.rb, so i take some time to add the following methods:

- List Groups Subgroups based on the group ID we send on the API call (https://docs.gitlab.com/ce/api/groups.html#list-a-groups-s-subgroups)
- Edit group method, based on the group ID we send on the API call (https://docs.gitlab.com/ce/api/groups.html#update-group)

Besides this, i've added the fixtures and specs for testing this new 2 methods.