### PR TITLE
Fixes error when tags contain special characters

### DIFF
--- a/lib/gitlab/client/tags.rb
+++ b/lib/gitlab/client/tags.rb
@@ -44,7 +44,7 @@ class Gitlab::Client
     # @param  [String] tag The name of the tag.
     # @return [Gitlab::ObjectifiedHash]
     def tag(project, tag)
-      get("/projects/#{url_encode project}/repository/tags/#{tag}")
+      get("/projects/#{url_encode project}/repository/tags/#{url_encode tag}")
     end
     alias_method :repo_tag, :tag
 
@@ -58,7 +58,7 @@ class Gitlab::Client
     # @param  [String] tag The name of the tag to delete
     # @return [Gitlab::ObjectifiedHash]
     def delete_tag(project, tag)
-      delete("/projects/#{url_encode project}/repository/tags/#{tag}")
+      delete("/projects/#{url_encode project}/repository/tags/#{url_encode tag}")
     end
     alias_method :repo_delete_tag, :delete_tag
 
@@ -73,7 +73,7 @@ class Gitlab::Client
     # @param  [String] description Release notes with markdown support
     # @return [Gitlab::ObjectifiedHash]
     def create_release(project, tag, description)
-      post("/projects/#{url_encode project}/repository/tags/#{tag}/release", body: { description: description })
+      post("/projects/#{url_encode project}/repository/tags/#{url_encode tag}/release", body: { description: description })
     end
     alias_method :repo_create_release, :create_release
 
@@ -88,7 +88,7 @@ class Gitlab::Client
     # @param  [String] description Release notes with markdown support
     # @return [Gitlab::ObjectifiedHash]
     def update_release(project, tag, description)
-      put("/projects/#{url_encode project}/repository/tags/#{tag}/release", body: { description: description })
+      put("/projects/#{url_encode project}/repository/tags/#{url_encode tag}/release", body: { description: description })
     end
     alias_method :repo_update_release, :update_release
 

--- a/spec/gitlab/client/tags_spec.rb
+++ b/spec/gitlab/client/tags_spec.rb
@@ -37,6 +37,17 @@ describe Gitlab::Client do
     it "returns information about a repository tag" do
       expect(@tag.name).to eq("0.0.1")
     end
+
+    context "tag with special character" do
+      before do
+        stub_get("/projects/3/repository/tags/test%2Fme", "tag")
+        @tag = Gitlab.tag(3, "test/me")
+      end
+
+      it "gets the correct resource" do
+        expect(a_get("/projects/3/repository/tags/test%2Fme")).to have_been_made
+      end
+    end
   end
 
   describe ".create_tag" do
@@ -72,6 +83,17 @@ describe Gitlab::Client do
     it "returns information about the deleted repository tag" do
       expect(@tag.tag_name).to eq("0.0.1")
     end
+
+    context "tag with special character" do
+      before do
+        stub_delete("/projects/3/repository/tags/test%2Fme", "tag_delete")
+        @tag = Gitlab.delete_tag(3, "test/me")
+      end
+
+      it "gets the correct resource" do
+        expect(a_delete("/projects/3/repository/tags/test%2Fme")).to have_been_made
+      end
+    end
   end
 
   describe ".create_release" do
@@ -88,6 +110,17 @@ describe Gitlab::Client do
       expect(@tag.tag_name).to eq("0.0.1")
       expect(@tag.description).to eq("Amazing release. Wow")
     end
+
+    context "tag with special character" do
+      before do
+        stub_post("/projects/3/repository/tags/test%2Fme/release", "release_create")
+        @tag = Gitlab.create_release(3, "test/me", "Amazing release. Wow")
+      end
+
+      it "gets the correct resource" do
+        expect(a_post("/projects/3/repository/tags/test%2Fme/release")).to have_been_made
+      end
+    end
   end
 
   describe ".update_release" do
@@ -103,6 +136,17 @@ describe Gitlab::Client do
     it "returns information about the tag" do
       expect(@tag.tag_name).to eq("0.0.1")
       expect(@tag.description).to eq('Amazing release. Wow')
+    end
+
+    context "tag with special character" do
+      before do
+        stub_put("/projects/3/repository/tags/test%2Fme/release", "release_update")
+        @tag = Gitlab.update_release(3, "test/me", 'Amazing release. Wow')
+      end
+
+      it "updates the correct resource" do
+        expect(a_put("/projects/3/repository/tags/test%2Fme/release")).to have_been_made
+      end
     end
   end
 end


### PR DESCRIPTION
When a git tag contain characters with a special meaning in a url, then this library would send requests to the wrong urls. Examples of such characters are '/' and '#'.

This PR makes sure that such characters are properly url-encoded.