### PR TITLE
Switches to m.unpack from m.unpack1

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -78,7 +78,7 @@ module Gitlab
     #
     # @return [String]
     def url_encode(url)
-      url.to_s.b.gsub(/[^a-zA-Z0-9_\-.~]/n) { |m| sprintf('%%%02X', m.unpack1('C')) } # rubocop:disable Style/FormatString, Style/FormatStringToken
+      url.to_s.b.gsub(/[^a-zA-Z0-9_\-.~]/n) { |m| sprintf('%%%02X', m.unpack('C')) } # rubocop:disable Style/FormatString, Style/FormatStringToken
     end
 
     private


### PR DESCRIPTION
`unpack1` is not defined. `unpack` is suggested

fix #550 