### PR TITLE
Support optional parameters to `.group`

### DIFF
--- a/lib/gitlab/client/groups.rb
+++ b/lib/gitlab/client/groups.rb
@@ -24,9 +24,12 @@ class Gitlab::Client
     #   Gitlab.group(42)
     #
     # @param  [Integer] id The ID of a group.
+    # @param  [Hash] options A customizable set of options.
+    # @option options [Boolean] :with_custom_attributes Include custom attributes in response (admins only)
+    # @option options [Boolean] :with_projects Include details about group projects (default: true)
     # @return [Gitlab::ObjectifiedHash]
-    def group(id)
-      get("/groups/#{url_encode id}")
+    def group(id, options = {})
+      get("/groups/#{url_encode id}", query: options)
     end
 
     # Creates a new group.

--- a/spec/gitlab/client/groups_spec.rb
+++ b/spec/gitlab/client/groups_spec.rb
@@ -22,6 +22,17 @@ describe Gitlab::Client do
     end
   end
 
+  describe '.group' do
+    before do
+      stub_get('/groups/3?with_projects=false', 'group')
+      @group = Gitlab.group(3, with_projects: false)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/groups/3?with_projects=false')).to have_been_made
+    end
+  end
+
   describe '.create_group' do
     context 'without description' do
       before do


### PR DESCRIPTION
The Group details API has support for two optional flags, which include
custom attributes in the response, and allows limiting the details
returned.

See https://docs.gitlab.com/ee/api/groups.html#details-of-a-group