### PR TITLE
Fix create branch API

### DIFF
--- a/lib/gitlab/client/branches.rb
+++ b/lib/gitlab/client/branches.rb
@@ -68,15 +68,15 @@ class Gitlab::Client
     # Creates a repository branch.  Requires Gitlab >= 6.8.x
     #
     # @example
-    #   Gitlab.create_branch(3, 'api')
-    #   Gitlab.repo_create_branch(5, 'master')
+    #   Gitlab.create_branch(3, 'api', 'feat/new-api')
+    #   Gitlab.repo_create_branch(5, 'master', 'develop')
     #
     # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] branch The name of the new branch.
     # @param  [String] ref Create branch from commit sha or existing branch
     # @return [Gitlab::ObjectifiedHash] Details about the branch
     def create_branch(project, branch, ref)
-      post("/projects/#{url_encode project}/repository/branches", body: { branch: branch, ref: ref })
+      post("/projects/#{url_encode project}/repository/branches", query: { branch: branch, ref: ref })
     end
     alias_method :repo_create_branch, :create_branch
 

--- a/spec/gitlab/client/branches_spec.rb
+++ b/spec/gitlab/client/branches_spec.rb
@@ -86,12 +86,14 @@ describe Gitlab::Client do
 
   describe ".create_branch" do
     before do
-      stub_post("/projects/3/repository/branches", "branch")
+      stub_post("/projects/3/repository/branches", "branch").with(query: { branch: 'api', ref: "master"})
       @branch = Gitlab.create_branch(3, "api", "master")
     end
 
     it "gets the correct resource" do
-      expect(a_post("/projects/3/repository/branches")).to have_been_made
+      expect(
+        a_post("/projects/3/repository/branches").with(query: { branch: 'api', ref: "master"})
+      ).to have_been_made
     end
 
     it "returns information about a new repository branch" do


### PR DESCRIPTION
## Create a branch

```ruby
g = Gitlab.client(endpoint: 'https://gitlab.com/api/v4', private_token: 'xxxx')

# Create a branch
g.create_branch(5221359, "newbranch", "master")
=> #<Gitlab::ObjectifiedHash:70145150190240 {hash: {"name"=>"newbranch", ~ 
```
- https://docs.gitlab.com/ce/api/branches.html#create-repository-branch

Thanks in advance :bow: