### PR TITLE
add support for file blame API

### DIFF
--- a/lib/gitlab/client/repository_files.rb
+++ b/lib/gitlab/client/repository_files.rb
@@ -25,6 +25,23 @@ class Gitlab::Client
     end
     alias repo_file_contents file_contents
 
+
+    # Get file blame from repository
+    #
+    # @example
+    #   Gitlab.get_file_blame(42, "README.md", "master")
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [String] file_path The full path of the file.
+    # @param  [String] ref The name of branch, tag or commit.
+    # @return [Gitlab::ObjectifiedHash]
+    #
+    def get_file_blame(project, file_path, ref)
+      get("/projects/#{url_encode project}/repository/files/#{url_encode file_path}/blame", query: {
+            ref: ref
+          })
+    end
+
     # Gets a repository file.
     #
     # @example

--- a/lib/gitlab/client/repository_files.rb
+++ b/lib/gitlab/client/repository_files.rb
@@ -25,7 +25,6 @@ class Gitlab::Client
     end
     alias repo_file_contents file_contents
 
-
     # Get file blame from repository
     #
     # @example

--- a/spec/fixtures/get_file_blame.json
+++ b/spec/fixtures/get_file_blame.json
@@ -1,0 +1,23 @@
+[
+  {
+    "commit": {
+      "id": "d42409d56517157c48bf3bd97d3f75974dde19fb",
+      "message": "Add feature\n\nalso fix bug\n",
+      "parent_ids": [
+        "cc6e14f9328fa6d7b5a0d3c30dc2002a3f2a3822"
+      ],
+      "authored_date": "2015-12-18T08:12:22.000Z",
+      "author_name": "John Doe",
+      "author_email": "john.doe@example.com",
+      "committed_date": "2015-12-18T08:12:22.000Z",
+      "committer_name": "John Doe",
+      "committer_email": "john.doe@example.com"
+    },
+    "lines": [
+      "require 'fileutils'",
+      "require 'open3'"
+    ]
+  }
+]
+
+

--- a/spec/gitlab/client/repository_files_spec.rb
+++ b/spec/gitlab/client/repository_files_spec.rb
@@ -18,6 +18,21 @@ describe Gitlab::Client do
     end
   end
 
+  describe '.get_file_blame' do
+    before do
+      stub_get('/projects/3/repository/files/README%2Emd/blame?ref=master', 'get_file_blame')
+      @blames = Gitlab.get_file_blame(3, 'README.md', 'master')
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/repository/files/README%2Emd/blame?ref=master')).to have_been_made
+    end
+
+    it 'returns the blame info of the file' do
+      expect(@blames.first.commit.id).to eq("d42409d56517157c48bf3bd97d3f75974dde19fb")
+    end
+  end
+
   describe '.get_file' do
     before do
       stub_get('/projects/3/repository/files/README%2Emd?ref=master', 'get_repository_file')

--- a/spec/gitlab/client/repository_files_spec.rb
+++ b/spec/gitlab/client/repository_files_spec.rb
@@ -29,7 +29,7 @@ describe Gitlab::Client do
     end
 
     it 'returns the blame info of the file' do
-      expect(@blames.first.commit.id).to eq("d42409d56517157c48bf3bd97d3f75974dde19fb")
+      expect(@blames.first.commit.id).to eq('d42409d56517157c48bf3bd97d3f75974dde19fb')
     end
   end
 


### PR DESCRIPTION
Detailed at  [get file blame from repository](https://docs.gitlab.com/ee/api/repository_files.html#get-file-blame-from-repository)