### PR TITLE
Delegate Hash methods in ObjectifiedHash

### DIFF
--- a/spec/gitlab/objectified_hash_spec.rb
+++ b/spec/gitlab/objectified_hash_spec.rb
@@ -30,6 +30,23 @@ describe Gitlab::ObjectifiedHash do
     end
   end
 
+  describe '#method_missing' do
+    it 'delegates to `@data` for valid keys' do
+      expect(@oh.a).to eq(@hash[:a])
+      expect(@oh.symbol).to eq(@hash[:symbol])
+      expect(@oh.string).to eq(@hash['string'])
+    end
+
+    it 'delegates to underlying Hash methods' do
+      expect(@oh.include?(:invalid_key)).to eq(false)
+      expect(@oh.include?(:a)).to eq(true)
+    end
+
+    it 'delegates to `super` for unknown messages' do
+      expect { @oh.invalid_method }.to raise_error(NoMethodError)
+    end
+  end
+
   describe '#respond_to' do
     it 'returns true for methods this object responds to through method_missing as sym' do
       expect(@oh).to respond_to(:a)


### PR DESCRIPTION
Assuming this class is meant to mimic a normal Ruby Hash if the sent
message doesn't exist as a data key, we need to also delegate methods
that the normal Hash responds to (e.g., `include?`).

This also corrects the method signature for `method_missing` to include
the remaining arguments and optional block.

Prior to this change, sending a message to ObjectifiedHash that wasn't one of
its keys, you'd get:

    ArgumentError:
      wrong number of arguments (given 2, expected 1)
    # ./lib/gitlab/objectified_hash.rb:27:in `method_missing'