### PR TITLE
Adding missing endpoints in project issue boards

### DIFF
--- a/lib/gitlab/client/boards.rb
+++ b/lib/gitlab/client/boards.rb
@@ -19,6 +19,62 @@ class Gitlab::Client
       get("/projects/#{url_encode project}/boards", query: options)
     end
 
+    # Get a single board.
+    #
+    # @example
+    #   Gitlab.board(5, 1)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of a board.
+    # @return [Gitlab::ObjectifiedHash] Returns information about the board
+    def board(project, id)
+      get("/projects/#{url_encode project}/boards/#{id}")
+    end
+
+    # Creates a new board.
+    #
+    # @example
+    #   Gitlab.create_board(5, 'newboard')
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [String] name The name of the new board.
+    # @return [Gitlab::ObjectifiedHash] Information about created board.
+    def create_board(project, name)
+      body = { name: name }
+      post("/projects/#{url_encode project}/boards", body: body)
+    end
+
+    # Updates a board.
+    #
+    # @example
+    #   Gitlab.edit_board(5, 1, name: 'new_name')
+    #   Gitlab.edit_board(5, 1, name: 'new_name', assignee_id: 1, milestone_id: 1)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of a board.
+    # @param  [Hash] options A customizable set of options.
+    # @option options [String] :name(optional) The new name of the board.
+    # @option options [Integer] :assignee_id(optional) The assignee the board should be scoped to.
+    # @option options [Integer] :milestone_id(optional) The milestone the board should be scoped to.
+    # @option options [String] :labels(optional) Comma-separated list of label names which the board should be scoped to.
+    # @option options [Integer] :weight(optional) The weight range from 0 to 9, to which the board should be scoped to.
+    # @return [Gitlab::ObjectifiedHash] Information about updated board.
+    def edit_board(project, id, options = {})
+      put("/projects/#{url_encode project}/boards/#{id}", body: options)
+    end
+
+    # Deletes a board.
+    #
+    # @example
+    #   Gitlab.delete_board(5, 1)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of a board.
+    # @return [void] This API call returns an empty response body.
+    def delete_board(project, id)
+      delete("/projects/#{url_encode project}/boards/#{id}")
+    end
+
     # Gets a board lists
     #
     # @example

--- a/spec/fixtures/board.json
+++ b/spec/fixtures/board.json
@@ -1,0 +1,46 @@
+  {
+    "id": 1,
+    "name": "project issue board",
+    "project": {
+      "id": 5,
+      "name": "Diaspora Project Site",
+      "name_with_namespace": "Diaspora / Diaspora Project Site",
+      "path": "diaspora-project-site",
+      "path_with_namespace": "diaspora/diaspora-project-site",
+      "http_url_to_repo": "http://example.com/diaspora/diaspora-project-site.git",
+      "web_url": "http://example.com/diaspora/diaspora-project-site"
+    },
+    "milestone":   {
+      "id": 12,
+      "title": "10.0"
+    },
+    "lists" : [
+      {
+        "id" : 1,
+        "label" : {
+          "name" : "Testing",
+          "color" : "#F0AD4E",
+          "description" : null
+        },
+        "position" : 1
+      },
+      {
+        "id" : 2,
+        "label" : {
+          "name" : "Ready",
+          "color" : "#FF0000",
+          "description" : null
+        },
+        "position" : 2
+      },
+      {
+        "id" : 3,
+        "label" : {
+          "name" : "Production",
+          "color" : "#FF5F00",
+          "description" : null
+        },
+        "position" : 3
+      }
+    ]
+  }

--- a/spec/fixtures/updated_board.json
+++ b/spec/fixtures/updated_board.json
@@ -1,0 +1,52 @@
+  {
+    "id": 1,
+    "project": {
+      "id": 5,
+      "name": "Diaspora Project Site",
+      "name_with_namespace": "Diaspora / Diaspora Project Site",
+      "path": "diaspora-project-site",
+      "path_with_namespace": "diaspora/diaspora-project-site",
+      "created_at": "2018-07-03T05:48:49.982Z",
+      "default_branch": null,
+      "tag_list": [],
+      "ssh_url_to_repo": "ssh://user@example.com/diaspora/diaspora-project-site.git",
+      "http_url_to_repo": "http://example.com/diaspora/diaspora-project-site.git",
+      "web_url": "http://example.com/diaspora/diaspora-project-site",
+      "readme_url": null,
+      "avatar_url": null,
+      "star_count": 0,
+      "forks_count": 0,
+      "last_activity_at": "2018-07-03T05:48:49.982Z"
+    },
+    "lists": [],
+    "name": "new_name",
+    "group": null,
+    "milestone": {
+      "id": 43,
+      "iid": 1,
+      "project_id": 15,
+      "title": "Milestone 1",
+      "description": "Milestone 1 desc",
+      "state": "active",
+      "created_at": "2018-07-03T06:36:42.618Z",
+      "updated_at": "2018-07-03T06:36:42.618Z",
+      "due_date": null,
+      "start_date": null,
+      "web_url": "http://example.com/root/board1/milestones/1"
+    },
+    "assignee": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://example.com/root"
+    },
+    "labels": [{
+      "id": 10,
+      "name": "Doing",
+      "color": "#5CB85C",
+      "description": null
+    }],
+    "weight": 4
+  }

--- a/spec/gitlab/client/boards_spec.rb
+++ b/spec/gitlab/client/boards_spec.rb
@@ -18,6 +18,68 @@ describe Gitlab::Client do
     end
   end
 
+  describe '.board' do
+    before do
+      stub_get('/projects/5/boards/1', 'board')
+      @board = Gitlab.board(5, 1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/5/boards/1')).to have_been_made
+    end
+
+    it 'returns information about the board' do
+      expect(@board.id).to eq(1)
+      expect(@board.project.id).to eq(5)
+    end
+  end
+
+  describe '.create_board' do
+    before do
+      stub_post('/projects/5/boards', 'board')
+      @board = Gitlab.create_board(5, 'project issue board')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_post('/projects/5/boards')
+        .with(body: { name: 'project issue board' })).to have_been_made
+    end
+
+    it 'returns information about a created board' do
+      expect(@board.name).to eq('project issue board')
+      expect(@board.project.id).to eq(5)
+    end
+  end
+
+  describe '.edit_board' do
+    before do
+      stub_put('/projects/5/boards/1', 'updated_board')
+      @board = Gitlab.edit_board(5, 1, name: 'new_name', milestone_id: 43, assignee_id: 1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_put('/projects/5/boards/1')
+        .with(body: { name: 'new_name', milestone_id: 43, assignee_id: 1 })).to have_been_made
+    end
+
+    it 'returns information about an edited board' do
+      expect(@board.name).to eq('new_name')
+      expect(@board.milestone.id).to eq(43)
+      expect(@board.assignee.id).to eq(1)
+    end
+  end
+
+  describe '.delete_board' do
+    before do
+      stub_delete('/projects/5/boards/1', 'empty')
+      Gitlab.delete_board(5, 1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_delete('/projects/5/boards/1')).to have_been_made
+    end
+  end
+
   describe '.board_lists' do
     before do
       stub_get('/projects/3/boards/1/lists', 'board_lists')
@@ -59,7 +121,7 @@ describe Gitlab::Client do
       expect(a_post('/projects/3/boards/1/lists')).to have_been_made
     end
 
-    it 'returns information about a created board' do
+    it 'returns information about a created board list' do
       expect(@board_list.position).to eq(1)
     end
   end
@@ -74,7 +136,7 @@ describe Gitlab::Client do
       expect(a_put('/projects/3/boards/1/lists/1')).to have_been_made
     end
 
-    it 'returns information about an edited board' do
+    it 'returns information about an edited board list' do
       expect(@board_list.id).to eq(1)
     end
   end


### PR DESCRIPTION
Missing project issue board endpoints:

```ruby
  Gitlab.board(project, id)
  Gitlab.create_board(project, name)
  Gitlab.edit_board(project, id, options = {})
  Gitlab.delete_board(project, id)
```

Closes #468 