### PR TITLE
Edit approvals/approvers fix

### DIFF
--- a/lib/gitlab/client/merge_request_approvals.rb
+++ b/lib/gitlab/client/merge_request_approvals.rb
@@ -37,11 +37,11 @@ class Gitlab::Client
     #    Gitlab.edit_project_approvers(1, {approver_ids: [5], approver_groups: [1]})
     #
     # @param [Integer] project(required) The ID of a project.
-    # @option options [Array] :approver_ids(optional) An array of User IDs that can approve MRs
-    # @option options [Array] :approver_group_ids(optional) An array of Group IDs whose members can approve MRs
+    # @option options [Array] :approver_ids(required, nil if none) An array of User IDs that can approve MRs
+    # @option options [Array] :approver_group_ids(required, nil if none) An array of Group IDs whose members can approve MRs
     # @return [Gitlab::ObjectifiedHash] MR approval configuration information about the project
     def edit_project_approvers(project, options = {})
-      put("/projects/#{url_encode project}/approvals", body: options)
+      put("/projects/#{url_encode project}/approvers", body: options)
     end
 
     # Get Configuration for approvals on a specific Merge Request.

--- a/lib/gitlab/client/merge_request_approvals.rb
+++ b/lib/gitlab/client/merge_request_approvals.rb
@@ -28,7 +28,7 @@ class Gitlab::Client
     # @option options [Boolean] :disable_overriding_approvers_per_merge_request(optional) Allow/Disallow overriding approvers per MR
     # @return [Gitlab::ObjectifiedHash] MR approval configuration information about the project
     def edit_project_merge_request_approvals(project, options = {})
-      post("/projects/#{url_encode project}/approvers", body: options)
+      post("/projects/#{url_encode project}/approvals", body: options)
     end
 
     # Change allowed approvers and approver groups for a project
@@ -76,8 +76,8 @@ class Gitlab::Client
     #
     # @param [Integer] project(required) The ID of a project.
     # @param [Integer] merge_request(required) The IID of a merge_request.
-    # @option options [Array] :approver_ids(optional) An array of User IDs that can approve MRs
-    # @option options [Array] :approver_group_ids(optional) An array of Group IDs whose members can approve MRs
+    # @option options [Array] :approver_ids(required, nil if none) An array of User IDs that can approve MRs
+    # @option options [Array] :approver_group_ids(required, nil if none) An array of Group IDs whose members can approve MRs
     # @return [Gitlab::ObjectifiedHash] MR approval configuration information about the project
     def edit_merge_request_approvers(project, merge_request, options = {})
       put("/projects/#{url_encode project}/merge_requests/#{merge_request}/approvers", body: options)

--- a/spec/gitlab/client/merge_request_approvals_spec.rb
+++ b/spec/gitlab/client/merge_request_approvals_spec.rb
@@ -21,13 +21,13 @@ describe Gitlab::Client do
   describe '.edit_project_merge_request_approvals' do
     before do
       body = { approvals_before_merge: '3', reset_approvals_on_push: 'false', disable_overriding_approvers_per_merge_request: 'true' }
-      stub_post('/projects/1/approvers', 'project_merge_request_approvals').with(body: body)
+      stub_post('/projects/1/approvals', 'project_merge_request_approvals').with(body: body)
       @project_mr_approvals = Gitlab.edit_project_merge_request_approvals(1, approvals_before_merge: 3, reset_approvals_on_push: false, disable_overriding_approvers_per_merge_request: true)
     end
 
     it 'gets the correct resource' do
       body = { approvals_before_merge: '3', reset_approvals_on_push: 'false', disable_overriding_approvers_per_merge_request: 'true' }
-      expect(a_post('/projects/1/approvers')
+      expect(a_post('/projects/1/approvals')
         .with(body: body)).to have_been_made
     end
 
@@ -42,13 +42,13 @@ describe Gitlab::Client do
   describe '.edit_project_approvers' do
     before do
       body = { "approver_ids": ['5'], "approver_group_ids": ['1'] }
-      stub_put('/projects/1/approvals', 'project_merge_request_approvals').with(body: body)
+      stub_put('/projects/1/approvers', 'project_merge_request_approvals').with(body: body)
       @project_mr_approvals = Gitlab.edit_project_approvers(1, approver_ids: [5], approver_group_ids: [1])
     end
 
     it 'gets the correct resource' do
       body = { "approver_ids": ['5'], "approver_group_ids": ['1'] }
-      expect(a_put('/projects/1/approvals')
+      expect(a_put('/projects/1/approvers')
         .with(body: body)).to have_been_made
     end
 


### PR DESCRIPTION
Fix edit_project_approvers to use correct API path & update comments to properly reflect options as required, and to set to nil if you want one or both of them empty.