### PR TITLE
adds the resource label events api to the gitlab client

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -37,6 +37,7 @@ module Gitlab
     include Repositories
     include RepositoryFiles
     include RepositorySubmodules
+    include ResourceLabelEvents
     include Runners
     include Services
     include Sidekiq

--- a/lib/gitlab/client/resource_label_events.rb
+++ b/lib/gitlab/client/resource_label_events.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+class Gitlab::Client
+  # Defines methods related to resource label events.
+  # @see https://docs.gitlab.com/ee/api/resource_label_events.html
+  module ResourceLabelEvents
+    # Gets a list of all label events for a single issue.
+    #
+    # @example
+    #   Gitlab.issue_label_events(5, 42)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] issue_iid The IID of an issue.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def issue_label_events(project, issue_iid)
+      get("/projects/#{url_encode project}/issues/#{issue_iid}/resource_label_events")
+    end
+
+    # Returns a single label event for a specific project issue
+    #
+    # @example
+    #   Gitlab.issue_label_event(5, 42, 1)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] issue_iid The IID of an issue.
+    # @param  [Integer] id The ID of a label event.
+    # @return Gitlab::ObjectifiedHash
+    def issue_label_event(project, issue_iid, id)
+      get("/projects/#{url_encode project}/issues/#{issue_iid}/resource_label_events/#{id}")
+    end
+
+    # Gets a list of all label events for a single epic.
+    #
+    # @example
+    #   Gitlab.epic_label_events(5, 42)
+    #
+    # @param  [Integer, String] group The ID or name of a group.
+    # @param  [Integer] epic_id The ID of an epic.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def epic_label_events(group, epic_id)
+      get("/groups/#{url_encode group}/epics/#{epic_id}/resource_label_events")
+    end
+
+    # Returns a single label event for a specific group epic
+    #
+    # @example
+    #   Gitlab.epic_label_event(5, 42, 1)
+    #
+    # @param  [Integer, String] group The ID or name of a group.
+    # @param  [Integer] epic_id The ID of an epic.
+    # @param  [Integer] id The ID of a label event.
+    # @return Gitlab::ObjectifiedHash
+    def epic_label_event(group, epic_id, id)
+      get("/groups/#{url_encode group}/epics/#{epic_id}/resource_label_events/#{id}")
+    end
+
+    # Gets a list of all label events for a single merge request.
+    #
+    # @example
+    #   Gitlab.merge_request_label_events(5, 42)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] merge_request_iid The IID of a merge request.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def merge_request_label_events(project, merge_request_iid)
+      get("/projects/#{url_encode project}/merge_requests/#{merge_request_iid}/resource_label_events")
+    end
+
+    # Returns a single label event for a specific project merge request
+    #
+    # @example
+    #   Gitlab.merge_request_label_event(5, 42, 1)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] merge_request_iid The IID of an merge request.
+    # @param  [Integer] id The ID of a label event.
+    # @return Gitlab::ObjectifiedHash
+    def merge_request_label_event(project, merge_request_iid, id)
+      get("/projects/#{url_encode project}/merge_requests/#{merge_request_iid}/resource_label_events/#{id}")
+    end
+  end
+end

--- a/spec/fixtures/resource_label_event.json
+++ b/spec/fixtures/resource_label_event.json
@@ -1,0 +1,21 @@
+{
+  "id": 142,
+  "user": {
+    "id": 1,
+    "name": "Administrator",
+    "username": "root",
+    "state": "active",
+    "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+    "web_url": "http://gitlab.example.com/root"
+  },
+  "created_at": "2018-08-20T13:38:20.077Z",
+  "resource_type": "Issue",
+  "resource_id": 253,
+  "label": {
+    "id": 73,
+    "name": "a1",
+    "color": "#34495E",
+    "description": ""
+  },
+  "action": "add"
+}

--- a/spec/fixtures/resource_label_events.json
+++ b/spec/fixtures/resource_label_events.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": 142,
+    "user": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "created_at": "2018-08-20T13:38:20.077Z",
+    "resource_type": "Issue",
+    "resource_id": 253,
+    "label": {
+      "id": 73,
+      "name": "a1",
+      "color": "#34495E",
+      "description": ""
+    },
+    "action": "add"
+  },
+  {
+    "id": 143,
+    "user": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "created_at": "2018-08-20T13:38:20.077Z",
+    "resource_type": "Issue",
+    "resource_id": 253,
+    "label": {
+      "id": 74,
+      "name": "p1",
+      "color": "#0033CC",
+      "description": ""
+    },
+    "action": "remove"
+  }
+]

--- a/spec/gitlab/client/resource_label_events_spec.rb
+++ b/spec/gitlab/client/resource_label_events_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Gitlab::Client do
+  describe '.issue_label_events' do
+    before do
+      stub_get('/projects/5/issues/42/resource_label_events', 'resource_label_events')
+      @events = Gitlab.issue_label_events(5, 42)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/5/issues/42/resource_label_events')).to have_been_made
+    end
+
+    it "returns a paginated response of project's issue's label events" do
+      expect(@events).to be_a Gitlab::PaginatedResponse
+      expect(@events.first.id).to eq(142)
+    end
+  end
+
+  describe '.issue_label_event' do
+    before do
+      stub_get('/projects/5/issues/42/resource_label_events/142', 'resource_label_event')
+      @event = Gitlab.issue_label_event(5, 42, 142)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/5/issues/42/resource_label_events/142')).to have_been_made
+    end
+
+    it "returns a paginated response of project's issue's label event" do
+      expect(@event).to be_a Gitlab::ObjectifiedHash
+      expect(@event.user.name).to eq('Administrator')
+    end
+  end
+
+  describe '.epic_label_events' do
+    before do
+      stub_get('/groups/5/epics/42/resource_label_events', 'resource_label_events')
+      @events = Gitlab.epic_label_events(5, 42)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/groups/5/epics/42/resource_label_events')).to have_been_made
+    end
+
+    it "returns a paginated response of project's epic's label events" do
+      expect(@events).to be_a Gitlab::PaginatedResponse
+      expect(@events.first.id).to eq(142)
+    end
+  end
+
+  describe '.epic_label_event' do
+    before do
+      stub_get('/groups/5/epics/42/resource_label_events/142', 'resource_label_event')
+      @event = Gitlab.epic_label_event(5, 42, 142)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/groups/5/epics/42/resource_label_events/142')).to have_been_made
+    end
+
+    it "returns a paginated response of project's epic's label event" do
+      expect(@event).to be_a Gitlab::ObjectifiedHash
+      expect(@event.user.name).to eq('Administrator')
+    end
+  end
+
+  describe '.merge_request_label_events' do
+    before do
+      stub_get('/projects/5/merge_requests/42/resource_label_events', 'resource_label_events')
+      @events = Gitlab.merge_request_label_events(5, 42)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/5/merge_requests/42/resource_label_events')).to have_been_made
+    end
+
+    it "returns a paginated response of project's merge request's label events" do
+      expect(@events).to be_a Gitlab::PaginatedResponse
+      expect(@events.first.id).to eq(142)
+    end
+  end
+
+  describe '.merge_request_label_event' do
+    before do
+      stub_get('/projects/5/merge_requests/42/resource_label_events/142', 'resource_label_event')
+      @event = Gitlab.merge_request_label_event(5, 42, 142)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/5/merge_requests/42/resource_label_events/142')).to have_been_made
+    end
+
+    it "returns a paginated response of project's merge request's label event" do
+      expect(@event).to be_a Gitlab::ObjectifiedHash
+      expect(@event.user.name).to eq('Administrator')
+    end
+  end
+end


### PR DESCRIPTION
I noticed that the resource label events api was not implemented and I have to use this in a script of ours.  I have completed the full API here and added tests which seem to conform to your style (please let me know if it is missing anything).