### PR TITLE
Add support for Version API

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -41,6 +41,7 @@ module Gitlab
     include Tags
     include Todos
     include Users
+    include Versions
 
     # Text representation of the client, masking private token.
     #

--- a/lib/gitlab/client/versions.rb
+++ b/lib/gitlab/client/versions.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Gitlab::Client
+  # Defines methods related to version
+  # @see https://docs.gitlab.com/ce/api/version.html
+  module Versions
+    # Returns server version.
+    # @see https://docs.gitlab.com/ce/api/version.html
+    #
+    # @example
+    #   Gitlab.version
+    #
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def version
+      get('/version')
+    end
+  end
+end

--- a/spec/fixtures/version.json
+++ b/spec/fixtures/version.json
@@ -1,0 +1,4 @@
+{
+  "version": "8.13.0-pre",
+  "revision": "4e963fe"
+}

--- a/spec/gitlab/client/versions_spec.rb
+++ b/spec/gitlab/client/versions_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Gitlab::Client do
+  describe '.version' do
+    before do
+      stub_get('/version', 'version')
+    end
+
+    let!(:version) { Gitlab.version }
+
+    it 'gets the correct resource' do
+      expect(a_get('/version')).to have_been_made
+    end
+
+    it 'returns information about gitlab server' do
+      expect(version.version).to eq('8.13.0-pre')
+      expect(version.revision).to eq('4e963fe')
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for the Version api that was added in GitLab 8.13.

https://docs.gitlab.com/ce/api/version.html