### PR TITLE
Add support to handle 429 responses from a rate limited gitlab instance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,9 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
 
+Metrics/CyclomaticComplexity:
+  Max: 15
+
 Style/Documentation:
   Enabled: false
 

--- a/lib/gitlab/request.rb
+++ b/lib/gitlab/request.rb
@@ -58,6 +58,7 @@ module Gitlab
                     when 405 then Error::MethodNotAllowed
                     when 409 then Error::Conflict
                     when 422 then Error::Unprocessable
+                    when 429 then Error::TooManyRequests
                     when 500 then Error::InternalServerError
                     when 502 then Error::BadGateway
                     when 503 then Error::ServiceUnavailable

--- a/spec/gitlab/error_spec.rb
+++ b/spec/gitlab/error_spec.rb
@@ -34,3 +34,21 @@ describe Gitlab::Error::ResponseError do
     end
   end
 end
+
+describe Gitlab::Error::ResponseError do
+  before do
+    @request_double = double('request', base_uri: 'https://gitlab.com/api/v3', path: '/foo', options: {})
+  end
+
+  it 'Builds an error message from text' do
+    headers = { 'content-type' => 'text/plain' }
+    response_double = double('response', body: 'Retry later', to_s: 'Retry text', parsed_response: { message: 'Retry hash' }, code: 429, options: {}, headers: headers, request: @request_double)
+    expect(described_class.new(response_double).send(:build_error_message)).to match(/Retry text/)
+  end
+
+  it 'Builds an error message from parsed json' do
+    headers = { 'content-type' => 'application/json' }
+    response_double = double('response', body: 'Retry later', to_s: 'Retry text', parsed_response: { message: 'Retry hash' }, code: 429, options: {}, headers: headers, request: @request_double)
+    expect(described_class.new(response_double).send(:build_error_message)).to match(/Retry hash/)
+  end
+end


### PR DESCRIPTION
Gitlab may respond with a 429 error and a message of 'Retry later'.  The
response body in this case has content-type 'text/plain'. This change
adds support for 429 errors and processes the body of responses with
content formated as 'text/plain'.

Should fix issue #458.