### PR TITLE
Options hash documentation for tree and commits methods is outdated

### DIFF
--- a/lib/gitlab/client/commits.rb
+++ b/lib/gitlab/client/commits.rb
@@ -8,11 +8,11 @@ class Gitlab::Client
     #
     # @example
     #   Gitlab.commits('viking')
-    #   Gitlab.repo_commits('gitlab', { ref_name: 'api' })
+    #   Gitlab.repo_commits('gitlab', { ref: 'api' })
     #
     # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
-    # @option options [String] :ref_name The branch or tag name of a project repository.
+    # @option options [String] :ref The branch or tag name of a project repository.
     # @option options [Integer] :page The page number.
     # @option options [Integer] :per_page The number of results per page.
     # @return [Array<Gitlab::ObjectifiedHash>]

--- a/lib/gitlab/client/repositories.rb
+++ b/lib/gitlab/client/repositories.rb
@@ -13,7 +13,7 @@ class Gitlab::Client
     # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :path The path inside repository.
-    # @option options [String] :ref_name The name of a repository branch or tag.
+    # @option options [String] :ref The name of a repository branch or tag.
     # @option options [Integer] :per_page Number of results to show per page (default = 20)
     # @return [Gitlab::ObjectifiedHash]
     def tree(project, options = {})

--- a/spec/gitlab/client/commits_spec.rb
+++ b/spec/gitlab/client/commits_spec.rb
@@ -15,13 +15,13 @@ describe Gitlab::Client do
   describe '.commits' do
     before do
       stub_get('/projects/3/repository/commits', 'project_commits')
-        .with(query: { ref_name: 'api' })
-      @commits = Gitlab.commits(3, ref_name: 'api')
+        .with(query: { ref: 'api' })
+      @commits = Gitlab.commits(3, ref: 'api')
     end
 
     it 'gets the correct resource' do
       expect(a_get('/projects/3/repository/commits')
-        .with(query: { ref_name: 'api' })).to have_been_made
+        .with(query: { ref: 'api' })).to have_been_made
     end
 
     it 'returns a paginated response of repository commits' do


### PR DESCRIPTION
Gitlab API v4 uses the get parameter `ref` instead of `ref_name` when listing commits and files. Current documentation does not reflect that change. Its confusing because when `ref_name` is used, API will just default to master. We tested it in our server (master contains 9 files and version 1.0.0 has 7):

```
irb(main):061:0> g.tree(5419,ref_name: '1.0.0').count
=> 9
irb(main):062:0> g.tree(5419,ref: '1.0.0').count
=> 7
```