### PR TITLE
Added www in front of rubydoc.info

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/license-BSD-red.svg)](https://github.com/NARKOZ/gitlab/blob/master/LICENSE.txt)
 
 [website](https://narkoz.github.io/gitlab) |
-[documentation](https://rubydoc.info/gems/gitlab/frames) |
+[documentation](https://www.rubydoc.info/gems/gitlab/frames) |
 [gitlab-live](https://github.com/NARKOZ/gitlab-live)
 
 Gitlab is a Ruby wrapper and CLI for the [GitLab API](https://docs.gitlab.com/ce/api/README.html).  
@@ -110,7 +110,7 @@ end
 projects.auto_paginate
 ```
 
-For more information, refer to [documentation](https://rubydoc.info/gems/gitlab/frames).
+For more information, refer to [documentation](https://www.rubydoc.info/gems/gitlab/frames).
 
 ## CLI
 


### PR DESCRIPTION
Accessing https://rubydoc.info/ gives an SSL error since their certificate only covers `www.rubydoc.info`.

![Screenshot 2019-05-13 at 13 17 55](https://user-images.githubusercontent.com/736606/57617743-da95eb80-7581-11e9-801b-9ad496a8dcbe.png)

![Screenshot 2019-05-13 at 13 22 09](https://user-images.githubusercontent.com/736606/57617892-28125880-7582-11e9-8c27-5ab37666a16b.png)
