### PR TITLE
Project Badges API

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -31,6 +31,7 @@ module Gitlab
     include PipelineSchedules
     include PipelineTriggers
     include Pipelines
+    include ProjectBadges
     include Projects
     include Repositories
     include RepositoryFiles

--- a/lib/gitlab/client/project_badges.rb
+++ b/lib/gitlab/client/project_badges.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+class Gitlab::Client
+  # Defines methods related to project badges.
+  # @see https://docs.gitlab.com/ee/api/project_badges.html
+  module ProjectBadges
+    # Gets a list of a projects badges and its group badges.
+    #
+    # @example
+    #   Gitlab.project_badges(5)
+    #
+    # @param [Integer, String] project The ID or name of a project.
+    # @return [Array<Gitlab::ObjectifiedHash>] List of all badges of a project
+    def project_badges(project)
+      get("/projects/#{url_encode project}/badges")
+    end
+
+    # Gets a badge of a project.
+    #
+    # @example
+    #   Gitlab.project_badge(5, 42)
+    #
+    # @param [Integer, String] project The ID or name of a project.
+    # @param [Integer] badge_id The badge ID.
+    # @return [Gitlab::ObjectifiedHash] Information about the requested badge
+    def project_badge(project, badge_id)
+      get("/projects/#{url_encode project}/badges/#{badge_id}")
+    end
+
+    # Adds a badge to a project.
+    #
+    # @example
+    #   Gitlab.add_project_badge(5, { link_url: 'https://abc.com/gitlab/gitlab-ce/commits/master', image_url: 'https://shields.io/my/badge1' })
+    #
+    # @param [Integer, String] project The ID or name of a project.
+    # @param  [Hash] options A customizable set of options.
+    # @option options [String] :link_url(required) URL of the badge link
+    # @option options [String] :image_url(required) URL of the badge image
+    # @return [Gitlab::ObjectifiedHash] Information about the added project badge.
+    def add_project_badge(project, options = {})
+      post("/projects/#{url_encode project}/badges", body: options)
+    end
+
+    # Updates a badge of a project..
+    #
+    # @example
+    #   Gitlab.edit_project_badge(5, 1, { link_url: 'https://abc.com/gitlab/gitlab-ce/commits/master', image_url: 'https://shields.io/my/badge1' })
+    #
+    # @param [Integer, String] project The ID or name of a project.
+    # @param [Integer] badge_id The badge ID.
+    # @param [Hash] options A customizable set of options.
+    # @option options [String] :link_url(optional) URL of the badge link
+    # @option options [String] :image_url(optional) URL of the badge image
+    # @return [Gitlab::ObjectifiedHash] Information about the updated project badge.
+    def edit_project_badge(project, badge_id, options = {})
+      put("/projects/#{url_encode project}/badges/#{badge_id}", body: options)
+    end
+
+    # Removes a badge from a project. Only projects badges will be removed by using this endpoint.
+    #
+    # @example
+    #   Gitlab.remove_project_badge(5, 42)
+    #
+    # @param [Integer, String] project The ID or name of a project.
+    # @param [Integer] badge_id The badge ID.
+    # @return [nil] This API call returns an empty response body.
+    def remove_project_badge(project, badge_id)
+      delete("/projects/#{url_encode project}/badges/#{badge_id}")
+    end
+
+    # Preview a badge from a project.
+    #
+    # @example
+    #   Gitlab.preview_project_badge(3, 'https://abc.com/gitlab/gitlab-ce/commits/master', 'https://shields.io/my/badge1')
+    #
+    # @param [Integer, String] project The ID or name of a project.
+    # @param [String] :link_url URL of the badge link
+    # @param [String] :image_url URL of the badge image
+    # @return [Gitlab::ObjectifiedHash] Returns how the link_url and image_url final URLs would be after resolving the placeholder interpolation.
+    def preview_project_badge(project, link_url, image_url)
+      query = { link_url: link_url, image_url: image_url }
+      get("/projects/#{url_encode project}/badges/render", query: query)
+    end
+  end
+end

--- a/spec/fixtures/preview_project_badge.json
+++ b/spec/fixtures/preview_project_badge.json
@@ -1,0 +1,6 @@
+{
+  "link_url": "http://example.com/ci_status.svg?project=%{project_path}&ref=%{default_branch}",
+  "image_url": "https://shields.io/my/badge",
+  "rendered_link_url": "http://example.com/ci_status.svg?project=example-org/example-project&ref=master",
+  "rendered_image_url": "https://shields.io/my/badge"
+}

--- a/spec/fixtures/project_badge.json
+++ b/spec/fixtures/project_badge.json
@@ -1,0 +1,8 @@
+{
+  "id": 1,
+  "link_url": "http://example.com/ci_status.svg?project=%{project_path}&ref=%{default_branch}",
+  "image_url": "https://shields.io/my/badge",
+  "rendered_link_url": "http://example.com/ci_status.svg?project=example-org/example-project&ref=master",
+  "rendered_image_url": "https://shields.io/my/badge",
+  "kind": "project"
+}

--- a/spec/fixtures/project_badges.json
+++ b/spec/fixtures/project_badges.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": 1,
+    "link_url": "http://example.com/ci_status.svg?project=%{project_path}&ref=%{default_branch}",
+    "image_url": "https://shields.io/my/badge",
+    "rendered_link_url": "http://example.com/ci_status.svg?project=example-org/example-project&ref=master",
+    "rendered_image_url": "https://shields.io/my/badge",
+    "kind": "project"
+  },
+  {
+    "id": 2,
+    "link_url": "http://example.com/ci_status.svg?project=%{project_path}&ref=%{default_branch}",
+    "image_url": "https://shields.io/my/badge",
+    "rendered_link_url": "http://example.com/ci_status.svg?project=example-org/example-project&ref=master",
+    "rendered_image_url": "https://shields.io/my/badge",
+    "kind": "group"
+  }
+]

--- a/spec/gitlab/client/project_badges_spec.rb
+++ b/spec/gitlab/client/project_badges_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/FormatStringToken
+
+require 'spec_helper'
+
+describe Gitlab::Client do
+  describe '.project_badges' do
+    before do
+      stub_get('/projects/3/badges', 'project_badges')
+      @project_badges = Gitlab.project_badges(3)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/badges')).to have_been_made
+    end
+
+    it "returns a paginated response of project's badges" do
+      expect(@project_badges).to be_a Gitlab::PaginatedResponse
+    end
+  end
+
+  describe '.project_badge' do
+    before do
+      stub_get('/projects/3/badges/3', 'project_badge')
+      @project_badge = Gitlab.project_badge(3, 3)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/badges/3')).to have_been_made
+    end
+
+    it 'returns information about a badge' do
+      expect(@project_badge.id).to eq(1)
+    end
+  end
+
+  describe '.add_project_badge' do
+    before do
+      stub_post('/projects/3/badges', 'project_badge')
+      @project_badge = Gitlab.add_project_badge(3, link_url: 'http://example.com/ci_status.svg?project=%{project_path}&ref=%{default_branch}', image_url: 'https://shields.io/my/badge')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_post('/projects/3/badges')
+        .with(body: { link_url: 'http://example.com/ci_status.svg?project=%{project_path}&ref=%{default_branch}', image_url: 'https://shields.io/my/badge' })).to have_been_made
+    end
+
+    it 'returns information about an added project badge' do
+      expect(@project_badge.link_url).to eq('http://example.com/ci_status.svg?project=%{project_path}&ref=%{default_branch}')
+      expect(@project_badge.image_url).to eq('https://shields.io/my/badge')
+    end
+  end
+
+  describe '.edit_project_badge' do
+    before do
+      stub_put('/projects/3/badges/1', 'project_badge')
+      @project_badge = Gitlab.edit_project_badge(3, 1, link_url: 'http://example.com/ci_status.svg?project=%{project_path}&ref=%{default_branch}', image_url: 'https://shields.io/my/badge')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_put('/projects/3/badges/1')
+        .with(body: { link_url: 'http://example.com/ci_status.svg?project=%{project_path}&ref=%{default_branch}', image_url: 'https://shields.io/my/badge' })).to have_been_made
+    end
+
+    it 'returns information about an edited project badge' do
+      expect(@project_badge.link_url).to eq('http://example.com/ci_status.svg?project=%{project_path}&ref=%{default_branch}')
+      expect(@project_badge.image_url).to eq('https://shields.io/my/badge')
+    end
+  end
+
+  describe '.remove_project_badge' do
+    before do
+      stub_delete('/projects/3/badges/3', 'empty')
+      @project_badge = Gitlab.remove_project_badge(3, 3)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_delete('/projects/3/badges/3')).to have_been_made
+    end
+  end
+
+  describe '.preview_project_badge' do
+    before do
+      stub_get('/projects/3/badges/render?image_url=https://shields.io/my/badge&link_url=http://example.com/ci_status.svg?project=%25%7Bproject_path%7D%26ref=%25%7Bdefault_branch%7D', 'preview_project_badge')
+      @preview_project_badge = Gitlab.preview_project_badge(3, 'http://example.com/ci_status.svg?project=%{project_path}&ref=%{default_branch}', 'https://shields.io/my/badge')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/badges/render?image_url=https://shields.io/my/badge&link_url=http://example.com/ci_status.svg?project=%25%7Bproject_path%7D%26ref=%25%7Bdefault_branch%7D')).to have_been_made
+    end
+
+    it 'returns information about the rendered values of a badge' do
+      expect(@preview_project_badge.link_url).to eq('http://example.com/ci_status.svg?project=%{project_path}&ref=%{default_branch}')
+      expect(@preview_project_badge.image_url).to eq('https://shields.io/my/badge')
+    end
+  end
+end
+# rubocop:enable Style/FormatStringToken


### PR DESCRIPTION
**Project Badges API**:

```rb
  Gitlab.project_badges(project)
  Gitlab.project_badge(project, badge_id)
  Gitlab.add_project_badge(project, options = {})
  Gitlab.edit_project_badge(project, badge_id, options = {})
  Gitlab.remove_project_badge(project, badge_id)
  Gitlab.preview_project_badge(project, link_url, image_url)
```

closes #402 