### PR TITLE
Add 'Participants on issues' endpoint

### DIFF
--- a/lib/gitlab/client/issues.rb
+++ b/lib/gitlab/client/issues.rb
@@ -205,5 +205,16 @@ class Gitlab::Client
     def time_stats_for_issue(project, id)
       get("/projects/#{url_encode project}/issues/#{id}/time_stats")
     end
+
+    # Get participants on issue
+    #
+    # @example
+    #   @gitlab.participants_on_issue(3, 42)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of an issue.
+    def participants_on_issue(project, id)
+      get("/projects/#{url_encode project}/issues/#{id}/participants")
+    end
   end
 end

--- a/spec/fixtures/participants_on_issue.json
+++ b/spec/fixtures/participants_on_issue.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": 1,
+    "name": "John Doe1",
+    "username": "user1",
+    "state": "active",
+    "avatar_url": "http://www.gravatar.com/avatar/c922747a93b40d1ea88262bf1aebee62?s=80&d=identicon",
+    "web_url": "http://localhost/user1"
+  },
+  {
+    "id": 5,
+    "name": "John Doe5",
+    "username": "user5",
+    "state": "active",
+    "avatar_url": "http://www.gravatar.com/avatar/4aea8cf834ed91844a2da4ff7ae6b491?s=80&d=identicon",
+    "web_url": "http://localhost/user5"
+  }
+]

--- a/spec/gitlab/client/issues_spec.rb
+++ b/spec/gitlab/client/issues_spec.rb
@@ -284,4 +284,20 @@ describe Gitlab::Client do
       expect(@issue.assignee.name).to eq('Jack Smith')
     end
   end
+
+  describe '.issue_participants' do
+    before do
+      stub_get('/projects/3/issues/33/participants', 'issue')
+      @issue = Gitlab.participants_on_issue(3, 33)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/issues/33/participants')).to have_been_made
+    end
+
+    it 'returns information about the participants on issue' do
+      expect(@issue.project_id).to eq(3)
+      expect(@issue.assignee.name).to eq('Jack Smith')
+    end
+  end
 end

--- a/spec/gitlab/client/issues_spec.rb
+++ b/spec/gitlab/client/issues_spec.rb
@@ -285,10 +285,10 @@ describe Gitlab::Client do
     end
   end
 
-  describe '.issue_participants' do
+  describe '.participants_on_issue' do
     before do
-      stub_get('/projects/3/issues/33/participants', 'issue')
-      @issue = Gitlab.participants_on_issue(3, 33)
+      stub_get('/projects/3/issues/33/participants', 'participants_on_issue')
+      @participants = Gitlab.participants_on_issue(3, 33)
     end
 
     it 'gets the correct resource' do
@@ -296,8 +296,8 @@ describe Gitlab::Client do
     end
 
     it 'returns information about the participants on issue' do
-      expect(@issue.project_id).to eq(3)
-      expect(@issue.assignee.name).to eq('Jack Smith')
+      expect(@participants.first.name).to eq('John Doe1')
+      expect(@participants.size).to eq(2)
     end
   end
 end


### PR DESCRIPTION
Adds missing 'Participants on issues' endpoint and spec.

Documentation reference: https://docs.gitlab.com/ce/api/issues.html#participants-on-issues