### PR TITLE
Improvement to ssh_keys, gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.2
   - 2.3
   - 2.4
+  - 2.5
 before_install: gem update bundler
 
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Unreleased
 
+### 4.3.2 (26/02/2018)
+- Gemspec: force reliance on Psych > 2.2.0 for safe_load
+- Gemspec: remove dev dependency on pry (useful but not needed)
+- ssh_key family: support list/create/delete of keys for specific users
+
 ### 4.2.0 (13/07/2017)
 - Use `url_encode` in all `Commit` resources (@grodowski)
 - Fix `project_search` path for APIv4 (@edaubert)

--- a/gitlab.gemspec
+++ b/gitlab.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'httparty'
   gem.add_runtime_dependency 'terminal-table'
+  gem.add_runtime_dependency 'psych',[">= 2.2.0"]
 
-  gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'webmock'

--- a/lib/gitlab/version.rb
+++ b/lib/gitlab/version.rb
@@ -1,3 +1,3 @@
 module Gitlab
-  VERSION = '4.3.0'.freeze
+  VERSION = '4.3.2'.freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+gem 'psych','>=2.2'
+require 'psych'
+
 require 'rspec'
 require 'webmock/rspec'
 


### PR DESCRIPTION
This patch provides support for maintaining the ssh_keys of other users. The existing implementation is not consistent in its use of user-id as a parameter; this is corrected when fetching keys. For these call implementations, pseudo-function-overloading is implemented with variable argument lists.

Also, a prior version introduced the use of yaml.safe_load, which is available only in psych +2.2, so that dependency is coded into the Gemspec.

It is so far still possible to build and deploy on Ruby 2.0 system (ie, RHEL). Let's keep it that way please.