### PR TITLE
Updating Repositories code documentation

### DIFF
--- a/lib/gitlab/client/repositories.rb
+++ b/lib/gitlab/client/repositories.rb
@@ -14,6 +14,7 @@ class Gitlab::Client
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :path The path inside repository.
     # @option options [String] :ref_name The name of a repository branch or tag.
+    # @option options [Integer] :per_page Number of results to show per page (default = 20)
     # @return [Gitlab::ObjectifiedHash]
     def tree(project, options = {})
       get("/projects/#{url_encode project}/repository/tree", query: options)


### PR DESCRIPTION
Hi there 👋 

While using the `tree`  method of Repositories I noticed one small discrepancy with the actual API.

Although it's not documented in code, there's one other option of passing the `per_page` value to configure how many results you want per page.

See https://docs.gitlab.com/ee/api/repositories.html#list-repository-tree

I've used this with the actual version of this wrapper and it's working 👍 

It's just a matter of updating the documentation.


Thanks for this wrapper! It's super useful 😄 