### PR TITLE
Use correct URL for edit_merge_request_approvers

### DIFF
--- a/lib/gitlab/client/merge_request_approvals.rb
+++ b/lib/gitlab/client/merge_request_approvals.rb
@@ -80,7 +80,7 @@ class Gitlab::Client
     # @option options [Array] :approver_group_ids(optional) An array of Group IDs whose members can approve MRs
     # @return [Gitlab::ObjectifiedHash] MR approval configuration information about the project
     def edit_merge_request_approvers(project, merge_request, options = {})
-      put("/projects/#{url_encode project}/merge_requests/#{merge_request}/approvals", body: options)
+      put("/projects/#{url_encode project}/merge_requests/#{merge_request}/approvers", body: options)
     end
 
     # Approve a merge request

--- a/spec/gitlab/client/merge_request_approvals_spec.rb
+++ b/spec/gitlab/client/merge_request_approvals_spec.rb
@@ -97,13 +97,13 @@ describe Gitlab::Client do
   describe '.edit_merge_request_approvers' do
     before do
       body = { "approver_ids": ['1'], "approver_group_ids": ['5'] }
-      stub_put('/projects/1/merge_requests/5/approvals', 'merge_request_approvals').with(body: body)
+      stub_put('/projects/1/merge_requests/5/approvers', 'merge_request_approvals').with(body: body)
       @merge_request_approvals = Gitlab.edit_merge_request_approvers(1, 5, approver_ids: [1], approver_group_ids: [5])
     end
 
     it 'gets the correct resource' do
       body = { "approver_ids": ['1'], "approver_group_ids": ['5'] }
-      expect(a_put('/projects/1/merge_requests/5/approvals')
+      expect(a_put('/projects/1/merge_requests/5/approvers')
         .with(body: body)).to have_been_made
     end
 


### PR DESCRIPTION
Updates URL to match [docs](https://docs.gitlab.com/ee/api/merge_request_approvals.html#change-allowed-approvers-for-merge-request).