### PR TITLE
Prevent error obfuscation on json parse errors

### DIFF
--- a/lib/gitlab/error.rb
+++ b/lib/gitlab/error.rb
@@ -63,6 +63,14 @@ module Gitlab
         else
           @response.parsed_response
         end
+      rescue Gitlab::Error::Parsing
+        # Return stringified response when receiving a
+        # parsing error to avoid obfuscation of the
+        # api error.
+        #
+        # note: The Gitlab API does not always return valid
+        # JSON when there are errors.
+        @response.to_s
       end
 
       # Handle error response message in case of nested hashes

--- a/spec/gitlab/error_spec.rb
+++ b/spec/gitlab/error_spec.rb
@@ -51,4 +51,21 @@ describe Gitlab::Error::ResponseError do
     response_double = double('response', body: 'Retry later', to_s: 'Retry text', parsed_response: { message: 'Retry hash' }, code: 429, options: {}, headers: headers, request: @request_double)
     expect(described_class.new(response_double).send(:build_error_message)).to match(/Retry hash/)
   end
+
+  context 'parsing errors' do
+    let(:headers) { { 'content-type' => 'application/json' } }
+    let(:response_double) do
+      double('response', body: 'Retry later', to_s: 'Retry text', code: status, options: {}, headers: headers, request: @request_double)
+    end
+    let(:status) { 429 }
+
+    before do
+      allow(response_double).to receive(:parsed_response)
+        .and_raise(Gitlab::Error::Parsing)
+    end
+
+    it 'Builds an error message from text' do
+      expect(described_class.new(response_double).send(:build_error_message)).to match(/Retry text/)
+    end
+  end
 end


### PR DESCRIPTION
Sometimes the Gitlab API responds with an error code with incorrect
content-type headers. (application/json header with text/plain body)
This causes a Parsing error to be raised instead
of the api error (e.g. throttling). This change updates
ResponseError to ignore parsing errors so that the original api error
is still raised.

The specific scenario I've noticed was a 429 response from the Gitlab API. The body was an html error page:
```
 message: "765: unexpected token at '<!DOCTYPE html>
<html>
<head>
  <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
  <title>429 Too Many Requests</title>
  <style>
    body {
      color: #666;
      text-align: center;
      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
      margin: auto;
      font-size: 14px;
    }
    h1 {
      font-size: 56px;
      line-height: 100px;
      font-weight: normal;
      color: #456;
    }
    h2 {
      font-size: 24px;
      color: #666;
      line-height: 1.5em;
    }
    h3 {
      color: #456;
      font-size: 20px;
      font-weight: normal;
      line-height: 28px;
    }
    hr {
      max-width: 800px;
      margin: 18px auto;
      border: 0;
      border-top: 1px solid #EEE;
      border-bottom: 1px solid white;
    }
    img {
      max-width: 40vw;
    }
    .container {
      margin: auto 20px;
    }
  </style>
</head>
<body>
  <h1>
    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo=" alt="GitLab Logo" /><br />
    429
  </h1>
  <div class="container">
    <h3>Too many requests received.</h3>
    <hr />
    <p>Please try again later.</p>
  </div>
</body>
</html>
```