### PR TITLE
add ruby 2.7 support

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -74,7 +74,7 @@ module Gitlab
     end
 
     def url_encode(url)
-      URI.encode(url.to_s, /\W/)
+      URI.encode_www_form_component(url.to_s)
     end
 
     private


### PR DESCRIPTION
Hello,

Since ruby 2.7 I've this warning:
```
gems/gitlab-4.13.1/lib/gitlab/client.rb:77: warning: URI.escape is obsolete
```

I suppose that now it's [encode_www_form_component](https://docs.ruby-lang.org/en/2.7.0/URI.html#method-c-encode_www_form_component)