### PR TITLE
Revert "fix uri error when ref includes chinese like hotfix/崩溃"

### DIFF
--- a/lib/gitlab/client/pipelines.rb
+++ b/lib/gitlab/client/pipelines.rb
@@ -49,7 +49,7 @@ class Gitlab::Client
 
       post(
         "/projects/#{url_encode project}/pipeline",
-        query: { ref: url_encode(ref) },
+        query: { ref: ref },
         body: body
       )
     end


### PR DESCRIPTION
Reverts NARKOZ/gitlab#445

@NARKOZ 
I am sorry for the PR, HTTParty will encode query if we pass it in query parameter.
I was using 1.5.0 version, the error would occurs because we pass query in url.
can you help me revert the PR?
thanks
