### PR TITLE
[FEATURE] Group/Project Access Requests API

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -4,6 +4,7 @@ module Gitlab
     Dir[File.expand_path('../client/*.rb', __FILE__)].each { |f| require f }
 
     # Please keep in alphabetical order
+    include AccessRequests
     include AwardEmojis
     include Boards
     include Branches

--- a/lib/gitlab/client/access_requests.rb
+++ b/lib/gitlab/client/access_requests.rb
@@ -50,7 +50,7 @@ class Gitlab::Client
     #
     # @param  [Integer, String] :project(required) The ID or name of a project.
     # @param  [Integer] :user_id(required) The user ID of the access requester
-    # @option options [String] :access_level(optional) A valid access level (defaults: '30', developer access level)
+    # @option options [Integer] :access_level(optional) A valid access level (defaults: 30, developer access level)
     # @return <Gitlab::ObjectifiedHash] Information about the approved project access request
     def approve_project_access_request(project, user_id, options = {})
       put("/projects/#{url_encode project}/access_requests/#{user_id}/approve", body: options)
@@ -63,7 +63,7 @@ class Gitlab::Client
     #
     # @param  [Integer, String] :group(required) The ID or name of a group.
     # @param  [Integer] :user_id(required) The user ID of the access requester
-    # @option options [String] :access_level(optional) A valid access level (defaults: '30', developer access level)
+    # @option options [Integer] :access_level(optional) A valid access level (defaults: 30, developer access level)
     # @return <Gitlab::ObjectifiedHash] Information about the approved group access request
     def approve_group_access_request(group, user_id, options = {})
       put("/groups/#{url_encode group}/access_requests/#{user_id}/approve", body: options)

--- a/lib/gitlab/client/access_requests.rb
+++ b/lib/gitlab/client/access_requests.rb
@@ -46,29 +46,27 @@ class Gitlab::Client
     #
     # @example
     #    Gitlab.approve_project_access_request(1, 1)
-    #    Gitlab.approve_project_access_request(1, 1, 30)
+    #    Gitlab.approve_project_access_request(1, 1, {access_level: '30'})
     #
     # @param  [Integer, String] :project(required) The ID or name of a project.
     # @param  [Integer] :user_id(required) The user ID of the access requester
-    # @param  [Integer] :access_level(optional) A valid access level (defaults: 30, developer access level)
+    # @option options [String] :access_level(optional) A valid access level (defaults: '30', developer access level)
     # @return <Gitlab::ObjectifiedHash] Information about the approved project access request
-    def approve_project_access_request(project, user_id, access_level = '')
-      body = {access_level: access_level}
-      put("/projects/#{url_encode project}/access_requests/#{user_id}/approve", body: body)
+    def approve_project_access_request(project, user_id, options = {})
+      put("/projects/#{url_encode project}/access_requests/#{user_id}/approve", body: options)
     end
     # Approves a group access request for the given user.
     #
     # @example
     #    Gitlab.approve_group_access_request(1, 1)
-    #    Gitlab.approve_group_access_request(1, 1, 30)
+    #    Gitlab.approve_group_access_request(1, 1, {access_level: '30'})
     #
     # @param  [Integer, String] :group(required) The ID or name of a group.
     # @param  [Integer] :user_id(required) The user ID of the access requester
-    # @param  [Integer] :access_level(optional) A valid access level (defaults: 30, developer access level)
+    # @option options [String] :access_level(optional) A valid access level (defaults: '30', developer access level)
     # @return <Gitlab::ObjectifiedHash] Information about the approved group access request
-    def approve_group_access_request(group, user_id, access_level = '')
-      body = {access_level: access_level}
-      put("/groups/#{url_encode group}/access_requests/#{user_id}/approve", body: body)
+    def approve_group_access_request(group, user_id, options = {})
+      put("/groups/#{url_encode group}/access_requests/#{user_id}/approve", body: options)
     end
     # Denies a project access request for the given user.
     #

--- a/lib/gitlab/client/access_requests.rb
+++ b/lib/gitlab/client/access_requests.rb
@@ -1,0 +1,96 @@
+class Gitlab::Client
+  # Defines methods related to Award Emojis.
+  # @see https://docs.gitlab.com/ce/api/access_requests.html
+  module AccessRequests
+    # Gets a list of access requests for a project viewable by the authenticated user.
+    #
+    # @example
+    #   Gitlab.project_access_requests(1)
+    #
+    # @param  [Integer, String] :project(required) The ID or name of a project.
+    # @return [Array<Gitlab::ObjectifiedHash>] List of project access requests
+    def project_access_requests(project)
+      get("/projects/#{url_encode project}/access_requests")
+    end
+    # Gets a list of access requests for a group viewable by the authenticated user.
+    #
+    # @example
+    #   Gitlab.group_access_requests(1)
+    #
+    # @param  [Integer, String] :group(required) The ID or name of a group.
+    # @return [Array<Gitlab::ObjectifiedHash>] List of group access requests
+    def group_access_requests(group)
+      get("/groups/#{url_encode group}/access_requests")
+    end
+    # Requests access for the authenticated user to a project.
+    #
+    # @example
+    #    Gitlab.request_project_access(1)
+    #
+    # @param  [Integer, String] :project(required) The ID or name of a project.
+    # @return <Gitlab::ObjectifiedHash] Information about the requested project access
+    def request_project_access(project)
+      post("/projects/#{url_encode project}/access_requests")
+    end
+    # Requests access for the authenticated user to a group.
+    #
+    # @example
+    #    Gitlab.request_group_access(1)
+    #
+    # @param  [Integer, String] :group(required) The ID or name of a group.
+    # @return <Gitlab::ObjectifiedHash] Information about the requested group access
+    def request_group_access(group)
+      post("/groups/#{url_encode group}/access_requests")
+    end
+    # Approves a project access request for the given user.
+    #
+    # @example
+    #    Gitlab.approve_project_access_request(1, 1)
+    #    Gitlab.approve_project_access_request(1, 1, 30)
+    #
+    # @param  [Integer, String] :project(required) The ID or name of a project.
+    # @param  [Integer] :user_id(required) The user ID of the access requester
+    # @param  [Integer] :access_level(optional) A valid access level (defaults: 30, developer access level)
+    # @return <Gitlab::ObjectifiedHash] Information about the approved project access request
+    def approve_project_access_request(project, user_id, access_level = '')
+      body = {access_level: access_level}
+      put("/projects/#{url_encode project}/access_requests/#{user_id}/approve", body: body)
+    end
+    # Approves a group access request for the given user.
+    #
+    # @example
+    #    Gitlab.approve_group_access_request(1, 1)
+    #    Gitlab.approve_group_access_request(1, 1, 30)
+    #
+    # @param  [Integer, String] :group(required) The ID or name of a group.
+    # @param  [Integer] :user_id(required) The user ID of the access requester
+    # @param  [Integer] :access_level(optional) A valid access level (defaults: 30, developer access level)
+    # @return <Gitlab::ObjectifiedHash] Information about the approved group access request
+    def approve_group_access_request(group, user_id, access_level = '')
+      body = {access_level: access_level}
+      put("/groups/#{url_encode group}/access_requests/#{user_id}/approve", body: body)
+    end
+    # Denies a project access request for the given user.
+    #
+    # @example
+    #    Gitlab.deny_project_access_request(1, 1)
+    #
+    # @param  [Integer, String] :project(required) The ID or name of a project.
+    # @param  [Integer] :user_id(required) The user ID of the access requester
+    # @return [void] This API call returns an empty response body.
+    def deny_project_access_request(project, user_id)
+      delete("/projects/#{url_encode project}/access_requests/#{user_id}")
+    end
+    # Denies a group access request for the given user.
+    #
+    # @example
+    #    Gitlab.deny_group_access_request(1, 1)
+    #
+    # @param  [Integer, String] :group(required) The ID or name of a group.
+    # @param  [Integer] :user_id(required) The user ID of the access requester
+    # @return [void] This API call returns an empty response body.
+    def deny_group_access_request(group, user_id)
+      delete("/groups/#{url_encode group}/access_requests/#{user_id}")
+    end
+  end
+end

--- a/spec/fixtures/access_request.json
+++ b/spec/fixtures/access_request.json
@@ -1,0 +1,8 @@
+{
+  "id": 1,
+  "username": "raymond_smith",
+  "name": "Raymond Smith",
+  "state": "active",
+  "created_at": "2012-10-22T14:13:35Z",
+  "requested_at": "2012-10-22T14:13:35Z"
+}

--- a/spec/fixtures/access_requests.json
+++ b/spec/fixtures/access_requests.json
@@ -1,0 +1,18 @@
+[
+ {
+   "id": 1,
+   "username": "raymond_smith",
+   "name": "Raymond Smith",
+   "state": "active",
+   "created_at": "2012-10-22T14:13:35Z",
+   "requested_at": "2012-10-22T14:13:35Z"
+ },
+ {
+   "id": 2,
+   "username": "john_doe",
+   "name": "John Doe",
+   "state": "active",
+   "created_at": "2012-10-22T14:13:35Z",
+   "requested_at": "2012-10-22T14:13:35Z"
+ }
+]

--- a/spec/fixtures/approved_access_request.json
+++ b/spec/fixtures/approved_access_request.json
@@ -1,0 +1,8 @@
+{
+  "id": 1,
+  "username": "raymond_smith",
+  "name": "Raymond Smith",
+  "state": "active",
+  "created_at": "2012-10-22T14:13:35Z",
+  "access_level": 20
+}

--- a/spec/fixtures/default_approved_access_request.json
+++ b/spec/fixtures/default_approved_access_request.json
@@ -1,0 +1,8 @@
+{
+  "id": 1,
+  "username": "raymond_smith",
+  "name": "Raymond Smith",
+  "state": "active",
+  "created_at": "2012-10-22T14:13:35Z",
+  "access_level": 30
+}

--- a/spec/gitlab/client/access_requests_spec.rb
+++ b/spec/gitlab/client/access_requests_spec.rb
@@ -56,13 +56,12 @@ describe Gitlab::Client do
   describe '.approve_project_access_request' do
     context 'When no access level is given' do
       before do
-        stub_put("/projects/1/access_requests/1/approve", "default_approved_access_request").with(body: {access_level: ''})
+        stub_put("/projects/1/access_requests/1/approve", "default_approved_access_request")
         @access_request = Gitlab.approve_project_access_request(1, 1)
       end
 
       it 'gets the correct resource' do
-        expect(a_put("/projects/1/access_requests/1/approve").
-               with(body: { access_level: '' })).to have_been_made
+        expect(a_put("/projects/1/access_requests/1/approve")).to have_been_made
       end
 
       it "returns information about the project access request" do
@@ -72,7 +71,7 @@ describe Gitlab::Client do
     context 'When access level is given' do
       before do
         stub_put("/projects/1/access_requests/1/approve", "approved_access_request").with(body: {access_level: '20'})
-        @access_request = Gitlab.approve_project_access_request(1, 1, 20)
+        @access_request = Gitlab.approve_project_access_request(1, 1, {access_level: '20'})
       end
 
       it 'gets the correct resource' do
@@ -89,13 +88,12 @@ describe Gitlab::Client do
   describe '.approve_group_access_request' do
     context 'When no access level is given' do
       before do
-        stub_put("/groups/1/access_requests/1/approve", "default_approved_access_request").with(body: {access_level: ''})
+        stub_put("/groups/1/access_requests/1/approve", "default_approved_access_request")
         @access_request = Gitlab.approve_group_access_request(1, 1)
       end
 
       it 'gets the correct resource' do
-        expect(a_put("/groups/1/access_requests/1/approve").
-               with(body: { access_level: '' })).to have_been_made
+        expect(a_put("/groups/1/access_requests/1/approve")).to have_been_made
       end
 
       it "returns information about the group access request" do
@@ -105,7 +103,7 @@ describe Gitlab::Client do
     context 'When access level is given' do
       before do
         stub_put("/groups/1/access_requests/1/approve", "approved_access_request").with(body: {access_level: '20'})
-        @access_request = Gitlab.approve_group_access_request(1, 1, 20)
+        @access_request = Gitlab.approve_group_access_request(1, 1, {access_level: '20'})
       end
 
       it 'gets the correct resource' do

--- a/spec/gitlab/client/access_requests_spec.rb
+++ b/spec/gitlab/client/access_requests_spec.rb
@@ -1,0 +1,143 @@
+require 'spec_helper'
+
+describe Gitlab::Client do
+  describe '.project_access_requests' do
+    before do
+      stub_get("/projects/1/access_requests", "access_requests")
+      @access_requests = Gitlab.project_access_requests(1)
+    end
+
+    it 'gets the correct resources' do
+      expect(a_get("/projects/1/access_requests")).to have_been_made
+    end
+
+    it 'returns a paginated response of project access requests' do
+      expect(@access_requests).to be_a Gitlab::PaginatedResponse
+    end
+  end
+
+  describe '.group_access_requests' do
+    before do
+      stub_get("/groups/1/access_requests", "access_requests")
+      @access_requests = Gitlab.group_access_requests(1)
+    end
+
+    it 'gets the correct resources' do
+      expect(a_get("/groups/1/access_requests")).to have_been_made
+    end
+
+    it 'returns a paginated response of group access requests' do
+      expect(@access_requests).to be_a Gitlab::PaginatedResponse
+    end
+  end
+
+  describe '.request_project_access' do
+    before do
+      stub_post("/projects/1/access_requests", "access_request")
+      @access_request = Gitlab.request_project_access(1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_post("/projects/1/access_requests")).to have_been_made
+    end
+  end
+
+  describe '.request_group_access' do
+    before do
+      stub_post("/groups/1/access_requests", "access_request")
+      @access_request = Gitlab.request_group_access(1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_post("/groups/1/access_requests")).to have_been_made
+    end
+  end
+
+  describe '.approve_project_access_request' do
+    context 'When no access level is given' do
+      before do
+        stub_put("/projects/1/access_requests/1/approve", "default_approved_access_request").with(body: {access_level: ''})
+        @access_request = Gitlab.approve_project_access_request(1, 1)
+      end
+
+      it 'gets the correct resource' do
+        expect(a_put("/projects/1/access_requests/1/approve").
+               with(body: { access_level: '' })).to have_been_made
+      end
+
+      it "returns information about the project access request" do
+        expect(@access_request.access_level).to eq(30)
+      end
+    end
+    context 'When access level is given' do
+      before do
+        stub_put("/projects/1/access_requests/1/approve", "approved_access_request").with(body: {access_level: '20'})
+        @access_request = Gitlab.approve_project_access_request(1, 1, 20)
+      end
+
+      it 'gets the correct resource' do
+        expect(a_put("/projects/1/access_requests/1/approve").
+               with(body: { access_level: "20" })).to have_been_made
+      end
+
+      it "returns information about the project access request" do
+        expect(@access_request.access_level).to eq(20)
+      end
+    end
+  end
+
+  describe '.approve_group_access_request' do
+    context 'When no access level is given' do
+      before do
+        stub_put("/groups/1/access_requests/1/approve", "default_approved_access_request").with(body: {access_level: ''})
+        @access_request = Gitlab.approve_group_access_request(1, 1)
+      end
+
+      it 'gets the correct resource' do
+        expect(a_put("/groups/1/access_requests/1/approve").
+               with(body: { access_level: '' })).to have_been_made
+      end
+
+      it "returns information about the group access request" do
+        expect(@access_request.access_level).to eq(30)
+      end
+    end
+    context 'When access level is given' do
+      before do
+        stub_put("/groups/1/access_requests/1/approve", "approved_access_request").with(body: {access_level: '20'})
+        @access_request = Gitlab.approve_group_access_request(1, 1, 20)
+      end
+
+      it 'gets the correct resource' do
+        expect(a_put("/groups/1/access_requests/1/approve").
+               with(body: { access_level: "20" })).to have_been_made
+      end
+
+      it "returns information about the group access request" do
+        expect(@access_request.access_level).to eq(20)
+      end
+    end
+  end
+
+  describe '.deny_project_access_request' do
+    before do
+      stub_delete("/projects/1/access_requests/1", "access_request")
+      @access_request = Gitlab.deny_project_access_request(1, 1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_delete("/projects/1/access_requests/1")).to have_been_made
+    end
+  end
+
+  describe '.deny_group_access_request' do
+    before do
+      stub_delete("/groups/1/access_requests/1", "access_request")
+      @access_request = Gitlab.deny_group_access_request(1, 1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_delete("/groups/1/access_requests/1")).to have_been_made
+    end
+  end
+end

--- a/spec/gitlab/shell_spec.rb
+++ b/spec/gitlab/shell_spec.rb
@@ -55,7 +55,7 @@ describe Gitlab::Shell do
       it "returns an Array of matching commands" do
         completed_cmds = @comp.call 'group'
         expect(completed_cmds).to be_a Array
-        expect(completed_cmds.sort).to eq(%w(group group_member group_members group_projects group_search group_subgroups group_variable group_variables groups))
+        expect(completed_cmds.sort).to eq(%w(group group_access_requests group_member group_members group_projects group_search group_subgroups group_variable group_variables groups))
       end
     end
   end


### PR DESCRIPTION
Group/Project Access Requests API

Methods to

- List access requests to a group/project

- Make access request to a group/project

- Approve access request to a group/project

- Deny access request to a group/project

Closes #315 