### PR TITLE
Add merge_base support

### DIFF
--- a/lib/gitlab/client/repositories.rb
+++ b/lib/gitlab/client/repositories.rb
@@ -57,5 +57,18 @@ class Gitlab::Client
       get("/projects/#{url_encode project}/repository/compare", query: { from: from, to: to })
     end
     alias repo_compare compare
+
+    # Get the common ancestor for 2 refs (commit SHAs, branch names or tags).
+    #
+    # @example
+    #   Gitlab.merge_base(42, ['master', 'feature/branch'])
+    #   Gitlab.merge_base(42, ['master', 'feature/branch'])
+    #
+    # @param [Integer] project The ID of a project.
+    # @param [String] refs Array containing 2 commit SHAs, branch names, or tags.
+    # @return [Gitlab::ObjectifiedHash]
+    def merge_base(project, refs)
+      get("/projects/#{url_encode project}/repository/merge_base", query: { refs: refs })
+    end
   end
 end

--- a/spec/fixtures/merge_base.json
+++ b/spec/fixtures/merge_base.json
@@ -1,0 +1,14 @@
+{
+    "id": "1a0b36b3cdad1d2ee32457c102a8c0b7056fa863",
+    "short_id": "1a0b36b3",
+    "title": "Initial commit",
+    "created_at": "2014-02-27T08:03:18.000Z",
+    "parent_ids": [],
+    "message": "Initial commit\n",
+    "author_name": "Dmitriy Zaporozhets",
+    "author_email": "dmitriy.zaporozhets@gmail.com",
+    "authored_date": "2014-02-27T08:03:18.000Z",
+    "committer_name": "Dmitriy Zaporozhets",
+    "committer_email": "dmitriy.zaporozhets@gmail.com",
+    "committed_date": "2014-02-27T08:03:18.000Z"
+}

--- a/spec/gitlab/client/repositories_spec.rb
+++ b/spec/gitlab/client/repositories_spec.rb
@@ -96,7 +96,7 @@ describe Gitlab::Client do
 
   describe '.merge_base' do
     before do
-      stub_get('/projects/3/repository/merge_base', 'compare_merge_request_diff')
+      stub_get('/projects/3/repository/merge_base', 'merge_base')
         .with(query: { refs: %w[master feature] })
       @response = Gitlab.merge_base(3, %w[master feature])
     end
@@ -108,7 +108,7 @@ describe Gitlab::Client do
 
     it 'gets common ancestor of the two refs' do
       expect(@response).to be_kind_of Gitlab::ObjectifiedHash
-      expect(@response.commit.id).to eq '12d65c8dd2b2676fa3ac47d955accc085a37a9c1'
+      expect(@response.id).to eq '1a0b36b3cdad1d2ee32457c102a8c0b7056fa863'
     end
   end
 end

--- a/spec/gitlab/client/repositories_spec.rb
+++ b/spec/gitlab/client/repositories_spec.rb
@@ -93,4 +93,22 @@ describe Gitlab::Client do
       expect(@diff.diffs.last['new_path']).to eq 'files/js/application.js'
     end
   end
+
+  describe '.merge_base' do
+    before do
+      stub_get('/projects/3/repository/merge_base', 'compare_merge_request_diff')
+        .with(query: { refs: %w[master feature] })
+      @response = Gitlab.merge_base(3, %w[master feature])
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/repository/merge_base')
+        .with(query: { refs: %w[master feature] })).to have_been_made
+    end
+
+    it 'gets common ancestor of the two refs' do
+      expect(@response).to be_kind_of Gitlab::ObjectifiedHash
+      expect(@response.commit.id).to eq '12d65c8dd2b2676fa3ac47d955accc085a37a9c1'
+    end
+  end
 end


### PR DESCRIPTION
This adds support for the repositories merge_base API endpoint documented [here](https://docs.gitlab.com/ce/api/repositories.html#merge-base). 

It uses the sample response from the docs for spec/fixtures/merge_base.json.