### PR TITLE
Deleting all merged branches in a project

### DIFF
--- a/lib/gitlab/client/branches.rb
+++ b/lib/gitlab/client/branches.rb
@@ -94,5 +94,17 @@ class Gitlab::Client
       delete("/projects/#{url_encode project}/repository/branches/#{url_encode branch}")
     end
     alias repo_delete_branch delete_branch
+
+    # Delete all branches that are merged into the project default branch. Protected branches will not be deleted as part of this operation.
+    #
+    # @example
+    #   Gitlab.delete_merged_branches(3)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @return [nil] This API call returns an empty response body.
+    def delete_merged_branches(project)
+      delete("/projects/#{url_encode project}/repository/merged_branches")
+    end
+    alias repo_delete_merged_branches delete_merged_branches
   end
 end

--- a/spec/gitlab/client/branches_spec.rb
+++ b/spec/gitlab/client/branches_spec.rb
@@ -7,6 +7,9 @@ describe Gitlab::Client do
   it { is_expected.to respond_to :repo_branch }
   it { is_expected.to respond_to :repo_protect_branch }
   it { is_expected.to respond_to :repo_unprotect_branch }
+  it { is_expected.to respond_to :repo_create_branch }
+  it { is_expected.to respond_to :repo_delete_branch }
+  it { is_expected.to respond_to :repo_delete_merged_branches }
 
   describe '.branches' do
     before do
@@ -115,6 +118,17 @@ describe Gitlab::Client do
 
     it 'returns information about the deleted repository branch' do
       expect(@branch.branch_name).to eq('api')
+    end
+  end
+
+  describe '.delete_merged_branches' do
+    before do
+      stub_delete('/projects/3/repository/merged_branches', 'empty')
+      @branch = Gitlab.delete_merged_branches(3)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_delete('/projects/3/repository/merged_branches')).to have_been_made
     end
   end
 end


### PR DESCRIPTION
`Gitlab.delete_merged_branches(project)`

Closes #433 