### PR TITLE
Removed unnecessary files from Gemspec to reduce file size of distributed gem

### DIFF
--- a/gitlab.gemspec
+++ b/gitlab.gemspec
@@ -11,7 +11,9 @@ Gem::Specification.new do |gem|
   gem.summary       = 'A Ruby wrapper and CLI for the GitLab API'
   gem.homepage      = 'https://github.com/narkoz/gitlab'
 
-  gem.files         = `git ls-files`.split($/)
+  gem.files         = `git ls-files`.split($/).
+                      reject { |f| f[/^spec/] } -
+                      %w[Dockerfile docker-compose.yml docker.env .travis.yml .rubocop.yml .dockerignore]
   gem.bindir        = 'exe'
   gem.executables   = gem.files.grep(%r{^exe/}) { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Background: I want to use gitlab gem to run in a CLI and vendor all the dependencies. Gitlab was the largest with over 1MB. Granted, compared to node_modules the overhead is tiny, but nevertheless there are some needless configs that are shipped with the Gem but never needed for a usage.

Removed /specs + Docker configs + Dev configs

Size of the unzipped gem dir:
Before: 1,4MB 
After: 380KB (-72%)

Instead of reject { .. regex } one could use grep_v, which is available from Ruby 2.3. I was not sure, if you are supporting Ruby 2.2 and lower though.