### PR TITLE
Add the gitlab CI variable as a fallback for Gitlab.endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Configuration example:
 
 ```ruby
 Gitlab.configure do |config|
-  config.endpoint       = 'https://example.net/api/v4' # API endpoint URL, default: ENV['GITLAB_API_ENDPOINT']
+  config.endpoint       = 'https://example.net/api/v4' # API endpoint URL, default: ENV['GITLAB_API_ENDPOINT'] and falls back to ENV['CI_API_V4_URL']
   config.private_token  = 'qEsq1pt6HJPaNciie3MG'       # user's private token or OAuth2 access token, default: ENV['GITLAB_API_PRIVATE_TOKEN']
   # Optional
   # config.user_agent   = 'Custom User Agent'          # user agent, default: 'Gitlab Ruby Gem [version]'

--- a/lib/gitlab/configuration.rb
+++ b/lib/gitlab/configuration.rb
@@ -35,7 +35,7 @@ module Gitlab
 
     # Resets all configuration options to the defaults.
     def reset
-      self.endpoint       = ENV['GITLAB_API_ENDPOINT']
+      self.endpoint       = ENV['GITLAB_API_ENDPOINT'] || ENV['CI_API_V4_URL']
       self.private_token  = ENV['GITLAB_API_PRIVATE_TOKEN'] || ENV['GITLAB_API_AUTH_TOKEN']
       self.httparty       = get_httparty_config(ENV['GITLAB_API_HTTPARTY_OPTIONS'])
       self.sudo           = nil


### PR DESCRIPTION
Gitlab CI Provides CI_API_V4_URLfor the V4 API as of 11.7. It'd be nice to just pick that up if using the gem in a gitlab ci job.