### PR TITLE
Avoid modifying request parameters in-place

### DIFF
--- a/lib/gitlab/request.rb
+++ b/lib/gitlab/request.rb
@@ -41,14 +41,16 @@ module Gitlab
 
     %w[get post put delete].each do |method|
       define_method method do |path, options = {}|
-        httparty_config(options)
+        params = options.dup
 
-        unless options[:unauthenticated]
-          options[:headers] ||= {}
-          options[:headers].merge!(authorization_header)
+        httparty_config(params)
+
+        unless params[:unauthenticated]
+          params[:headers] ||= {}
+          params[:headers].merge!(authorization_header)
         end
 
-        validate self.class.send(method, @endpoint + path, options)
+        validate self.class.send(method, @endpoint + path, params)
       end
     end
 

--- a/spec/gitlab/request_spec.rb
+++ b/spec/gitlab/request_spec.rb
@@ -79,6 +79,22 @@ describe Gitlab::Request do
         'Cookie' => 'gitlab_canary=true'
       }.merge(described_class.headers))).to have_been_made
     end
+
+    it 'does not modify options in-place' do
+      options = { per_page: 10 }
+      original_options = options.dup
+
+      @request.private_token = 'token'
+      @request.endpoint = 'https://example.com/api/v4'
+
+      # Stub Gitlab::Configuration
+      allow(@request).to receive(:httparty).and_return(nil)
+
+      stub_request(:get, "#{@request.endpoint}/projects")
+      @request.get('/projects', options)
+
+      expect(options).to eq(original_options)
+    end
   end
 
   describe '#authorization_header' do


### PR DESCRIPTION
Consider the following script:

```ruby
require 'gitlab'

client = Gitlab::Client.new(
  endpoint: 'https://gitlab.com/api/v4',
  private_token: '[REDACTED]'
)

args = { per_page: 10 }
puts args.inspect

client.get('/projects', args)
puts args.inspect
```

Prior to this change, this would output:

    {:per_page=>10}
    {:per_page=>10, :headers=>{"PRIVATE-TOKEN"=>"[REDACTED]"}}

Which would be a problem if a user were logging the parameters they were
passing to a `PUT` endpoint inside a loop, for example. The first log
message would have their parameters, while subsequent logs would have
their parameters plus their private token.

This is unexpected behavior that could expose credentials.

Now we duplicate the user parameters before modifying them in-place.