### PR TITLE
Added BroadcastMessages API

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -8,6 +8,7 @@ module Gitlab
     # Please keep in alphabetical order
     include AccessRequests
     include AwardEmojis
+    include BroadcastMessages
     include Boards
     include Branches
     include BuildVariables

--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -8,9 +8,9 @@ module Gitlab
     # Please keep in alphabetical order
     include AccessRequests
     include AwardEmojis
-    include BroadcastMessages
     include Boards
     include Branches
+    include BroadcastMessages
     include BuildVariables
     include Builds
     include Commits

--- a/lib/gitlab/client/broadcast_messages.rb
+++ b/lib/gitlab/client/broadcast_messages.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class Gitlab::Client
+  # Defines methods related to broadcast messages(only accessible to administrators).
+  # @see https://docs.gitlab.com/ce/api/broadcast_messages.html
+  module BroadcastMessages
+    # Get all broadcast messages
+    #
+    # @example
+    #   Gitlab.broadcast_messages
+    #
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def broadcast_messages
+      get('/broadcast_messages')
+    end
+
+    # Get a specific broadcast message
+    #
+    # @example
+    #   Gitlab.broadcast_message(3)
+    #
+    # @param  [Integer] id The ID of broadcast message
+    # @return [Gitlab::ObjectifiedHash]
+    def broadcast_message(id)
+      get("/broadcast_messages/#{id}")
+    end
+
+    # Create a broadcast message.
+    #
+    # @example
+    #   Gitlab.create_broadcast_message('Mayday')
+    #   Gitlab.create_broadcast_message('Mayday', {starts_at: Time.zone.now, ends_at: Time.zone.now + 30.minutes, color: '#cecece', font: '#FFFFFF'})
+    #
+    # @param  [String] message Message to display
+    # @param  [Hash] options A customizable set of options.
+    # @option options [DateTime] :starts_at(optional) Starting time (defaults to current time)
+    # @option options [DateTime] :ends_at(optional) Ending time (defaults to one hour from current time)
+    # @option options [String] :color(optional) Background color hex code
+    # @option options [String] :font(optional) Foreground color hex code
+    # @return [Gitlab::ObjectifiedHash] Information about created broadcast message.
+    def create_broadcast_message(message, options = {})
+      body = { message: message }.merge(options)
+      post('/broadcast_messages', body: body)
+    end
+
+    # Update a broadcast message
+    #
+    # @example
+    #   Gitlab.edit_broadcast_message(6, { message: 'No Mayday' })
+    #   Gitlab.edit_broadcast_message(6, { font: '#FEFEFE' })
+    #
+    # @param  [Integer] id The ID of a broadcast message
+    # @param  [Hash] options A customizable set of options.
+    # @option options [String] :message(optional) Message to display
+    # @option options [DateTime] :starts_at(optional) Starting time (defaults to current time)
+    # @option options [DateTime] :ends_at(optional) Ending time (defaults to one hour from current time)
+    # @option options [String] :color(optional) Background color hex code
+    # @option options [String] :font(optional) Foreground color hex code
+    # @return [Gitlab::ObjectifiedHash] Information about updated broadcast message.
+    def edit_broadcast_message(id, options = {})
+      put("/broadcast_messages/#{id}", body: options)
+    end
+
+    # Delete a broadcast message.
+    #
+    # @example
+    #   Gitlab.delete_broadcast_message(3)
+    #
+    # @param  [Integer] id The ID of a broadcast message.
+    # @return [nil] This API call returns an empty response body.
+    def delete_broadcast_message(id)
+      delete("/broadcast_messages/#{id}")
+    end
+  end
+end

--- a/spec/fixtures/broadcast_message.json
+++ b/spec/fixtures/broadcast_message.json
@@ -1,0 +1,9 @@
+{
+    "message":"Deploy in progress",
+    "starts_at":"2016-08-24T23:21:16.078Z",
+    "ends_at":"2016-08-26T23:21:16.080Z",
+    "color":"#cecece",
+    "font":"#FFFFFF",
+    "id":1,
+    "active":false
+}

--- a/spec/fixtures/broadcast_messages.json
+++ b/spec/fixtures/broadcast_messages.json
@@ -1,0 +1,11 @@
+[
+    {
+        "message":"Example broadcast message",
+        "starts_at":"2016-08-24T23:21:16.078Z",
+        "ends_at":"2016-08-26T23:21:16.080Z",
+        "color":"#E75E40",
+        "font":"#FFFFFF",
+        "id":1,
+        "active": false
+    }
+]

--- a/spec/gitlab/client/broadcast_messages_spec.rb
+++ b/spec/gitlab/client/broadcast_messages_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Gitlab::Client do
+  describe '.broadcast_messages' do
+    before do
+      stub_get('/broadcast_messages', 'broadcast_messages')
+      @broadcast_messages = Gitlab.broadcast_messages
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/broadcast_messages')).to have_been_made
+    end
+
+    it 'returns a paginated response of broadcast messages' do
+      expect(@broadcast_messages).to be_a Gitlab::PaginatedResponse
+    end
+  end
+
+  describe '.broadcast_message' do
+    before do
+      stub_get('/broadcast_messages/1', 'broadcast_message')
+      @broadcast_message = Gitlab.broadcast_message(1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/broadcast_messages/1')).to have_been_made
+    end
+
+    it 'returns correct information about the broadcast message' do
+      expect(@broadcast_message.id).to eq 1
+    end
+  end
+
+  describe '.create_broadcast_message' do
+    before do
+      stub_post('/broadcast_messages', 'broadcast_message')
+      @broadcast_message = Gitlab.create_broadcast_message('Deploy in progress', color: '#cecece')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_post('/broadcast_messages')
+        .with(body: { message: 'Deploy in progress', color: '#cecece' })).to have_been_made
+    end
+
+    it 'returns correct information about the broadcast message created' do
+      expect(@broadcast_message.message).to eq 'Deploy in progress'
+      expect(@broadcast_message.color).to eq '#cecece'
+    end
+  end
+
+  describe '.edit_broadcast_message' do
+    before do
+      stub_put('/broadcast_messages/1', 'broadcast_message')
+      @broadcast_message = Gitlab.edit_broadcast_message(1, font: '#FFFFFF')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_put('/broadcast_messages/1')
+        .with(body: { font: '#FFFFFF' })).to have_been_made
+    end
+
+    it 'returns correct information about the edited broadcast message' do
+      expect(@broadcast_message.font).to eq '#FFFFFF'
+    end
+  end
+
+  describe '.delete_broadcast_message' do
+    before do
+      stub_delete('/broadcast_messages/1', 'empty')
+      @broadcast_message = Gitlab.delete_broadcast_message(1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_delete('/broadcast_messages/1')).to have_been_made
+    end
+  end
+end


### PR DESCRIPTION
**Broadcast messages API**

`Gitlab.broadcast_messages`
`Gitlab.broadcast_message(id)`
`Gitlab.create_broadcast_message(message, options = {})`
`Gitlab.edit_broadcast_message(id, options = {})`
`Gitlab.delete_broadcast_message(id)`

Closes #436 