### PR TITLE
Create label with 6-digit hex color without extra escaping

### DIFF
--- a/lib/gitlab/cli_helpers.rb
+++ b/lib/gitlab/cli_helpers.rb
@@ -231,9 +231,16 @@ class Gitlab::CLI
       hash
     end
 
+    # Check if arg is a color in 6-digit hex notation with leading '#' sign
+    def hex_color?(arg)
+      pattern = /\A#\h{6}\Z/
+
+      pattern.match(arg)
+    end
+
     # YAML::load on a single argument
     def yaml_load(arg)
-      YAML.safe_load(arg)
+      hex_color?(arg) ? arg : YAML.safe_load(arg)
     rescue Psych::SyntaxError
       raise "Error: Argument is not valid YAML syntax: #{arg}"
     end

--- a/spec/gitlab/cli_spec.rb
+++ b/spec/gitlab/cli_spec.rb
@@ -62,6 +62,18 @@ describe Gitlab::CLI do
         expect(@output).to include('Jack Smith')
       end
     end
+
+    context 'when command is create_label' do
+      before do
+        stub_post('/projects/Project/labels', 'label')
+        args = ['Project', 'Backlog', '#DD10AA']
+        @output = capture_output { described_class.run('create_label', args) }
+      end
+
+      it 'shows executed command' do
+        expect(@output).to include('Gitlab.create_label Project, Backlog, #DD10AA')
+      end
+    end
   end
 
   describe '.start' do


### PR DESCRIPTION
Fixes https://github.com/NARKOZ/gitlab/issues/376

If arg is a color in 6-digit hex notation with leading '#' sign then YAML.safe_load is not applied on it.

Without fix, it is possible to create label with hex color, but it needs extra escaping
```
gitlab create_label mygroup/scb abc '"#001100"'
```