### PR TITLE
Add support for commit refs API

### DIFF
--- a/lib/gitlab/client/commits.rb
+++ b/lib/gitlab/client/commits.rb
@@ -35,6 +35,22 @@ class Gitlab::Client
     end
     alias repo_commit commit
 
+    # Get all references (from branches or tags) a commit is pushed to.
+    #
+    # @example
+    #   Gitlab.commit_refs(42, '6104942438c14ec7bd21c6cd5bd995272b3faff6')
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [String] sha The commit hash
+    # @param  [Hash] options A customizable set of options.
+    # @option options [String] :type The scope of commits. Possible values `branch`, `tag`, `all`. Default is `all`.
+    # @option options [Integer] :page The page number.
+    # @option options [Integer] :per_page The number of results per page.
+    # @return [Gitlab::ObjectifiedHash]
+    def commit_refs(project, sha, options = {})
+      get("/projects/#{url_encode project}/repository/commits/#{sha}/refs", query: options)
+    end
+
     # Cherry picks a commit to a given branch.
     #
     # @example

--- a/spec/fixtures/project_commit_refs.json
+++ b/spec/fixtures/project_commit_refs.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "branch",
+    "name": "12-1-stable"
+  },
+  {
+    "type": "branch",
+    "name": "12-1-stable-prepare-rc23"
+  },
+  {
+    "type": "tag",
+    "name": "v12.1.0"
+  },
+  {
+    "type": "tag",
+    "name": "v12.1.0-rc22"
+  },
+  {
+    "type": "tag",
+    "name": "v12.1.0-rc23"
+  }
+]

--- a/spec/gitlab/client/commits_spec.rb
+++ b/spec/gitlab/client/commits_spec.rb
@@ -46,6 +46,24 @@ describe Gitlab::Client do
     end
   end
 
+  describe '.commit_refs' do
+    before do
+      stub_get('/projects/3/repository/commits/0b4cd14ccc6a5c392526df719d29baf4315a4bbb/refs', 'project_commit_refs')
+      @refs = Gitlab.commit_refs(3, '0b4cd14ccc6a5c392526df719d29baf4315a4bbb')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/repository/commits/0b4cd14ccc6a5c392526df719d29baf4315a4bbb/refs'))
+        .to have_been_made
+    end
+
+    it 'returns an Array of refs' do
+      expect(@refs.map(&:to_h))
+        .to include('type' => 'branch', 'name' => '12-1-stable')
+        .and include('type' => 'tag', 'name' => 'v12.1.0')
+    end
+  end
+
   describe '.cherry_pick_commit' do
     before do
       stub_post('/projects/3/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/cherry_pick', 'project_commit').with(body: { branch: 'master' })


### PR DESCRIPTION
See https://docs.gitlab.com/ee/api/commits.html#get-references-a-commit-is-pushed-to