### PR TITLE
Simplify pagination using Enumerator::Lazy

### DIFF
--- a/lib/gitlab/paginated_response.rb
+++ b/lib/gitlab/paginated_response.rb
@@ -42,18 +42,20 @@ module Gitlab
       end
     end
 
-    def lazy_paginate(&b)
+    def lazy_paginate
       to_enum(:each_page).lazy.flat_map(&:to_ary)
     end
 
-    def auto_paginate(&b)
+    def auto_paginate(&block)
       return lazy_paginate.to_a unless block_given?
-      lazy_paginate.each(&b)
+
+      lazy_paginate.each(&block)
     end
 
-    def paginate_with_limit(limit, &b)
+    def paginate_with_limit(limit, &block)
       return lazy_paginate.take(limit).to_a unless block_given?
-      lazy_paginate.take(limit).each(&b)
+
+      lazy_paginate.take(limit).each(&block)
     end
 
     def last_page?


### PR DESCRIPTION
This preserves compatibility with the existing pagination methods while leveraging a lazy enumerator to simplify the implementation.  The other advantage is that using the new `lazy_paginate` method directly allows users to take advantage of all the additional methods available to lazy enumerators, such as `take` or `first`, without needing to code those methods into this library.