### PR TITLE
Fixes a bug in handling "Spam detected" messages

### DIFF
--- a/lib/gitlab/error.rb
+++ b/lib/gitlab/error.rb
@@ -59,7 +59,7 @@ module Gitlab
         case message
         when Gitlab::ObjectifiedHash
           message.to_h.sort.map do |key, val|
-            "'#{key}' #{(val.is_a?(Hash) ? val.sort.map { |k, v| "(#{k}: #{v.join(' ')})" } : val).join(' ')}"
+            "'#{key}' #{(val.is_a?(Hash) ? val.sort.map { |k, v| "(#{k}: #{v.join(' ')})" } : [val].flatten).join(' ')}"
           end.join(', ')
         when Array
           message.join(' ')

--- a/spec/gitlab/error_spec.rb
+++ b/spec/gitlab/error_spec.rb
@@ -25,7 +25,7 @@ describe Gitlab::Error::ResponseError do
     { code: 401, parsed_response: Gitlab::ObjectifiedHash.new(error: 'Displayed error') },
     { code: 500, parsed_response: Gitlab::ObjectifiedHash.new(embed_entity: { foo: ['bar'], sna: ['fu'] }, password: ['too short']) },
     { code: 403, parsed_response: Array.new(['First message.', 'Second message.']) },
-    { code: 400, parsed_response: Gitlab::ObjectifiedHash.new(message: { error: 'Spam detected' } ) }
+    { code: 400, parsed_response: Gitlab::ObjectifiedHash.new(message: { error: 'Spam detected' }) }
 
   ].each_with_index do |data, index|
     it 'returns the expected message' do

--- a/spec/gitlab/error_spec.rb
+++ b/spec/gitlab/error_spec.rb
@@ -13,7 +13,8 @@ describe Gitlab::Error::ResponseError do
       %r{Server responded with code \d+, message: Displayed error_description. Request URI: https://gitlab.com/api/v3/foo},
       %r{Server responded with code \d+, message: Displayed error. Request URI: https://gitlab.com/api/v3/foo},
       %r{Server responded with code \d+, message: 'embed_entity' \(foo: bar\) \(sna: fu\), 'password' too short. Request URI: https://gitlab.com/api/v3/foo},
-      %r{Server responded with code \d+, message: First message. Second message.. Request URI: https://gitlab.com/api/v3/foo}
+      %r{Server responded with code \d+, message: First message. Second message.. Request URI: https://gitlab.com/api/v3/foo},
+      %r{Server responded with code \d+, message: 'error' Spam detected. Request URI: https://gitlab.com/api/v3/foo}
     ]
   end
 
@@ -23,7 +24,9 @@ describe Gitlab::Error::ResponseError do
     { code: 404, parsed_response: Gitlab::ObjectifiedHash.new(error_description: 'Displayed error_description', error: 'also will not be displayed') },
     { code: 401, parsed_response: Gitlab::ObjectifiedHash.new(error: 'Displayed error') },
     { code: 500, parsed_response: Gitlab::ObjectifiedHash.new(embed_entity: { foo: ['bar'], sna: ['fu'] }, password: ['too short']) },
-    { code: 403, parsed_response: Array.new(['First message.', 'Second message.']) }
+    { code: 403, parsed_response: Array.new(['First message.', 'Second message.']) },
+    { code: 400, parsed_response: Gitlab::ObjectifiedHash.new(message: { error: 'Spam detected' } ) }
+
   ].each_with_index do |data, index|
     it 'returns the expected message' do
       response_double = double(**data, request: @request_double)


### PR DESCRIPTION
This fixes `error.rb` so that it handles error responses created by Gitlab.com's spam protection
correctly. The error message is nested in a slightly off way (I believe
this is a bug), causing the error message formatting code to blow up as
it tries to join a string.

I admit doing `[val].flatten` feels a bit hackish, but the alternative (nested ternaries) is also not pretty. :)