### PR TITLE
Correct API endpoint for project approvers

### DIFF
--- a/lib/gitlab/client/merge_request_approvals.rb
+++ b/lib/gitlab/client/merge_request_approvals.rb
@@ -28,7 +28,7 @@ class Gitlab::Client
     # @option options [Boolean] :disable_overriding_approvers_per_merge_request(optional) Allow/Disallow overriding approvers per MR
     # @return [Gitlab::ObjectifiedHash] MR approval configuration information about the project
     def edit_project_merge_request_approvals(project, options = {})
-      post("/projects/#{url_encode project}/approvals", body: options)
+      post("/projects/#{url_encode project}/approvers", body: options)
     end
 
     # Change allowed approvers and approver groups for a project

--- a/spec/gitlab/client/merge_request_approvals_spec.rb
+++ b/spec/gitlab/client/merge_request_approvals_spec.rb
@@ -21,13 +21,13 @@ describe Gitlab::Client do
   describe '.edit_project_merge_request_approvals' do
     before do
       body = { approvals_before_merge: '3', reset_approvals_on_push: 'false', disable_overriding_approvers_per_merge_request: 'true' }
-      stub_post('/projects/1/approvals', 'project_merge_request_approvals').with(body: body)
+      stub_post('/projects/1/approvers', 'project_merge_request_approvals').with(body: body)
       @project_mr_approvals = Gitlab.edit_project_merge_request_approvals(1, approvals_before_merge: 3, reset_approvals_on_push: false, disable_overriding_approvers_per_merge_request: true)
     end
 
     it 'gets the correct resource' do
       body = { approvals_before_merge: '3', reset_approvals_on_push: 'false', disable_overriding_approvers_per_merge_request: 'true' }
-      expect(a_post('/projects/1/approvals')
+      expect(a_post('/projects/1/approvers')
         .with(body: body)).to have_been_made
     end
 


### PR DESCRIPTION
Updating the approvers API endpoint to align with the gitlab docs:

Reference: https://docs.gitlab.com/ee/api/merge_request_approvals.html#change-allowed-approvers