### PR TITLE
Implement GET /user/activities

### DIFF
--- a/lib/gitlab/client/users.rb
+++ b/lib/gitlab/client/users.rb
@@ -123,6 +123,20 @@ class Gitlab::Client
       post('/session', body: { email: email, password: password }, unauthenticated: true)
     end
 
+    # Gets a list of user activities (for admin access only).
+    #
+    # @example
+    #   Gitlab.activities
+    #
+    # @param  [Hash] options A customizable set of options.
+    # @option options [Integer] :page The page number.
+    # @option options [Integer] :per_page The number of results per page.
+    # @option options [DateTime] :from The start date for paginated results.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def activities(options = {})
+      get('/user/activities', query: options)
+    end
+
     # Gets a list of user's SSH keys.
     #
     # @example

--- a/lib/gitlab/client/users.rb
+++ b/lib/gitlab/client/users.rb
@@ -131,7 +131,7 @@ class Gitlab::Client
     # @param  [Hash] options A customizable set of options.
     # @option options [Integer] :page The page number.
     # @option options [Integer] :per_page The number of results per page.
-    # @option options [DateTime] :from The start date for paginated results.
+    # @option options [String] :from The start date for paginated results.
     # @return [Array<Gitlab::ObjectifiedHash>]
     def activities(options = {})
       get('/user/activities', query: options)

--- a/spec/fixtures/activities.json
+++ b/spec/fixtures/activities.json
@@ -1,0 +1,1 @@
+[{"username": "someuser", "last_activity_on": "2020-03-16", "last_activity_at": "2020-03-16"}]

--- a/spec/gitlab/client/users_spec.rb
+++ b/spec/gitlab/client/users_spec.rb
@@ -210,6 +210,22 @@ describe Gitlab::Client do
     end
   end
 
+  describe '.activities' do
+    before do
+      stub_get('/user/activities', 'activities')
+      @activities = Gitlab.activities
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/user/activities')).to have_been_made
+    end
+
+    it 'returns a paginated response of user activity' do
+      expect(@activities).to be_a Gitlab::PaginatedResponse
+      expect(@activities.first.username).to eq('someuser')
+    end
+  end
+
   describe '.ssh_keys' do
     context 'with user ID passed' do
       before do


### PR DESCRIPTION
Adds `Gitlab.activities`, valid for admin auth tokens only: https://docs.gitlab.com/ee/api/users.html#get-user-activities-admin-only