### PR TITLE
Add Group Label support

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -18,6 +18,7 @@ module Gitlab
     include Environments
     include Events
     include Features
+    include GroupLabels
     include GroupMilestones
     include Groups
     include Issues

--- a/lib/gitlab/client/group_labels.rb
+++ b/lib/gitlab/client/group_labels.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+class Gitlab::Client
+  # Defines methods related to group labels.
+  #
+  # @note Requires GitLab 11.8+
+  # @see https://docs.gitlab.com/ee/api/group_labels.html
+  module GroupLabels
+    # Gets a list of group's labels.
+    #
+    # @example
+    #   Gitlab.group_labels('globex')
+    #
+    # @param  [Integer, String] group The ID or name of a group.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def group_labels(group, options = {})
+      get("/groups/#{url_encode group}/labels", query: options)
+    end
+
+    # Creates a new group label.
+    #
+    # @example
+    #   Gitlab.create_group_label('globex', 'Backlog', '#DD10AA')
+    #
+    # @param  [Integer, String] group The ID or name of a group.
+    # @param  [String] name The name of a label.
+    # @param  [String] color The color of a label.
+    # @param  [Hash] options A customizable set of options.
+    # @option options [String] :description The description of the label.
+    # @return [Gitlab::ObjectifiedHash] Information about created label.
+    def create_group_label(group, name, color, options = {})
+      post("/groups/#{url_encode group}/labels", body: options.merge(name: name, color: color))
+    end
+
+    # Updates a group label.
+    #
+    # @example
+    #   Gitlab.edit_group_label('globex', 'Backlog', { new_name: 'Priority' })
+    #   Gitlab.edit_group_label('globex', 'Backlog', { new_name: 'Priority', color: '#DD10AA' })
+    #
+    # @param  [Integer, String] group The ID or name of a group.
+    # @param  [String] name The name of a label.
+    # @param  [Hash] options A customizable set of options.
+    # @option options [String] :new_name The new name of a label.
+    # @option options [String] :color The color of a label.
+    # @option options [String] :description The description of the label.
+    # @return [Gitlab::ObjectifiedHash] Information about updated label.
+    def edit_group_label(group, name, options = {})
+      put("/groups/#{url_encode group}/labels", body: options.merge(name: name))
+    end
+
+    # Deletes a group label.
+    #
+    # @example
+    #   Gitlab.delete_group_label('globex', 'Backlog')
+    #
+    # @param  [Integer, String] group The ID or name of a group.
+    # @param  [String] name The name of a label.
+    # @return [Gitlab::ObjectifiedHash] Information about deleted label.
+    def delete_group_label(group, name)
+      delete("/groups/#{url_encode group}/labels", body: { name: name })
+    end
+
+    # Subscribes the user to a group label to receive notifications
+    #
+    # @example
+    #   Gitlab.subscribe_to_group_label('globex', 'Backlog')
+    #
+    # @param  [Integer, String] group The ID or name of a group.
+    # @param  [String] name The name of a label.
+    # @return [Gitlab::ObjectifiedHash] Information about the label subscribed to.
+    def subscribe_to_group_label(group, name)
+      post("/groups/#{url_encode group}/labels/#{url_encode name}/subscribe")
+    end
+
+    # Unsubscribes the user from a group label to not receive notifications from it
+    #
+    # @example
+    #   Gitlab.unsubscribe_from_group_label('globex', 'Backlog')
+    #
+    # @param  [Integer, String] group The ID or name of a group.
+    # @param  [String] name The name of a label.
+    # @return [Gitlab::ObjectifiedHash] Information about the label unsubscribed from.
+    def unsubscribe_from_group_label(group, name)
+      post("/groups/#{url_encode group}/labels/#{url_encode name}/unsubscribe")
+    end
+  end
+end

--- a/lib/gitlab/client/labels.rb
+++ b/lib/gitlab/client/labels.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Gitlab::Client
-  # Defines methods related to labels.
+  # Defines methods related to project labels.
   # @see https://docs.gitlab.com/ce/api/labels.html
   module Labels
     # Gets a list of project's labels.

--- a/spec/fixtures/group_label.json
+++ b/spec/fixtures/group_label.json
@@ -1,0 +1,8 @@
+{
+  "name": "Backlog",
+  "color": "#DD10AA",
+  "open_issues_count": 72,
+  "closed_issues_count": 72,
+  "open_merge_requests_count": 4,
+  "subscribed": true
+}

--- a/spec/fixtures/group_label_unsubscribe.json
+++ b/spec/fixtures/group_label_unsubscribe.json
@@ -1,0 +1,8 @@
+{
+  "name": "Backlog",
+  "color": "#DD10AA",
+  "open_issues_count": 72,
+  "closed_issues_count": 72,
+  "open_merge_requests_count": 4,
+  "subscribed": false
+}

--- a/spec/fixtures/group_labels.json
+++ b/spec/fixtures/group_labels.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Backlog",
+    "color": "#DD10AA",
+    "open_issues_count": 72,
+    "closed_issues_count": 72,
+    "open_merge_requests_count": 4,
+    "subscribed": true
+  },
+  {
+    "name": "Documentation",
+    "color": "#1E80DD",
+    "open_issues_count": 42,
+    "closed_issues_count": 42,
+    "open_merge_requests_count": 6,
+    "subscribed": true
+  }
+]

--- a/spec/gitlab/client/group_labels_spec.rb
+++ b/spec/gitlab/client/group_labels_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Gitlab::Client do
+  describe '.group_labels' do
+    before do
+      stub_get('/groups/3/labels', 'group_labels')
+      @labels = Gitlab.group_labels(3)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/groups/3/labels')).to have_been_made
+    end
+
+    it "returns a paginated response of group's labels" do
+      expect(@labels).to be_a Gitlab::PaginatedResponse
+      expect(@labels.first.name).to eq('Backlog')
+    end
+  end
+
+  describe '.create_group_label' do
+    before do
+      stub_post('/groups/3/labels', 'group_label')
+      @label = Gitlab.create_group_label(3, 'Backlog', '#DD10AA')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_post('/groups/3/labels')
+        .with(body: { name: 'Backlog', color: '#DD10AA' })).to have_been_made
+    end
+
+    it 'returns information about a created label' do
+      expect(@label.name).to eq('Backlog')
+      expect(@label.color).to eq('#DD10AA')
+    end
+  end
+
+  describe '.edit_group_label' do
+    before do
+      stub_put('/groups/3/labels', 'group_label')
+      @label = Gitlab.edit_group_label(3, 'TODO', new_name: 'Backlog')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_put('/groups/3/labels')
+        .with(body: { name: 'TODO', new_name: 'Backlog' })).to have_been_made
+    end
+
+    it 'returns information about an edited label' do
+      expect(@label.name).to eq('Backlog')
+    end
+  end
+
+  describe '.delete_group_label' do
+    before do
+      stub_delete('/groups/3/labels', 'label')
+      @label = Gitlab.delete_group_label(3, 'Backlog')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_delete('/groups/3/labels')
+             .with(body: { name: 'Backlog' })).to have_been_made
+    end
+
+    it 'returns information about a deleted snippet' do
+      expect(@label.name).to eq('Backlog')
+    end
+  end
+
+  describe '.subscribe_to_group_label' do
+    before do
+      stub_post('/groups/3/labels/Backlog/subscribe', 'group_label')
+      @label = Gitlab.subscribe_to_group_label(3, 'Backlog')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_post('/groups/3/labels/Backlog/subscribe')).to have_been_made
+    end
+
+    it 'returns information about the label subscribed to' do
+      expect(@label.name).to eq('Backlog')
+      expect(@label.subscribed).to eq(true)
+    end
+  end
+
+  describe '.unsubscribe_from_group_label' do
+    before do
+      stub_post('/groups/3/labels/Backlog/unsubscribe', 'group_label_unsubscribe')
+      @label = Gitlab.unsubscribe_from_group_label(3, 'Backlog')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_post('/groups/3/labels/Backlog/unsubscribe')).to have_been_made
+    end
+
+    it 'returns information about the label subscribed to' do
+      expect(@label.name).to eq('Backlog')
+      expect(@label.subscribed).to eq(false)
+    end
+  end
+end

--- a/spec/gitlab/shell_spec.rb
+++ b/spec/gitlab/shell_spec.rb
@@ -58,7 +58,7 @@ describe Gitlab::Shell do
       it 'returns an Array of matching commands' do
         completed_cmds = @comp.call 'group'
         expect(completed_cmds).to be_a Array
-        expect(completed_cmds.sort).to eq(%w[group group_access_requests group_issues group_member group_members group_milestone group_milestone_issues group_milestone_merge_requests group_milestones group_projects group_search group_subgroups group_variable group_variables groups])
+        expect(completed_cmds.sort).to eq(%w[group group_access_requests group_issues group_labels group_member group_members group_milestone group_milestone_issues group_milestone_merge_requests group_milestones group_projects group_search group_subgroups group_variable group_variables groups])
       end
     end
   end


### PR DESCRIPTION
Group Label API support is being added in GitLab 11.8 (February 22nd)
and is available now on gitlab.com!