### PR TITLE
Added Cherry pick a commit client method

### DIFF
--- a/lib/gitlab/client/commits.rb
+++ b/lib/gitlab/client/commits.rb
@@ -35,6 +35,19 @@ class Gitlab::Client
     end
     alias repo_commit commit
 
+    # Cherry picks a commit to a given branch.
+    #
+    # @example
+    #   Gitlab.cherry_pick_commit(42, '6104942438c14ec7bd21c6cd5bd995272b3faff6', 'master')
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [String] sha The commit hash or name of a repository branch or tag
+    # @param  [String] branch The name of the branch
+    # @return [Gitlab::ObjectifiedHash]
+    def cherry_pick_commit(project, sha, branch)
+      post("/projects/#{url_encode project}/repository/commits/#{sha}/cherry_pick", body: {branch: branch})
+    end
+
     # Get the diff of a commit in a project.
     #
     # @example

--- a/lib/gitlab/client/commits.rb
+++ b/lib/gitlab/client/commits.rb
@@ -45,7 +45,7 @@ class Gitlab::Client
     # @param  [String] branch The name of the branch
     # @return [Gitlab::ObjectifiedHash]
     def cherry_pick_commit(project, sha, branch)
-      post("/projects/#{url_encode project}/repository/commits/#{sha}/cherry_pick", body: {branch: branch})
+      post("/projects/#{url_encode project}/repository/commits/#{sha}/cherry_pick", body: { branch: branch })
     end
 
     # Get the diff of a commit in a project.

--- a/spec/gitlab/client/commits_spec.rb
+++ b/spec/gitlab/client/commits_spec.rb
@@ -48,14 +48,14 @@ describe Gitlab::Client do
 
   describe '.cherry_pick_commit' do
     before do
-      stub_post('/projects/3/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/cherry_pick', 'project_commit').with(body: {branch: 'master'})
+      stub_post('/projects/3/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/cherry_pick', 'project_commit').with(body: { branch: 'master' })
       @cherry_pick_commit = Gitlab.cherry_pick_commit(3, '6104942438c14ec7bd21c6cd5bd995272b3faff6', 'master')
     end
 
     it 'gets the correct resource' do
       expect(a_post('/projects/3/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/cherry_pick')
-        .with(body: {branch: 'master'})
-        ).to have_been_made
+        .with(body: { branch: 'master' }))
+        .to have_been_made
     end
 
     it 'returns the correct response' do

--- a/spec/gitlab/client/commits_spec.rb
+++ b/spec/gitlab/client/commits_spec.rb
@@ -46,6 +46,24 @@ describe Gitlab::Client do
     end
   end
 
+  describe '.cherry_pick_commit' do
+    before do
+      stub_post('/projects/3/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/cherry_pick', 'project_commit').with(body: {branch: 'master'})
+      @cherry_pick_commit = Gitlab.cherry_pick_commit(3, '6104942438c14ec7bd21c6cd5bd995272b3faff6', 'master')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_post('/projects/3/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/cherry_pick')
+        .with(body: {branch: 'master'})
+        ).to have_been_made
+    end
+
+    it 'returns the correct response' do
+      expect(@cherry_pick_commit).to be_a Gitlab::ObjectifiedHash
+      expect(@cherry_pick_commit.id).to eq('6104942438c14ec7bd21c6cd5bd995272b3faff6')
+    end
+  end
+
   describe '.commit_diff' do
     before do
       stub_get('/projects/3/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/diff', 'project_commit_diff')


### PR DESCRIPTION
Added method to cherry pick a commit

`Gitlab.cherry_pick_commit(project_id, sha, branch)`

closes #423 