### PR TITLE
Protected branches missing methods

### DIFF
--- a/lib/gitlab/client/branches.rb
+++ b/lib/gitlab/client/branches.rb
@@ -106,5 +106,30 @@ class Gitlab::Client
       delete("/projects/#{url_encode project}/repository/merged_branches")
     end
     alias repo_delete_merged_branches delete_merged_branches
+
+    # Gets a list of protected branches from a project.
+    #
+    # @example
+    #   Gitlab.protected_branches(42)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def protected_branches(project)
+      get("/projects/#{url_encode project}/protected_branches")
+    end
+    alias repo_protected_branches protected_branches
+
+    # Gets a single protected branch or wildcard protected branch
+    #
+    # @example
+    #   Gitlab.protected_branch(3, 'api')
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [String] The name of the branch or wildcard
+    # @return [Gitlab::ObjectifiedHash]
+    def protected_branch(project, branch)
+      get("/projects/#{url_encode project}/protected_branches/#{url_encode branch}")
+    end
+    alias repo_protected_branch protected_branch
   end
 end

--- a/spec/fixtures/protected_branch.json
+++ b/spec/fixtures/protected_branch.json
@@ -1,0 +1,15 @@
+{
+  "name": "master",
+  "push_access_levels": [
+    {
+      "access_level": 40,
+      "access_level_description": "Maintainers"
+    }
+  ],
+  "merge_access_levels": [
+    {
+      "access_level": 40,
+      "access_level_description": "Maintainers"
+    }
+  ]
+}

--- a/spec/fixtures/protected_branches.json
+++ b/spec/fixtures/protected_branches.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "master",
+    "push_access_levels": [
+      {
+        "access_level": 40,
+        "access_level_description": "Maintainers"
+      }
+    ],
+    "merge_access_levels": [
+      {
+        "access_level": 40,
+        "access_level_description": "Maintainers"
+      }
+    ]
+  }
+]

--- a/spec/gitlab/client/branches_spec.rb
+++ b/spec/gitlab/client/branches_spec.rb
@@ -10,6 +10,8 @@ describe Gitlab::Client do
   it { is_expected.to respond_to :repo_create_branch }
   it { is_expected.to respond_to :repo_delete_branch }
   it { is_expected.to respond_to :repo_delete_merged_branches }
+  it { is_expected.to respond_to :repo_protected_branches }
+  it { is_expected.to respond_to :repo_protected_branch }
 
   describe '.branches' do
     before do
@@ -129,6 +131,40 @@ describe Gitlab::Client do
 
     it 'gets the correct resource' do
       expect(a_delete('/projects/3/repository/merged_branches')).to have_been_made
+    end
+  end
+
+  describe '.protected_branches' do
+    before do
+      stub_get('/projects/3/protected_branches', 'protected_branches')
+      @branches = Gitlab.protected_branches(3)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/protected_branches')).to have_been_made
+    end
+
+    it 'returns information about the protected_branches' do
+      expect(@branches).to be_a Gitlab::PaginatedResponse
+      expect(@branches.first.merge_access_levels).to be_a Array
+      expect(@branches.first.push_access_levels).to be_a Array
+    end
+  end
+
+  describe '.protected_branch' do
+    before do
+      stub_get('/projects/3/protected_branches/master', 'protected_branch')
+      @branch = Gitlab.protected_branch(3, 'master')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/protected_branches/master')).to have_been_made
+    end
+
+    it 'returns correct information about the protected_branch' do
+      expect(@branch.name).to eq 'master'
+      expect(@branch.merge_access_levels).to be_a Array
+      expect(@branch.push_access_levels).to be_a Array
     end
   end
 end


### PR DESCRIPTION
`Gitlab.protected_branches(project)`
`Gitlab.protected_branch(project, branch)`

Closes #434 