### PR TITLE
Add featrues that allow users to specify namespace_id with strings

### DIFF
--- a/lib/gitlab/client/projects.rb
+++ b/lib/gitlab/client/projects.rb
@@ -87,9 +87,25 @@ class Gitlab::Client
     # @option options [Integer] :user_id The user/owner id of a project.
     # @return [Gitlab::ObjectifiedHash] Information about created project.
     def create_project(name, options={})
+      if options.key?(:namespace_id) && options[:namespace_id].is_a?(String)
+        resp =
+            eval(get("/namespaces?search=#{options[:namespace_id]}"
+            ).instance_variable_get(
+            :@array).inspect().match(/{.*/)[0].partition(']').first)
+        if resp.empty?
+        options[:namespace_id] = nil
+        else
+        id=resp[:hash]["id"]
+        if resp[:hash]["id"] != nil
+          options[:namespace_id] = id
+        else
+          options[:namespace_id] = nil
+        end
+        end
+      end
       url = options[:user_id] ? "/projects/user/#{options[:user_id]}" : "/projects"
       post(url, body: { name: name }.merge(options))
-    end
+    end   
 
     # Deletes a project.
     #

--- a/lib/gitlab/version.rb
+++ b/lib/gitlab/version.rb
@@ -1,3 +1,3 @@
 module Gitlab
-  VERSION = '4.3.0'.freeze
+  VERSION = '4.3.1'.freeze
 end


### PR DESCRIPTION
I add a feature that allows users using String to describe their namespace_id while using command create_project. 
Something like `gitlab create_project 'gitlab' "{namespace_id : 'sleeplessy' }"`.
So that user can directly create repos under a group without trying to getting the **value of namespace_id**
And plz notify that the former help infomation of this command tells user that namespace_id should be a String,but [The Gitlab Official API DOC](https://docs.gitlab.com/ee/api/projects.html#create-project) tells that this param should be a Integer.
If the namespace_id is a Integer,or it wasn't defined,it would act like former.