### PR TITLE
Add options to runner_jobs

### DIFF
--- a/lib/gitlab/client/runners.rb
+++ b/lib/gitlab/client/runners.rb
@@ -82,7 +82,7 @@ class Gitlab::Client
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :status Status of the job; one of: running, success, failed, canceled
     # @return [Array<Gitlab::ObjectifiedHash>]
-    def runner_jobs(runner_id, options={})
+    def runner_jobs(runner_id, options = {})
       get("/runners/#{url_encode runner_id}/jobs", query: options)
     end
 

--- a/lib/gitlab/client/runners.rb
+++ b/lib/gitlab/client/runners.rb
@@ -79,9 +79,11 @@ class Gitlab::Client
     #   Gitlab.runner_jobs(1)
     #
     # @param  [Integer] id The ID of a runner.
+    # @param  [Hash] options A customizable set of options.
+    # @option options [String] :status Status of the job; one of: running, success, failed, canceled
     # @return [Array<Gitlab::ObjectifiedHash>]
-    def runner_jobs(runner_id)
-      get("/runners/#{url_encode runner_id}/jobs")
+    def runner_jobs(runner_id, options={})
+      get("/runners/#{url_encode runner_id}/jobs", query: options)
     end
 
     # List all runners (specific and shared) available in the project. Shared runners are listed if at least one shared runner is defined and shared runners usage is enabled in the project's settings.

--- a/spec/gitlab/client/runners_spec.rb
+++ b/spec/gitlab/client/runners_spec.rb
@@ -132,12 +132,12 @@ describe Gitlab::Client do
 
   describe '.runner_jobs' do
     before do
-      stub_get('/runners/1/jobs', 'runner_jobs')
-      @jobs = Gitlab.runner_jobs(1)
+      stub_get('/runners/1/jobs?status=running', 'runner_jobs')
+      @jobs = Gitlab.runner_jobs(1, status: :running)
     end
 
     it 'gets the correct resource' do
-      expect(a_get('/runners/1/jobs')).to have_been_made
+      expect(a_get('/runners/1/jobs').with(query: { status: :running })).to have_been_made
     end
   end
 


### PR DESCRIPTION
Ran into an issue where I needed to pass options to `runner_jobs`, so I've added the ability to do so.  Similar to #475 in spirit but passes through the full `options` hash rather than just a `status` argument.  Also updated the tests to include passing in the option.