### PR TITLE
Do not try to access an ObjectifiedHash with #[]. The method is curre…

### DIFF
--- a/lib/gitlab/error.rb
+++ b/lib/gitlab/error.rb
@@ -11,6 +11,8 @@ module Gitlab
 
     # Custom error class for rescuing from HTTP response errors.
     class ResponseError < Error
+      POSSIBLE_MESSAGE_KEYS = %i(message error_description error)
+
       def initialize(response)
         @response = response
         super(build_error_message)
@@ -37,12 +39,17 @@ module Gitlab
       # @return [String]
       def build_error_message
         parsed_response = @response.parsed_response
-        message = parsed_response.respond_to?(:message) ? parsed_response.message : parsed_response['message']
-        message = parsed_response.respond_to?(:error) ? parsed_response.error : parsed_response['error'] unless message
-
+        message = check_error_keys(parsed_response)
         "Server responded with code #{@response.code}, message: " \
         "#{handle_message(message)}. " \
         "Request URI: #{@response.request.base_uri}#{@response.request.path}"
+      end
+
+      # Error keys vary across the API, find the first key that the parsed_response
+      # object responds to and return that, otherwise return the original.
+      def check_error_keys(resp)
+        key = POSSIBLE_MESSAGE_KEYS.find { |k| resp.respond_to?(k) }
+        key ? resp.send(key) : resp
       end
 
       # Handle error response message in case of nested hashes


### PR DESCRIPTION
…ntly undefined and when #method_missing is invoked, only expects 1 param, it is handed 2 parameters: [] and the key. This causes a confusing ArgumentError on #method_missing.

Fixes #359 
Fixes #388