### PR TITLE
pin dependencies to version

### DIFF
--- a/gitlab.gemspec
+++ b/gitlab.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.0.0'
 
-  gem.add_runtime_dependency 'httparty'
-  gem.add_runtime_dependency 'terminal-table'
+  gem.add_runtime_dependency 'httparty', '~> 0.16.1'
+  gem.add_runtime_dependency 'terminal-table', '~> 1.8.0'
 
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
I keep getting this error which I think is due to not pinning a version in the gemspec file.  This PR fixes the problem below by pinning the version.


```
WARN: Unresolved specs during Gem::Specification.reset:
      httparty (>= 0)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.

```