### PR TITLE
Container Registry API

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -15,6 +15,7 @@ module Gitlab
     include BuildVariables
     include Builds
     include Commits
+    include ContainerRegistry
     include Deployments
     include Environments
     include Events

--- a/lib/gitlab/client/container_registry.rb
+++ b/lib/gitlab/client/container_registry.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+class Gitlab::Client
+  # Defines methods related to GitLab Container Registry.
+  # @see https://docs.gitlab.com/ce/api/container_registry.html
+  module ContainerRegistry
+    # Get a list of registry repositories in a project.
+    #
+    # @example
+    #   Gitlab.registry_repositories(5)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @return [Array<Gitlab::ObjectifiedHash>] Returns list of registry repositories in a project.
+    def registry_repositories(project)
+      get("/projects/#{url_encode project}/registry/repositories")
+    end
+
+    # Delete a repository in registry.
+    #
+    # @example
+    #   Gitlab.delete_registry_repository(5, 2)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of registry repository.
+    # @return [void] This API call returns an empty response body.
+    def delete_registry_repository(project, id)
+      delete("/projects/#{url_encode project}/registry/repositories/#{id}")
+    end
+
+    # Get a list of tags for given registry repository.
+    #
+    # @example
+    #   Gitlab.registry_repository_tags(5, 2)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] repository_id The ID of registry repository.
+    # @return [Array<Gitlab::ObjectifiedHash>] Returns list of tags of a registry repository.
+    def registry_repository_tags(project, repository_id)
+      get("/projects/#{url_encode project}/registry/repositories/#{repository_id}/tags")
+    end
+
+    # Get details of a registry repository tag.
+    #
+    # @example
+    #   Gitlab.registry_repository_tag(5, 2, 'v10.0.0')
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] repository_id The ID of registry repository.
+    # @param  [String] tag_name The name of tag.
+    # @return <Gitlab::ObjectifiedHash> Returns details about the registry repository tag
+    def registry_repository_tag(project, repository_id, tag_name)
+      get("/projects/#{url_encode project}/registry/repositories/#{repository_id}/tags/#{tag_name}")
+    end
+
+    # Delete a registry repository tag.
+    #
+    # @example
+    #   Gitlab.delete_registry_repository_tag(5, 2, 'v10.0.0')
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] repository_id The ID of registry repository.
+    # @param  [String] tag_name The name of tag.
+    # @return [void] This API call returns an empty response body.
+    def delete_registry_repository_tag(project, repository_id, tag_name)
+      delete("/projects/#{url_encode project}/registry/repositories/#{repository_id}/tags/#{tag_name}")
+    end
+
+    # Delete repository tags in bulk based on given criteria.
+    #
+    # @example
+    #   Gitlab.bulk_delete_registry_repository_tags(5, 2, name_regex: '.*')
+    #   Gitlab.bulk_delete_registry_repository_tags(5, 2, name_regex: '[0-9a-z]{40}', keep_n: 5, older_than: '1d')
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] repository_id The ID of registry repository.
+    # @param  [Hash] options A customizable set of options.
+    # @option options [String] :name_regex(required) The regex of the name to delete. To delete all tags specify .*.
+    # @option options [Integer] :keep_n(optional) The amount of latest tags of given name to keep.
+    # @option options [String] :older_than(required) Tags to delete that are older than the given time, written in human readable form 1h, 1d, 1month.
+    # @return [void] This API call returns an empty response body.
+    def bulk_delete_registry_repository_tags(project, repository_id, options = {})
+      delete("/projects/#{url_encode project}/registry/repositories/#{repository_id}/tags", query: options)
+    end
+  end
+end

--- a/spec/fixtures/registry_repositories.json
+++ b/spec/fixtures/registry_repositories.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 1,
+    "name": "",
+    "path": "group/project",
+    "location": "gitlab.example.com:5000/group/project",
+    "created_at": "2019-01-10T13:38:57.391Z"
+  },
+  {
+    "id": 2,
+    "name": "releases",
+    "path": "group/project/releases",
+    "location": "gitlab.example.com:5000/group/project/releases",
+    "created_at": "2019-01-10T13:39:08.229Z"
+  }
+]

--- a/spec/fixtures/registry_repository_tag.json
+++ b/spec/fixtures/registry_repository_tag.json
@@ -1,0 +1,10 @@
+{
+  "name": "v10.0.0",
+  "path": "group/project:latest",
+  "location": "gitlab.example.com:5000/group/project:latest",
+  "revision": "e9ed9d87c881d8c2fd3a31b41904d01ba0b836e7fd15240d774d811a1c248181",
+  "short_revision": "e9ed9d87c",
+  "digest": "sha256:c3490dcf10ffb6530c1303522a1405dfaf7daecd8f38d3e6a1ba19ea1f8a1751",
+  "created_at": "2019-01-06T16:49:51.272+00:00",
+  "total_size": 350224384
+}

--- a/spec/fixtures/registry_repository_tags.json
+++ b/spec/fixtures/registry_repository_tags.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "A",
+    "path": "group/project:A",
+    "location": "gitlab.example.com:5000/group/project:A"
+  },
+  {
+    "name": "latest",
+    "path": "group/project:latest",
+    "location": "gitlab.example.com:5000/group/project:latest"
+  }
+]

--- a/spec/gitlab/client/container_registry_spec.rb
+++ b/spec/gitlab/client/container_registry_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Gitlab::Client do
+  describe '.registry_repositories' do
+    before do
+      stub_get('/projects/3/registry/repositories', 'registry_repositories')
+      @registry_repositories = Gitlab.registry_repositories(3)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/registry/repositories')).to have_been_made
+    end
+
+    it "returns a paginated response of project's registry repositories" do
+      expect(@registry_repositories).to be_a Gitlab::PaginatedResponse
+    end
+  end
+
+  describe '.delete_registry_repository' do
+    before do
+      stub_delete('/projects/3/registry/repositories/1', 'empty')
+      Gitlab.delete_registry_repository(3, 1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_delete('/projects/3/registry/repositories/1')).to have_been_made
+    end
+  end
+
+  describe '.registry_repository_tags' do
+    before do
+      stub_get('/projects/3/registry/repositories/1/tags', 'registry_repository_tags')
+      @registry_repository_tags = Gitlab.registry_repository_tags(3, 1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/registry/repositories/1/tags')).to have_been_made
+    end
+
+    it "returns a paginated response of a registry repository's tags" do
+      expect(@registry_repository_tags).to be_a Gitlab::PaginatedResponse
+    end
+  end
+
+  describe '.registry_repository_tag' do
+    before do
+      stub_get('/projects/3/registry/repositories/1/tags/v10.0.0', 'registry_repository_tag')
+      @registry_repository_tag = Gitlab.registry_repository_tag(3, 1, 'v10.0.0')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/registry/repositories/1/tags/v10.0.0')).to have_been_made
+    end
+
+    it 'returns correct information about the registry repository tag' do
+      expect(@registry_repository_tag.name).to eq 'v10.0.0'
+    end
+  end
+
+  describe '.delete_registry_repository_tag' do
+    before do
+      stub_delete('/projects/3/registry/repositories/1/tags/v10.0.0', 'empty')
+      Gitlab.delete_registry_repository_tag(3, 1, 'v10.0.0')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_delete('/projects/3/registry/repositories/1/tags/v10.0.0')).to have_been_made
+    end
+  end
+
+  describe '.bulk_delete_registry_repository_tags' do
+    context 'when just name_regex provided for deletion' do
+      before do
+        stub_delete('/projects/3/registry/repositories/1/tags', 'empty').with(query: { name_regex: '.*' })
+        Gitlab.bulk_delete_registry_repository_tags(3, 1, name_regex: '.*')
+      end
+
+      it 'gets the correct resource' do
+        expect(a_delete('/projects/3/registry/repositories/1/tags')
+          .with(query: { name_regex: '.*' })).to have_been_made
+      end
+    end
+    context 'when all options provided for deletion' do
+      before do
+        stub_delete('/projects/3/registry/repositories/1/tags', 'empty').with(query: { name_regex: '[0-9a-z]{40}', keep_n: 5, older_than: '1d' })
+        Gitlab.bulk_delete_registry_repository_tags(3, 1, name_regex: '[0-9a-z]{40}', keep_n: 5, older_than: '1d')
+      end
+
+      it 'gets the correct resource' do
+        expect(a_delete('/projects/3/registry/repositories/1/tags')
+          .with(query: { name_regex: '[0-9a-z]{40}', keep_n: 5, older_than: '1d' })).to have_been_made
+      end
+    end
+  end
+end


### PR DESCRIPTION
Container Registry API

```ruby
  Gitlab.registry_repositories(project)
  Gitlab.delete_registry_repository(project, id)
  Gitlab.registry_repository_tags(project, repository_id) 
  Gitlab.registry_repository_tag(project, repository_id, tag_name) 
  Gitlab.delete_registry_repository_tag(project, repository_id, tag_name)
  Gitlab.bulk_delete_registry_repository_tags(project, repository_id, options = {})
```

Closes #471 