### PR TITLE
Fix the modify Note methods so that the Note body can be passed as a …

### DIFF
--- a/lib/gitlab/client/notes.rb
+++ b/lib/gitlab/client/notes.rb
@@ -219,9 +219,10 @@ class Gitlab::Client
     #
     # @param [Integer] project The ID of a project.
     # @param [Integer] id The ID of a note.
+    # @param [String] body The content of a note.
     # @return [Gitlab::ObjectifiedHash]
     def edit_note(project, id, body)
-      put("/projects/#{url_encode project}/notes/#{id}", body: body)
+      put("/projects/#{url_encode project}/notes/#{id}", body: note_content(body))
     end
 
     # Modifies an issue note.
@@ -232,9 +233,10 @@ class Gitlab::Client
     # @param [Integer] project The ID of a project.
     # @param [Integer] issue The ID of an issue.
     # @param [Integer] id The ID of a note.
+    # @param [String] body The content of a note.
     # @return [Gitlab::ObjectifiedHash]
     def edit_issue_note(project, issue, id, body)
-      put("/projects/#{url_encode project}/issues/#{issue}/notes/#{id}", body: body)
+      put("/projects/#{url_encode project}/issues/#{issue}/notes/#{id}", body: note_content(body))
     end
 
     # Modifies a snippet note.
@@ -245,9 +247,10 @@ class Gitlab::Client
     # @param [Integer] project The ID of a project.
     # @param [Integer] snippet The ID of a snippet.
     # @param [Integer] id The ID of a note.
+    # @param [String] body The content of a note.
     # @return [Gitlab::ObjectifiedHash]
     def edit_snippet_note(project, snippet, id, body)
-      put("/projects/#{url_encode project}/snippets/#{snippet}/notes/#{id}", body: body)
+      put("/projects/#{url_encode project}/snippets/#{snippet}/notes/#{id}", body: note_content(body))
     end
 
     # Modifies a merge_request note.
@@ -258,10 +261,24 @@ class Gitlab::Client
     # @param [Integer] project The ID of a project.
     # @param [Integer] merge_request The ID of a merge_request.
     # @param [Integer] id The ID of a note.
+    # @param [String] body The content of a note.
     # @return [Gitlab::ObjectifiedHash]
     def edit_merge_request_note(project, merge_request, id, body)
-      put("/projects/#{url_encode project}/merge_requests/#{merge_request}/notes/#{id}", body: body)
+      put("/projects/#{url_encode project}/merge_requests/#{merge_request}/notes/#{id}", body: note_content(body))
     end
     alias_method :edit_merge_request_comment, :edit_merge_request_note
+
+    private
+
+    # TODO: Remove this method after a couple deprecation cycles.  Replace calls with the code
+    # in the 'else'.
+    def note_content(body)
+      if body.is_a?(Hash)
+        STDERR.puts "Passing the note body as a Hash is deprecated.  You should just pass the String."
+        body
+      else
+        { body: body }
+      end
+    end
   end
 end

--- a/spec/gitlab/client/notes_spec.rb
+++ b/spec/gitlab/client/notes_spec.rb
@@ -269,7 +269,7 @@ describe Gitlab::Client do
     context "when wall note" do
       before do
         stub_put("/projects/3/notes/1201", "note")
-        @note = Gitlab.edit_note(3, 1201, body: "edited wall note content")
+        @note = Gitlab.edit_note(3, 1201, "edited wall note content")
       end
 
       it "gets the correct resource" do
@@ -285,7 +285,7 @@ describe Gitlab::Client do
     context "when issue note" do
       before do
         stub_put("/projects/3/issues/7/notes/1201", "note")
-        @note = Gitlab.edit_issue_note(3, 7, 1201, body: "edited issue note content")
+        @note = Gitlab.edit_issue_note(3, 7, 1201, "edited issue note content")
       end
 
       it "gets the correct resource" do
@@ -301,7 +301,7 @@ describe Gitlab::Client do
     context "when snippet note" do
       before do
         stub_put("/projects/3/snippets/7/notes/1201", "note")
-        @note = Gitlab.edit_snippet_note(3, 7, 1201, body: "edited snippet note content")
+        @note = Gitlab.edit_snippet_note(3, 7, 1201, "edited snippet note content")
       end
 
       it "gets the correct resource" do
@@ -317,7 +317,7 @@ describe Gitlab::Client do
     context "when merge request note" do
       before do
         stub_put("/projects/3/merge_requests/7/notes/1201", "note")
-        @note = Gitlab.edit_merge_request_note(3, 7, 1201, body: "edited merge request note content")
+        @note = Gitlab.edit_merge_request_note(3, 7, 1201, "edited merge request note content")
       end
 
       it "gets the correct resource" do


### PR DESCRIPTION
…String (preferred) or as a Hash (with deprecation warning).

Closes #304.  Supersedes these PRs: #348 & #305. 