### PR TITLE
Add support for Epic CRUD actions

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -19,6 +19,7 @@ module Gitlab
     include ContainerRegistry
     include Deployments
     include Environments
+    include Epics
     include Events
     include Features
     include GroupBoards

--- a/lib/gitlab/client/epics.rb
+++ b/lib/gitlab/client/epics.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class Gitlab::Client
+  # Defines methods related to Epics.
+  # @see https://docs.gitlab.com/ee/api/epics.html
+  module Epics
+    # Gets a list of epics.
+    #
+    # @example
+    #   Gitlab.epics(123)
+    #   Gitlab.epics(123, { per_page: 40, page: 2 })
+    #
+    # @param  [Integer] group_id The ID of a group.
+    # @param  [Hash] options A customizable set of options.
+    # @option options [Integer] :page The page number.
+    # @option options [Integer] :per_page The number of results per page.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def epics(group_id, options = {})
+      get("/groups/#{group_id}/epics", query: options)
+    end
+
+    # Gets a single epic.
+    #
+    # @example
+    #   Gitlab.epic(123, 1)
+    #
+    # @param  [Integer] group_id The ID of a group.
+    # @param  [Integer] epic_iid The ID of a epic.
+    # @param  [Hash] options A customizable set of options.
+    # @return [Gitlab::ObjectifiedHash]
+    def epic(group_id, epic_iid, options = {})
+      get("/groups/#{group_id}/epics/#{epic_iid}", query: options)
+    end
+
+    # Creates a new epic.
+    #
+    # @example
+    #   Gitlab.create_epic(123, "My new epic title")
+    #
+    # @param  [Integer] group_id The ID of a group.
+    # @param  [String] title
+    # @param  [Hash] options A customizable set of options.
+    # @return [Gitlab::ObjectifiedHash] Information about created epic.
+    def create_epic(group_id, title, options = {})
+      body = options.merge(title: title)
+      post("/groups/#{group_id}/epics", body: body)
+    end
+
+    # Deletes an epic.
+    #
+    # @example
+    #   Gitlab.delete_epic(42, 123)
+    # @param  [Integer] group_id The ID of a group.
+    # @param  [Integer] epic_iid The IID of an epic.
+    def delete_epic(group_id, epic_iid)
+      delete("/groups/#{group_id}/epics/#{epic_iid}")
+    end
+
+    # Updates an existing epic.
+    #
+    # @example
+    #   Gitlab.edit_epic(42)
+    #   Gitlab.edit_epic(42, 123, { title: 'New epic title' })
+    #
+    # @param  [Integer] group_id The ID.
+    # @param  [Integer] epic_iid The IID of an epic.
+    # @param  [Hash] options A customizable set of options
+    # @return [Gitlab::ObjectifiedHash] Information about the edited epic.
+    def edit_epic(group_id, epic_iid, options = {})
+      put("/groups/#{group_id}/epics/#{epic_iid}", body: options)
+    end
+  end
+end

--- a/spec/fixtures/epic.json
+++ b/spec/fixtures/epic.json
@@ -1,0 +1,34 @@
+{
+  "id": 30,
+  "iid": 5,
+  "group_id": 7,
+  "title": "Ea cupiditate dolores ut vero consequatur quasi veniam voluptatem et non.",
+  "description": "Molestias dolorem eos vitae expedita impedit necessitatibus quo voluptatum.",
+  "state": "opened",
+  "web_url": "http://localhost:3001/groups/test/-/epics/5",
+  "reference": "&5",
+  "author":{
+    "id": 7,
+    "name": "Pamella Huel",
+    "username": "arnita",
+    "state": "active",
+    "avatar_url": "http://www.gravatar.com/avatar/a2f5c6fcef64c9c69cb8779cb292be1b?s=80&d=identicon",
+    "web_url": "http://localhost:3001/arnita"
+  },
+  "start_date": null,
+  "start_date_is_fixed": false,
+  "start_date_fixed": null,
+  "start_date_from_inherited_source": null,
+  "due_date": "2018-07-31",
+  "due_date_is_fixed": false,
+  "due_date_fixed": null,
+  "due_date_from_inherited_source": "2018-07-31",
+  "created_at": "2018-07-17T13:36:22.770Z",
+  "updated_at": "2018-07-18T12:22:05.239Z",
+  "closed_at": "2018-08-18T12:22:05.239Z",
+  "labels": [],
+  "upvotes": 4,
+  "downvotes": 0,
+  "subscribed": true
+}
+

--- a/spec/fixtures/epics.json
+++ b/spec/fixtures/epics.json
@@ -1,0 +1,35 @@
+[
+  {
+  "id": 29,
+  "iid": 4,
+  "group_id": 7,
+  "title": "Accusamus iste et ullam ratione voluptatem omnis debitis dolor est.",
+  "description": "Molestias dolorem eos vitae expedita impedit necessitatibus quo voluptatum.",
+  "state": "opened",
+  "web_url": "http://localhost:3001/groups/test/-/epics/4",
+  "reference": "&4",
+  "author": {
+    "id": 10,
+    "name": "Lu Mayer",
+    "username": "kam",
+    "state": "active",
+    "avatar_url": "http://www.gravatar.com/avatar/018729e129a6f31c80a6327a30196823?s=80&d=identicon",
+    "web_url": "http://localhost:3001/kam"
+  },
+  "start_date": null,
+  "start_date_is_fixed": false,
+  "start_date_fixed": null,
+  "start_date_from_inherited_source": null,
+  "due_date": "2018-07-31",
+  "due_date_is_fixed": false,
+  "due_date_fixed": null,
+  "due_date_from_inherited_source": "2018-07-31",
+  "created_at": "2018-07-17T13:36:22.770Z",
+  "updated_at": "2018-07-18T12:22:05.239Z",
+  "closed_at": "2018-08-18T12:22:05.239Z",
+  "labels": [],
+  "upvotes": 4,
+  "downvotes": 0
+  }
+]
+

--- a/spec/gitlab/client/epics_spec.rb
+++ b/spec/gitlab/client/epics_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Gitlab::Client do
+  describe '.epics' do
+    before do
+      stub_get('/groups/1/epics', 'epics')
+      @epics = Gitlab.epics(1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/groups/1/epics')).to have_been_made
+    end
+
+    it 'returns a paginated response of groups' do
+      expect(@epics).to be_a Gitlab::PaginatedResponse
+    end
+  end
+
+  describe '.epic' do
+    before do
+      stub_get('/groups/1/epics/2', 'epic')
+      Gitlab.epic(1, 2)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/groups/1/epics/2')).to have_been_made
+    end
+  end
+
+  describe '.create_epic' do
+    before do
+      stub_post('/groups/1/epics', 'epic')
+      Gitlab.create_epic(1, 'foo', description: 'bar')
+    end
+
+    it 'creates the right resource' do
+      expect(a_post('/groups/1/epics')
+        .with(body: { title: 'foo', description: 'bar' })).to have_been_made
+    end
+  end
+
+  describe '.edit_epic' do
+    before do
+      stub_put('/groups/1/epics/2', 'epic')
+      Gitlab.edit_epic(1, 2, title: 'mepmep')
+    end
+
+    it 'updates the correct resource' do
+      expect(a_put('/groups/1/epics/2')
+        .with(body: { title: 'mepmep' })).to have_been_made
+    end
+  end
+
+  describe '.delete_epic' do
+    before do
+      stub_delete('/groups/1/epics/2', 'epic')
+      Gitlab.delete_epic(1, 2)
+    end
+
+    it 'deletes the correct resource' do
+      expect(a_delete('/groups/1/epics/2')).to have_been_made
+    end
+  end
+end


### PR DESCRIPTION
GitLab has Epics for paid subscriptions, or licenced products. To
interact with them, basic CRUD action support is added by this change.