### PR TITLE
make edit_(.*_)?note accept the note body as a string again

### DIFF
--- a/lib/gitlab/client/notes.rb
+++ b/lib/gitlab/client/notes.rb
@@ -221,7 +221,7 @@ class Gitlab::Client
     # @param [Integer] id The ID of a note.
     # @return [Gitlab::ObjectifiedHash]
     def edit_note(project, id, body)
-      put("/projects/#{url_encode project}/notes/#{id}", body: body)
+      put("/projects/#{url_encode project}/notes/#{id}", body: { body: body })
     end
 
     # Modifies an issue note.
@@ -234,7 +234,7 @@ class Gitlab::Client
     # @param [Integer] id The ID of a note.
     # @return [Gitlab::ObjectifiedHash]
     def edit_issue_note(project, issue, id, body)
-      put("/projects/#{url_encode project}/issues/#{issue}/notes/#{id}", body: body)
+      put("/projects/#{url_encode project}/issues/#{issue}/notes/#{id}", body: { body: body })
     end
 
     # Modifies a snippet note.
@@ -247,7 +247,7 @@ class Gitlab::Client
     # @param [Integer] id The ID of a note.
     # @return [Gitlab::ObjectifiedHash]
     def edit_snippet_note(project, snippet, id, body)
-      put("/projects/#{url_encode project}/snippets/#{snippet}/notes/#{id}", body: body)
+      put("/projects/#{url_encode project}/snippets/#{snippet}/notes/#{id}", body: { body: body })
     end
 
     # Modifies a merge_request note.
@@ -260,7 +260,7 @@ class Gitlab::Client
     # @param [Integer] id The ID of a note.
     # @return [Gitlab::ObjectifiedHash]
     def edit_merge_request_note(project, merge_request, id, body)
-      put("/projects/#{url_encode project}/merge_requests/#{merge_request}/notes/#{id}", body: body)
+      put("/projects/#{url_encode project}/merge_requests/#{merge_request}/notes/#{id}", body: { body: body })
     end
     alias_method :edit_merge_request_comment, :edit_merge_request_note
   end

--- a/spec/gitlab/client/notes_spec.rb
+++ b/spec/gitlab/client/notes_spec.rb
@@ -269,7 +269,7 @@ describe Gitlab::Client do
     context "when wall note" do
       before do
         stub_put("/projects/3/notes/1201", "note")
-        @note = Gitlab.edit_note(3, 1201, body: "edited wall note content")
+        @note = Gitlab.edit_note(3, 1201, "edited wall note content")
       end
 
       it "gets the correct resource" do
@@ -285,7 +285,7 @@ describe Gitlab::Client do
     context "when issue note" do
       before do
         stub_put("/projects/3/issues/7/notes/1201", "note")
-        @note = Gitlab.edit_issue_note(3, 7, 1201, body: "edited issue note content")
+        @note = Gitlab.edit_issue_note(3, 7, 1201, "edited issue note content")
       end
 
       it "gets the correct resource" do
@@ -301,7 +301,7 @@ describe Gitlab::Client do
     context "when snippet note" do
       before do
         stub_put("/projects/3/snippets/7/notes/1201", "note")
-        @note = Gitlab.edit_snippet_note(3, 7, 1201, body: "edited snippet note content")
+        @note = Gitlab.edit_snippet_note(3, 7, 1201, "edited snippet note content")
       end
 
       it "gets the correct resource" do
@@ -317,7 +317,7 @@ describe Gitlab::Client do
     context "when merge request note" do
       before do
         stub_put("/projects/3/merge_requests/7/notes/1201", "note")
-        @note = Gitlab.edit_merge_request_note(3, 7, 1201, body: "edited merge request note content")
+        @note = Gitlab.edit_merge_request_note(3, 7, 1201, "edited merge request note content")
       end
 
       it "gets the correct resource" do


### PR DESCRIPTION
the refactoring done in ceba47d6 made `edit_note`/`edit_*_note` expect the body in a Hash, instead if a plain String as it was before and as it is noted in the examples.

Refs: #304 
Yes, this breaks the API, but it was already broken for 4.2.0 by ceba47d6