### PR TITLE
Add repository contributors API

### DIFF
--- a/lib/gitlab/client/repositories.rb
+++ b/lib/gitlab/client/repositories.rb
@@ -88,6 +88,5 @@ class Gitlab::Client
       get("/projects/#{url_encode project}/repository/contributors", query: options)
     end
     alias repo_contributors contributors
-
   end
 end

--- a/lib/gitlab/client/repositories.rb
+++ b/lib/gitlab/client/repositories.rb
@@ -72,5 +72,22 @@ class Gitlab::Client
     def merge_base(project, refs)
       get("/projects/#{url_encode project}/repository/merge_base", query: { refs: refs })
     end
+
+    # Get project repository contributors.
+    #
+    # @example
+    #   Gitlab.contributors(42)
+    #   Gitlab.contributors(42, { order: 'name' })
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Hash] options A customizable set of options.
+    # @option options [String] :order_by Order by name, email or commits (default = commits).
+    # @option options [String] :sort Sort order asc or desc (default = asc).
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def contributors(project, options = {})
+      get("/projects/#{url_encode project}/repository/contributors", query: options)
+    end
+    alias repo_contributors contributors
+
   end
 end

--- a/spec/fixtures/contributors.json
+++ b/spec/fixtures/contributors.json
@@ -1,0 +1,13 @@
+[{
+    "name": "Dmitriy Zaporozhets",
+    "email": "dmitriy.zaporozhets@gmail.com",
+    "commits": 117,
+    "additions": 2097,
+    "deletions": 517
+  }, {
+    "name": "Jacob Vosmaer",
+    "email": "contact@jacobvosmaer.nl",
+    "commits": 33,
+    "additions": 338,
+    "deletions": 244
+  }]

--- a/spec/fixtures/contributors.json
+++ b/spec/fixtures/contributors.json
@@ -11,4 +11,3 @@
     "additions": 338,
     "deletions": 244
   }]
-  

--- a/spec/fixtures/contributors.json
+++ b/spec/fixtures/contributors.json
@@ -11,3 +11,4 @@
     "additions": 338,
     "deletions": 244
   }]
+  

--- a/spec/gitlab/client/repositories_spec.rb
+++ b/spec/gitlab/client/repositories_spec.rb
@@ -130,4 +130,3 @@ describe '.contributors' do
     expect(@contributors.first.commits).to eq(117)
   end
 end
-

--- a/spec/gitlab/client/repositories_spec.rb
+++ b/spec/gitlab/client/repositories_spec.rb
@@ -126,7 +126,7 @@ describe '.contributors' do
 
   it 'returns a paginated response of repository contributors' do
     expect(@contributors).to be_a Gitlab::PaginatedResponse
-    expect(@contributors.first.name).to eq("Dmitriy Zaporozhets")
+    expect(@contributors.first.name).to eq('Dmitriy Zaporozhets')
     expect(@contributors.first.commits).to eq(117)
   end
 end

--- a/spec/gitlab/client/repositories_spec.rb
+++ b/spec/gitlab/client/repositories_spec.rb
@@ -9,6 +9,7 @@ describe Gitlab::Client do
   it { is_expected.to respond_to :repo_branch }
   it { is_expected.to respond_to :repo_tree }
   it { is_expected.to respond_to :repo_compare }
+  it { is_expected.to respond_to :repo_contributors }
 
   describe '.tags' do
     before do
@@ -112,3 +113,21 @@ describe Gitlab::Client do
     end
   end
 end
+
+describe '.contributors' do
+  before do
+    stub_get('/projects/3/repository/contributors', 'contributors')
+    @contributors = Gitlab.contributors(3)
+  end
+
+  it 'gets the correct resource' do
+    expect(a_get('/projects/3/repository/contributors')).to have_been_made
+  end
+
+  it 'returns a paginated response of repository contributors' do
+    expect(@contributors).to be_a Gitlab::PaginatedResponse
+    expect(@contributors.first.name).to eq("Dmitriy Zaporozhets")
+    expect(@contributors.first.commits).to eq(117)
+  end
+end
+


### PR DESCRIPTION
Added a function `Gitlab.contributors(...)` to enable access to the GitLab repository contributors API.
https://docs.gitlab.com/ee/api/repositories.html#contributors
