### PR TITLE
Allow passing variables when creating a pipeline

### DIFF
--- a/lib/gitlab/client/pipelines.rb
+++ b/lib/gitlab/client/pipelines.rb
@@ -38,9 +38,20 @@ class Gitlab::Client
     #
     # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] ref Reference to commit.
+    # @param  [Hash] variables Variables passed to pipelines
     # @return [Gitlab::ObjectifiedHash] The pipelines changes.
-    def create_pipeline(project, ref)
-      post("/projects/#{url_encode project}/pipeline?ref=#{ref}")
+    def create_pipeline(project, ref, variables = {})
+      body = {}
+
+      # This mapping is necessary, cause the API expects an array with objects (with `key` and `value` keys)
+      # See: https://docs.gitlab.com/ee/api/pipelines.html#create-a-new-pipeline
+      body[:variables] = variables.map { |(key, value)| { key: key, value: value } } if variables.any?
+
+      post(
+        "/projects/#{url_encode project}/pipeline",
+        query: { ref: ref },
+        body: body
+      )
     end
 
     # Cancels a pipeline.

--- a/spec/gitlab/client/pipelines_spec.rb
+++ b/spec/gitlab/client/pipelines_spec.rb
@@ -39,13 +39,15 @@ describe Gitlab::Client do
   end
 
   describe '.create_pipeline' do
+    let(:pipeline_path) { '/projects/3/pipeline?ref=master' }
+
     before do
-      stub_post('/projects/3/pipeline?ref=master', 'pipeline_create')
+      stub_post(pipeline_path, 'pipeline_create')
       @pipeline_create = Gitlab.create_pipeline(3, 'master')
     end
 
     it 'gets the correct resource' do
-      expect(a_post('/projects/3/pipeline?ref=master')).to have_been_made
+      expect(a_post(pipeline_path)).to have_been_made
     end
 
     it 'returns a single pipeline' do
@@ -54,6 +56,19 @@ describe Gitlab::Client do
 
     it 'returns information about a pipeline' do
       expect(@pipeline_create.user.name).to eq('Administrator')
+    end
+
+    context 'when variables are passed' do
+      before do
+        stub_post(pipeline_path, 'pipeline_create')
+        variables = { 'VAR1' => 'value', VAR2: :value }
+        @pipeline_create = Gitlab.create_pipeline(3, 'master', variables)
+      end
+
+      it 'calls with the correct body' do
+        expected_body = 'variables[][key]=VAR1&variables[][value]=value&variables[][key]=VAR2&variables[][value]=value'
+        expect(a_post(pipeline_path).with(body: expected_body)).to have_been_made
+      end
     end
   end
 


### PR DESCRIPTION
@NARKOZ as mentioned in #401, here is a new MR with the updated code. :)

Unfortunately the Gitlab API does not allow an empty `variables` parameter, so it is necessary to add this `if variables.any?` check... Maybe you know a better way how to ensure that the `variables` parameter is only set when at least one variable is passed?