### PR TITLE
Deleting a project milestone

### DIFF
--- a/lib/gitlab/client/milestones.rb
+++ b/lib/gitlab/client/milestones.rb
@@ -98,7 +98,7 @@ class Gitlab::Client
     #
     # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of a milestone.
-    # @return [void] This API call returns an empty response body.
+    # @return [nil] This API call returns an empty response body.
     def delete_milestone(project, id)
       delete("/projects/#{url_encode project}/milestones/#{id}")
     end

--- a/lib/gitlab/client/milestones.rb
+++ b/lib/gitlab/client/milestones.rb
@@ -90,5 +90,17 @@ class Gitlab::Client
     def edit_milestone(project, id, options = {})
       put("/projects/#{url_encode project}/milestones/#{id}", body: options)
     end
+
+    # Delete a project milestone.
+    #
+    # @example
+    #   Gitlab.delete_milestone(5, 2)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of a milestone.
+    # @return [void] This API call returns an empty response body.
+    def delete_milestone(project, id)
+      delete("/projects/#{url_encode project}/milestones/#{id}")
+    end
   end
 end

--- a/spec/gitlab/client/milestones_spec.rb
+++ b/spec/gitlab/client/milestones_spec.rb
@@ -97,4 +97,15 @@ describe Gitlab::Client do
       expect(@milestone.project_id).to eq(3)
     end
   end
+
+  describe '.delete_milestone' do
+    before do
+      stub_delete('/projects/3/milestones/33', 'empty')
+      @milestone = Gitlab.delete_milestone(3, 33)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_delete('/projects/3/milestones/33')).to have_been_made
+    end
+  end
 end


### PR DESCRIPTION
`Gitlab.delete_milestone(project, milestone_id)`

Closes #431 