### PR TITLE
Add a method to delete job artifacts

### DIFF
--- a/lib/gitlab/client/jobs.rb
+++ b/lib/gitlab/client/jobs.rb
@@ -163,5 +163,19 @@ class Gitlab::Client
     def job_artifacts_keep(project_id, job_id)
       post("/projects/#{url_encode project_id}/jobs/#{job_id}/artifacts/keep")
     end
+
+    # Delete Artifacts
+    # Deletes the artifacts associated with a job.
+    #
+    # @example
+    #   Gitlab.job_artifacts_delete(1,1)
+    #   Gitlab.job_artifacts_delete("project", 1)
+    #
+    # @param  [Integer, String] The ID or name of a project.
+    # @param  [Integer]  the id of the job
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def job_artifacts_delete(project_id, job_id)
+      delete("/projects/#{url_encode project_id}/jobs/#{job_id}/artifacts")
+    end
   end
 end

--- a/spec/gitlab/client/jobs_spec.rb
+++ b/spec/gitlab/client/jobs_spec.rb
@@ -145,4 +145,15 @@ describe Gitlab::Client do
       expect(a_post('/projects/1/jobs/1/artifacts/keep')).to have_been_made
     end
   end
+
+  describe '.job_artifacts_delete' do
+    before do
+      stub_delete('/projects/1/jobs/1/artifacts', 'job')
+      @projects = Gitlab.job_artifacts_delete(1, 1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_delete('/projects/1/jobs/1/artifacts')).to have_been_made
+    end
+  end
 end


### PR DESCRIPTION
This adds a method for deleting job artifacts.

If you never set expiration for your artifacts and now need a mass delete, this function will help.