### PR TITLE
[UPDATE] Added expires_at option to team members in a project

### DIFF
--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -24,6 +24,7 @@ module Gitlab
   # Delegate to Gitlab::Client
   def self.method_missing(method, *args, &block)
     return super unless client.respond_to?(method)
+
     client.send(method, *args, &block)
   end
 

--- a/lib/gitlab/client/projects.rb
+++ b/lib/gitlab/client/projects.rb
@@ -118,28 +118,34 @@ class Gitlab::Client
     #
     # @example
     #   Gitlab.add_team_member('gitlab', 2, 40)
+    #   Gitlab.add_team_member('gitlab', 2, 40, { expires_at: "2018-12-31"})
     #
     # @param  [Integer, String] project The ID or path of a project.
     # @param  [Integer] id The ID of a user.
     # @param  [Integer] access_level The access level to project.
     # @param  [Hash] options A customizable set of options.
+    # @option options [String] :expires_at A date string in the format YEAR-MONTH-DAY.
     # @return [Gitlab::ObjectifiedHash] Information about added team member.
-    def add_team_member(project, id, access_level)
-      post("/projects/#{url_encode project}/members", body: { user_id: id, access_level: access_level })
+    def add_team_member(project, id, access_level, options = {})
+      body = { user_id: id, access_level: access_level }.merge(options)
+      post("/projects/#{url_encode project}/members", body: body)
     end
 
     # Updates a team member's project access level.
     #
     # @example
     #   Gitlab.edit_team_member('gitlab', 3, 20)
+    #   Gitlab.edit_team_member('gitlab', 3, 20, { expires_at: "2018-12-31"})
     #
     # @param  [Integer, String] project The ID or path of a project.
     # @param  [Integer] id The ID of a user.
     # @param  [Integer] access_level The access level to project.
     # @param  [Hash] options A customizable set of options.
+    # @option options [String] :expires_at A date string in the format YEAR-MONTH-DAY.
     # @return [Array<Gitlab::ObjectifiedHash>] Information about updated team member.
-    def edit_team_member(project, id, access_level)
-      put("/projects/#{url_encode project}/members/#{id}", body: { access_level: access_level })
+    def edit_team_member(project, id, access_level, options = {})
+      body = { access_level: access_level }.merge(options)
+      put("/projects/#{url_encode project}/members/#{id}", body: body)
     end
 
     # Removes a user from project team.

--- a/lib/gitlab/configuration.rb
+++ b/lib/gitlab/configuration.rb
@@ -51,6 +51,7 @@ module Gitlab
       httparty = Gitlab::CLI::Helpers.yaml_load(options)
 
       raise ArgumentError, 'HTTParty config should be a Hash.' unless httparty.is_a? Hash
+
       Gitlab::CLI::Helpers.symbolize_keys httparty
     end
   end

--- a/lib/gitlab/page_links.rb
+++ b/lib/gitlab/page_links.rb
@@ -26,6 +26,7 @@ module Gitlab
           url = match[1]
           meta = match[2]
           next if !url || !meta || METAS.index(meta).nil?
+
           send("#{meta}=", url)
         end
       end

--- a/lib/gitlab/paginated_response.rb
+++ b/lib/gitlab/paginated_response.rb
@@ -63,6 +63,7 @@ module Gitlab
 
     def last_page
       return nil if @client.nil? || !has_last_page?
+
       path = @links.last.sub(/#{@client.endpoint}/, '')
       @client.get(path)
     end
@@ -74,6 +75,7 @@ module Gitlab
 
     def first_page
       return nil if @client.nil? || !has_first_page?
+
       path = @links.first.sub(/#{@client.endpoint}/, '')
       @client.get(path)
     end
@@ -85,6 +87,7 @@ module Gitlab
 
     def next_page
       return nil if @client.nil? || !has_next_page?
+
       path = @links.next.sub(/#{@client.endpoint}/, '')
       @client.get(path)
     end
@@ -96,6 +99,7 @@ module Gitlab
 
     def prev_page
       return nil if @client.nil? || !has_prev_page?
+
       path = @links.prev.sub(/#{@client.endpoint}/, '')
       @client.get(path)
     end

--- a/lib/gitlab/request.rb
+++ b/lib/gitlab/request.rb
@@ -76,6 +76,7 @@ module Gitlab
     def request_defaults(sudo = nil)
       self.class.default_params sudo: sudo
       raise Error::MissingCredentials, 'Please set an endpoint to API' unless @endpoint
+
       self.class.default_params.delete(:sudo) if sudo.nil?
     end
 

--- a/spec/fixtures/team_member.json
+++ b/spec/fixtures/team_member.json
@@ -1,1 +1,10 @@
-{"id":1,"email":"john@example.com","name":"John Smith","blocked":false,"created_at":"2012-09-17T09:41:56Z","access_level":40}
+{
+  "id": 1,
+  "username": "john_smith",
+  "name": "John Smith",
+  "state": "active",
+  "avatar_url": "https://www.gravatar.com/avatar/c2525a7f58ae3776070e44c106c48e15?s=80&d=identicon",
+  "web_url": "http://192.168.1.8:3000/root",
+  "expires_at": "2018-12-31T00:00:00Z",
+  "access_level": 40
+}

--- a/spec/gitlab/client/projects_spec.rb
+++ b/spec/gitlab/client/projects_spec.rb
@@ -188,12 +188,12 @@ describe Gitlab::Client do
   describe '.add_team_member' do
     before do
       stub_post('/projects/3/members', 'team_member')
-      @team_member = Gitlab.add_team_member(3, 1, 40, {expires_at: "2018-12-31"})
+      @team_member = Gitlab.add_team_member(3, 1, 40, expires_at: '2018-12-31')
     end
 
     it 'gets the correct resource' do
       expect(a_post('/projects/3/members')
-          .with(body: { user_id: '1', access_level: '40', expires_at: "2018-12-31" })).to have_been_made
+          .with(body: { user_id: '1', access_level: '40', expires_at: '2018-12-31' })).to have_been_made
     end
 
     it 'returns information about an added team member' do
@@ -205,12 +205,12 @@ describe Gitlab::Client do
   describe '.edit_team_member' do
     before do
       stub_put('/projects/3/members/1', 'team_member')
-      @team_member = Gitlab.edit_team_member(3, 1, 40, {expires_at: "2018-12-31"})
+      @team_member = Gitlab.edit_team_member(3, 1, 40, expires_at: '2018-12-31')
     end
 
     it 'gets the correct resource' do
       expect(a_put('/projects/3/members/1')
-          .with(body: { access_level: '40', expires_at: "2018-12-31" })).to have_been_made
+          .with(body: { access_level: '40', expires_at: '2018-12-31' })).to have_been_made
     end
 
     it 'returns information about an edited team member' do

--- a/spec/gitlab/client/projects_spec.rb
+++ b/spec/gitlab/client/projects_spec.rb
@@ -188,32 +188,34 @@ describe Gitlab::Client do
   describe '.add_team_member' do
     before do
       stub_post('/projects/3/members', 'team_member')
-      @team_member = Gitlab.add_team_member(3, 1, 40)
+      @team_member = Gitlab.add_team_member(3, 1, 40, {expires_at: "2018-12-31"})
     end
 
     it 'gets the correct resource' do
       expect(a_post('/projects/3/members')
-          .with(body: { user_id: '1', access_level: '40' })).to have_been_made
+          .with(body: { user_id: '1', access_level: '40', expires_at: "2018-12-31" })).to have_been_made
     end
 
     it 'returns information about an added team member' do
       expect(@team_member.name).to eq('John Smith')
+      expect(@team_member.expires_at).to eq('2018-12-31T00:00:00Z')
     end
   end
 
   describe '.edit_team_member' do
     before do
       stub_put('/projects/3/members/1', 'team_member')
-      @team_member = Gitlab.edit_team_member(3, 1, 40)
+      @team_member = Gitlab.edit_team_member(3, 1, 40, {expires_at: "2018-12-31"})
     end
 
     it 'gets the correct resource' do
       expect(a_put('/projects/3/members/1')
-          .with(body: { access_level: '40' })).to have_been_made
+          .with(body: { access_level: '40', expires_at: "2018-12-31" })).to have_been_made
     end
 
     it 'returns information about an edited team member' do
       expect(@team_member.name).to eq('John Smith')
+      expect(@team_member.expires_at).to eq('2018-12-31T00:00:00Z')
     end
   end
 


### PR DESCRIPTION
1. Added `expires_at` as an option to adding and editing team members to a project
2. Updated `fixtures/team_member.json` to current schema

Closes #408 