### PR TITLE
Revert "Merge pull request #530 from rspeicher/rs-error-method-missing"

### DIFF
--- a/lib/gitlab/error.rb
+++ b/lib/gitlab/error.rb
@@ -78,18 +78,6 @@ module Gitlab
           message
         end
       end
-
-      def method_missing(method, *args, &block)
-        if @response.parsed_response.key?(method)
-          @response.parsed_response[method]
-        else
-          super
-        end
-      end
-
-      def respond_to_missing?(method, include_private = false)
-        super || @response.parsed_response.key?(method, include_private)
-      end
     end
 
     # Raised when API endpoint returns the HTTP status code 400.

--- a/spec/gitlab/error_spec.rb
+++ b/spec/gitlab/error_spec.rb
@@ -51,20 +51,4 @@ describe Gitlab::Error::ResponseError do
     response_double = double('response', body: 'Retry later', to_s: 'Retry text', parsed_response: { message: 'Retry hash' }, code: 429, options: {}, headers: headers, request: @request_double)
     expect(described_class.new(response_double).send(:build_error_message)).to match(/Retry hash/)
   end
-
-  it 'passes missing messages to the parsed response' do
-    response_hash = { message: 'Failed to cherry-pick', error_code: 'empty' }
-    response_double = double(
-      'response',
-      body: JSON.dump(response_hash),
-      parsed_response: response_hash,
-      code: 400,
-      headers: { 'content-type' => 'application/json' },
-      request: @request_double
-    )
-
-    error = described_class.new(response_double)
-
-    expect(error.error_code).to eq(response_hash[:error_code])
-  end
 end


### PR DESCRIPTION
This reverts commit 216251a554e2392ed22e61ef279bd7d4008fa1f0, reversing
changes made to e10c7e2a840666518d679f426082b1fbc6753aea.

After updating to 4.13.0 in https://gitlab.com/gitlab-com/chatops, I started seeing unexpected spec failures related to argument counts and `method_missing` on `ObjectifiedHash`, so for the time being I think it's best to revert this feature until it can be properly re-implemented.

I suggest a 4.13.1 patch release after this revert.