### PR TITLE
Allow custom header arguments via `httparty` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,14 @@ ENV['GITLAB_API_HTTPARTY_OPTIONS'] = '{read_timeout: 60}'
 Gitlab.projects(per_page: 5)
 # => [#<Gitlab::ObjectifiedHash:0x000000023326e0 @data={"id"=>1, "code"=>"brute", "name"=>"Brute", "description"=>nil, "path"=>"brute", "default_branch"=>nil, "owner"=>#<Gitlab::ObjectifiedHash:0x00000002331600 @data={"id"=>1, "email"=>"john@example.com", "name"=>"John Smith", "blocked"=>false, "created_at"=>"2012-09-17T09:41:56Z"}>, "private"=>true, "issues_enabled"=>true, "merge_requests_enabled"=>true, "wall_enabled"=>true, "wiki_enabled"=>true, "created_at"=>"2012-09-17T09:41:56Z"}>, #<Gitlab::ObjectifiedHash:0x000000023450d8 @data={"id"=>2, "code"=>"mozart", "name"=>"Mozart", "description"=>nil, "path"=>"mozart", "default_branch"=>nil, "owner"=>#<Gitlab::ObjectifiedHash:0x00000002344ca0 @data={"id"=>1, "email"=>"john@example.com", "name"=>"John Smith", "blocked"=>false, "created_at"=>"2012-09-17T09:41:56Z"}>, "private"=>true, "issues_enabled"=>true, "merge_requests_enabled"=>true, "wall_enabled"=>true, "wiki_enabled"=>true, "created_at"=>"2012-09-17T09:41:57Z"}>, #<Gitlab::ObjectifiedHash:0x00000002344958 @data={"id"=>3, "code"=>"gitlab", "name"=>"Gitlab", "description"=>nil, "path"=>"gitlab", "default_branch"=>nil, "owner"=>#<Gitlab::ObjectifiedHash:0x000000023447a0 @data={"id"=>1, "email"=>"john@example.com", "name"=>"John Smith", "blocked"=>false, "created_at"=>"2012-09-17T09:41:56Z"}>, "private"=>true, "issues_enabled"=>true, "merge_requests_enabled"=>true, "wall_enabled"=>true, "wiki_enabled"=>true, "created_at"=>"2012-09-17T09:41:58Z"}>]
 
-# initialize a new client
-g = Gitlab.client(endpoint: 'https://api.example.com', private_token: 'qEsq1pt6HJPaNciie3MG')
+# initialize a new client with custom headers
+g = Gitlab.client(
+  endpoint: 'https://example.com/api/v4',
+  private_token: 'qEsq1pt6HJPaNciie3MG',
+  httparty: {
+    headers: { 'Cookie' => 'gitlab_canary=true' }
+  }
+)
 # => #<Gitlab::Client:0x00000001e62408 @endpoint="https://api.example.com", @private_token="qEsq1pt6HJPaNciie3MG", @user_agent="Gitlab Ruby Gem 2.0.0">
 
 # get a user

--- a/lib/gitlab/request.rb
+++ b/lib/gitlab/request.rb
@@ -42,7 +42,12 @@ module Gitlab
     %w[get post put delete].each do |method|
       define_method method do |path, options = {}|
         httparty_config(options)
-        authorization_header(options)
+
+        unless options[:unauthenticated]
+          options[:headers] ||= {}
+          options[:headers].merge!(authorization_header)
+        end
+
         validate self.class.send(method, @endpoint + path, options)
       end
     end
@@ -62,28 +67,25 @@ module Gitlab
     # Sets a base_uri and default_params for requests.
     # @raise [Error::MissingCredentials] if endpoint not set.
     def request_defaults(sudo = nil)
-      self.class.default_params sudo: sudo
       raise Error::MissingCredentials, 'Please set an endpoint to API' unless @endpoint
 
+      self.class.default_params sudo: sudo
       self.class.default_params.delete(:sudo) if sudo.nil?
     end
 
     private
 
-    # Sets a PRIVATE-TOKEN or Authorization header for requests.
+    # Returns an Authorization header hash
     #
-    # @param [Hash] options A customizable set of options.
-    # @option options [Boolean] :unauthenticated true if the API call does not require user authentication.
     # @raise [Error::MissingCredentials] if private_token and auth_token are not set.
-    def authorization_header(options)
-      return if options[:unauthenticated]
+    def authorization_header
       raise Error::MissingCredentials, 'Please provide a private_token or auth_token for user' unless @private_token
 
-      options[:headers] = if @private_token.size < 21
-                            { 'PRIVATE-TOKEN' => @private_token }
-                          else
-                            { 'Authorization' => "Bearer #{@private_token}" }
-                          end
+      if @private_token.size < 21
+        { 'PRIVATE-TOKEN' => @private_token }
+      else
+        { 'Authorization' => "Bearer #{@private_token}" }
+      end
     end
 
     # Set HTTParty configuration

--- a/spec/gitlab/request_spec.rb
+++ b/spec/gitlab/request_spec.rb
@@ -7,7 +7,12 @@ describe Gitlab::Request do
   it { is_expected.to respond_to :post }
   it { is_expected.to respond_to :put }
   it { is_expected.to respond_to :delete }
+
   before do
+    # Prevent tests modifying the `default_params` value from causing cross-test
+    # pollution
+    described_class.default_params.delete(:sudo)
+
     @request = described_class.new
   end
 
@@ -18,7 +23,7 @@ describe Gitlab::Request do
       expect(default_options[:parser]).to be_a Proc
       expect(default_options[:format]).to eq(:json)
       expect(default_options[:headers]).to eq('Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded')
-      expect(default_options[:default_params]).to be_nil
+      expect(default_options[:default_params]).to be_empty
     end
   end
 
@@ -55,21 +60,42 @@ describe Gitlab::Request do
     end
   end
 
+  describe 'HTTP request methods' do
+    it 'does not overwrite headers set via HTTParty configuration' do
+      @request.private_token = 'token'
+      @request.endpoint = 'https://example.com/api/v4'
+      path = "#{@request.endpoint}/version"
+
+      # Stub Gitlab::Configuration
+      allow(@request).to receive(:httparty).and_return({
+        headers: { 'Cookie' => 'gitlab_canary=true' }
+      })
+
+      stub_request(:get, path)
+      @request.get('/version')
+
+      expect(a_request(:get, path).with(headers: {
+        'PRIVATE_TOKEN' => 'token',
+        'Cookie' => 'gitlab_canary=true'
+      }.merge(described_class.headers))).to have_been_made
+    end
+  end
+
   describe '#authorization_header' do
     it 'raises MissingCredentials when auth_token and private_token are not set' do
       expect do
-        @request.send(:authorization_header, {})
+        @request.send(:authorization_header)
       end.to raise_error(Gitlab::Error::MissingCredentials)
     end
 
     it 'sets the correct header when given a private_token' do
       @request.private_token = 'ys9BtunN3rDKbaJCYXaN'
-      expect(@request.send(:authorization_header, {})).to eq('PRIVATE-TOKEN' => 'ys9BtunN3rDKbaJCYXaN')
+      expect(@request.send(:authorization_header)).to eq('PRIVATE-TOKEN' => 'ys9BtunN3rDKbaJCYXaN')
     end
 
     it 'sets the correct header when setting an auth_token via the private_token config option' do
       @request.private_token = '3225e2804d31fea13fc41fc83bffef00cfaedc463118646b154acc6f94747603'
-      expect(@request.send(:authorization_header, {})).to eq('Authorization' => 'Bearer 3225e2804d31fea13fc41fc83bffef00cfaedc463118646b154acc6f94747603')
+      expect(@request.send(:authorization_header)).to eq('Authorization' => 'Bearer 3225e2804d31fea13fc41fc83bffef00cfaedc463118646b154acc6f94747603')
     end
   end
 end


### PR DESCRIPTION
The `Gitlab::Client` initializer allows you to pass an `httparty` option
to provide additional options to the internal HTTParty client. This is great!
However, previously the `Gitlab::Request` class would overwrite the
`headers` value in order to set its authorization token.

Now, we merge the authorization token with any user-defined HTTParty
header arguments.