### PR TITLE
[FIX] Moving file open logic to upload_file from args to support CLI

### DIFF
--- a/lib/gitlab/client/projects.rb
+++ b/lib/gitlab/client/projects.rb
@@ -529,14 +529,13 @@ class Gitlab::Client
     # @see https://docs.gitlab.com/ee/api/projects.html#upload-a-file
     #
     # @example
-    #   Gitlab.upload_file(1, File.open(File::NULL, 'r'))
-    #   File.open('myfile') { |file| Gitlab.upload_file(1, file) }
+    #   Gitlab.upload_file(1, '/full/path/to/avatar.jpg')
     #
     # @param  [Integer, String] id The ID or path of a project.
-    # @param  [File] The file you are interested to upload.
+    # @param  [String] file_fullpath The fullpath of the file you are interested to upload.
     # @return [Gitlab::ObjectifiedHash]
-    def upload_file(id, file)
-      post("/projects/#{url_encode id}/uploads", body: { file: file })
+    def upload_file(id, file_fullpath)
+      post("/projects/#{url_encode id}/uploads", body: { file: File.open(file_fullpath, 'r') })
     end
 
     # Get all project templates of a particular type

--- a/lib/gitlab/client/search.rb
+++ b/lib/gitlab/client/search.rb
@@ -56,7 +56,7 @@ class Gitlab::Client
     # @return [Array<Gitlab::ObjectifiedHash>] Returns a list of responses depending on the requested scope.
     def search_in_project(project, scope, search, ref = nil)
       options = { scope: scope, search: search }
-      
+
       # Add ref filter if provided - backward compatible with main project
       options[:ref] = ref unless ref.nil?
 

--- a/spec/gitlab/client/projects_spec.rb
+++ b/spec/gitlab/client/projects_spec.rb
@@ -695,11 +695,11 @@ describe Gitlab::Client do
 
   describe '.upload_file' do
     let(:id) { 1 }
-    let(:file) { File.open(File::NULL, 'r') }
+    let(:file_fullpath) { File::NULL }
 
     before do
       stub_post("/projects/#{id}/uploads", 'upload_file')
-      @file = Gitlab.upload_file(id, file)
+      @file = Gitlab.upload_file(id, file_fullpath)
     end
 
     it 'gets the correct resource' do


### PR DESCRIPTION
The `upload_file` api expects the file argument to be passed using a `File.open()` ie. a file object explicitly, to allow multipart upload. While this may work for someone working inside irb or a ruby app, but for Gitlab CLI, it becomes tougher to use for the common folk.

**Suggestion (and changes made):**

Take the fullpath of the file to be uploaded as argument, and then use the `File.open` logic inside the method to upload the file as multipart. This will make it consistently usable for both irb and CLI.

Closes #510 