### PR TITLE
Add a paginate_with_limit pagination function, to paginate but return…

### DIFF
--- a/lib/gitlab/paginated_response.rb
+++ b/lib/gitlab/paginated_response.rb
@@ -56,6 +56,25 @@ module Gitlab
       response
     end
 
+    def paginate_with_limit(limit)
+      response = block_given? ? nil : []
+      count = 0
+      each_page do |page|
+        if block_given?
+          page.each do |item|
+            yield item
+            count += 1
+            break if count >= limit
+          end
+        else
+          response += page[0, limit - count]
+          count = response.length
+        end
+        break if count >= limit
+      end
+      response
+    end
+
     def last_page?
       !(@links.nil? || @links.last.nil?)
     end

--- a/spec/gitlab/paginated_response_spec.rb
+++ b/spec/gitlab/paginated_response_spec.rb
@@ -95,7 +95,6 @@ describe Gitlab::PaginatedResponse do
     end
   end
 
-
   shared_context 'when performing limited pagination with a block' do
     before do
       next_page = double('next_page')
@@ -126,5 +125,4 @@ describe Gitlab::PaginatedResponse do
       expect { |b| @paginated_response.paginate_with_limit(5, &b) }.to yield_successive_args(1, 2, 3, 4, 5)
     end
   end
-
 end


### PR DESCRIPTION
… only up to X results

Useful for situations like fetching the 200 most recent MRs from a large project.
