### PR TITLE
implementation of merge_request_approval_state

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,1 +1,11 @@
-#!/usr/bin/env ruby# frozen_string_literal: true# ENV['GITLAB_API_ENDPOINT'] = ''# ENV['GITLAB_API_PRIVATE_TOKEN'] = ''require 'bundler/setup'require 'gitlab'require 'pry'Pry.start
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# ENV['GITLAB_API_ENDPOINT'] = ''
+# ENV['GITLAB_API_PRIVATE_TOKEN'] = ''
+
+require 'bundler/setup'
+require 'gitlab'
+require 'pry'
+
+Pry.start

--- a/bin/console
+++ b/bin/console
@@ -1,11 +1,1 @@
-#!/usr/bin/env ruby
-# frozen_string_literal: true
-
-# ENV['GITLAB_API_ENDPOINT'] = ''
-# ENV['GITLAB_API_PRIVATE_TOKEN'] = ''
-
-require 'bundler/setup'
-require 'gitlab'
-require 'pry'
-
-Pry.start
+#!/usr/bin/env ruby# frozen_string_literal: true# ENV['GITLAB_API_ENDPOINT'] = ''# ENV['GITLAB_API_PRIVATE_TOKEN'] = ''require 'bundler/setup'require 'gitlab'require 'pry'Pry.start

--- a/lib/gitlab/client/merge_request_approvals.rb
+++ b/lib/gitlab/client/merge_request_approvals.rb
@@ -139,6 +139,7 @@ class Gitlab::Client
       put("/projects/#{url_encode project}/merge_requests/#{merge_request}/approvers", body: options)
     end
 
+
     # Approve a merge request
     #
     # @example
@@ -164,6 +165,18 @@ class Gitlab::Client
     # @return [void] This API call returns an empty response body.
     def unapprove_merge_request(project, merge_request, options = {})
       post("/projects/#{url_encode project}/merge_requests/#{merge_request}/unapprove", body: options)
+    end
+
+    # Get the approval state of merge requests
+    #
+    # @example
+    #   Gitlab.merge_request_approval_state(5, 36)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of a merge request.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def merge_request_approval_state(project, id)
+      get("/projects/#{url_encode project}/merge_requests/#{id}/approval_state")
     end
   end
 end

--- a/lib/gitlab/client/merge_request_approvals.rb
+++ b/lib/gitlab/client/merge_request_approvals.rb
@@ -139,7 +139,6 @@ class Gitlab::Client
       put("/projects/#{url_encode project}/merge_requests/#{merge_request}/approvers", body: options)
     end
 
-
     # Approve a merge request
     #
     # @example

--- a/spec/fixtures/merge_request_approval_state.json
+++ b/spec/fixtures/merge_request_approval_state.json
@@ -1,0 +1,46 @@
+{
+  "id": 1,
+  "iid": 1,
+  "project_id": 3,
+  "title": "Approvals API",
+  "description": "Test",
+  "state": "opened",
+  "created_at": "2016-06-08T00:19:52.638Z",
+  "updated_at": "2016-06-08T21:20:42.470Z",
+  "merge_status": "cannot_be_merged",
+  "approvals_required": 2,
+  "approvals_left": 2,
+  "approved_by": [],
+  "approvers": [
+    {
+      "user": {
+        "name": "Administrator",
+        "username": "root",
+        "id": 1,
+        "state": "active",
+        "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80\u0026d=identicon",
+        "web_url": "http://localhost:3000/root"
+      }
+    }
+  ],
+  "approver_groups": [
+    {
+      "group": {
+        "id": 5,
+        "name": "group1",
+        "path": "group1",
+        "description": "",
+        "visibility": "public",
+        "lfs_enabled": false,
+        "avatar_url": null,
+        "web_url": "http://localhost/groups/group1",
+        "request_access_enabled": false,
+        "full_name": "group1",
+        "full_path": "group1",
+        "parent_id": null,
+        "ldap_cn": null,
+        "ldap_access": null
+      }
+    }
+  ]
+}

--- a/spec/gitlab/client/merge_request_approvals_spec.rb
+++ b/spec/gitlab/client/merge_request_approvals_spec.rb
@@ -202,4 +202,21 @@ describe Gitlab::Client do
       expect(a_post('/projects/1/merge_requests/5/unapprove')).to have_been_made
     end
   end
+
+  describe '.merge_request_approval_state' do
+    before do
+      stub_get('/projects/3/merge_requests/1/approval_state', 'pipelines')
+      @pipelines = Gitlab.merge_request_pipelines(3, 1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/merge_requests/1/approval_state')).to have_been_made
+    end
+
+    it 'returns information about all pipelines in merge request' do
+      expect(@pipelines.first.id).to eq(47)
+      expect(@pipelines.first.status).to eq('pending')
+    end
+  end
+
 end

--- a/spec/gitlab/client/merge_request_approvals_spec.rb
+++ b/spec/gitlab/client/merge_request_approvals_spec.rb
@@ -219,5 +219,4 @@ describe Gitlab::Client do
       expect(@approval_state.approved_by).to be_empty
     end
   end
-
 end

--- a/spec/gitlab/client/merge_request_approvals_spec.rb
+++ b/spec/gitlab/client/merge_request_approvals_spec.rb
@@ -205,17 +205,18 @@ describe Gitlab::Client do
 
   describe '.merge_request_approval_state' do
     before do
-      stub_get('/projects/3/merge_requests/1/approval_state', 'pipelines')
-      @pipelines = Gitlab.merge_request_pipelines(3, 1)
+      stub_get('/projects/3/merge_requests/1/approval_state', 'merge_request_approval_state')
+      @approval_state = Gitlab.merge_request_approval_state(3, 1)
     end
 
     it 'gets the correct resource' do
       expect(a_get('/projects/3/merge_requests/1/approval_state')).to have_been_made
     end
 
-    it 'returns information about all pipelines in merge request' do
-      expect(@pipelines.first.id).to eq(47)
-      expect(@pipelines.first.status).to eq('pending')
+    it 'returns information about all approval states of merge request' do
+      expect(@approval_state.approvals_required).to eq(2)
+      expect(@approval_state.approvals_left).to eq(2)
+      expect(@approval_state.approved_by).to be_empty
     end
   end
 


### PR DESCRIPTION
This merge implements the API function merge_request_approval_state introduced in Gitlab 12.6.

https://docs.gitlab.com/ee/api/merge_request_approvals.html#get-the-approval-state-of-merge-requests

And implements issue #564 