### PR TITLE
Thoroughly remove the client prefix for pagination response

### DIFF
--- a/lib/gitlab/paginated_response.rb
+++ b/lib/gitlab/paginated_response.rb
@@ -83,8 +83,7 @@ module Gitlab
     def last_page
       return nil if @client.nil? || !has_last_page?
 
-      path = @links.last.sub(/#{@client.endpoint}/, '')
-      @client.get(path)
+      @client.get(client_relative_path(@links.last))
     end
 
     def first_page?
@@ -95,8 +94,7 @@ module Gitlab
     def first_page
       return nil if @client.nil? || !has_first_page?
 
-      path = @links.first.sub(/#{@client.endpoint}/, '')
-      @client.get(path)
+      @client.get(client_relative_path(@links.first))
     end
 
     def next_page?
@@ -107,8 +105,7 @@ module Gitlab
     def next_page
       return nil if @client.nil? || !has_next_page?
 
-      path = @links.next.sub(/#{@client.endpoint}/, '')
-      @client.get(path)
+      @client.get(client_relative_path(@links.next))
     end
 
     def prev_page?
@@ -119,8 +116,12 @@ module Gitlab
     def prev_page
       return nil if @client.nil? || !has_prev_page?
 
-      path = @links.prev.sub(/#{@client.endpoint}/, '')
-      @client.get(path)
+      @client.get(client_relative_path(@links.prev))
+    end
+
+    def client_relative_path(link)
+      client_endpoint_path = URI.parse(@client.endpoint).request_uri # api/v4
+      URI.parse(link).request_uri.sub(client_endpoint_path, '')
     end
   end
 end


### PR DESCRIPTION
Fixes #494

There can be a mismatch in the API endpoint and the pagination endpoint. In our use-case, we whitelist the Gitlab API on `gitlab-internal.domain.com`, whereas the web interface `gitlab.domain.com` cannot contact the API. However, Gitlab pagination links point to `gitlab.domain.com` which does not work. There seem to be some other use cases in #494 and #521.

This change is to trust that the gem is configured with the appropriate endpoint. The assumption is that only the domain prefix would be different and not the api version-that could cause additional issues and should fail.