### PR TITLE
Add support for nested arrays on ObjectifiedHash (take 2)

### DIFF
--- a/lib/gitlab/objectified_hash.rb
+++ b/lib/gitlab/objectified_hash.rb
@@ -8,7 +8,7 @@ module Gitlab
       @hash = hash
       @data = hash.each_with_object({}) do |(key, value), data|
         value = self.class.new(value) if value.is_a? Hash
-        value = value.map { |v| self.class.new(v) } if value.is_a? Array
+        value = value.map { |v| v.is_a?(Hash) ? self.class.new(v) : v} if value.is_a? Array
         data[key.to_s] = value
       end
     end

--- a/lib/gitlab/objectified_hash.rb
+++ b/lib/gitlab/objectified_hash.rb
@@ -8,6 +8,7 @@ module Gitlab
       @hash = hash
       @data = hash.each_with_object({}) do |(key, value), data|
         value = self.class.new(value) if value.is_a? Hash
+        value = value.map { |v| self.class.new(v) } if value.is_a? Array
         data[key.to_s] = value
       end
     end

--- a/lib/gitlab/objectified_hash.rb
+++ b/lib/gitlab/objectified_hash.rb
@@ -8,7 +8,7 @@ module Gitlab
       @hash = hash
       @data = hash.each_with_object({}) do |(key, value), data|
         value = self.class.new(value) if value.is_a? Hash
-        value = value.map { |v| v.is_a?(Hash) ? self.class.new(v) : v} if value.is_a? Array
+        value = value.map { |v| v.is_a?(Hash) ? self.class.new(v) : v } if value.is_a? Array
         data[key.to_s] = value
       end
     end

--- a/lib/gitlab/objectified_hash.rb
+++ b/lib/gitlab/objectified_hash.rb
@@ -24,6 +24,10 @@ module Gitlab
       "#<#{self.class}:#{object_id} {hash: #{hash.inspect}}"
     end
 
+    def [](key)
+      @data[key]
+    end
+
     private
 
     attr_reader :hash, :data

--- a/lib/gitlab/objectified_hash.rb
+++ b/lib/gitlab/objectified_hash.rb
@@ -25,7 +25,7 @@ module Gitlab
     end
 
     def [](key)
-      @data[key]
+      data[key]
     end
 
     private

--- a/spec/gitlab/objectified_hash_spec.rb
+++ b/spec/gitlab/objectified_hash_spec.rb
@@ -4,13 +4,19 @@ require 'spec_helper'
 
 describe Gitlab::ObjectifiedHash do
   before do
-    @hash = { a: 1, b: 2, 'string' => 'string', symbol: :symbol }
+    @hash = { a: 1, b: 2, 'string' => 'string', symbol: :symbol, array: ["string", {:a => 1, :b => 2}] }
     @oh = described_class.new @hash
   end
 
   it 'objectifies a hash' do
     expect(@oh.a).to eq(@hash[:a])
     expect(@oh.b).to eq(@hash[:b])
+  end
+
+  it 'objectifies a hash contained in an array' do
+    expect(@oh.array[1].a).to eq(@hash[:array][1][:a])
+    expect(@oh.array[1].b).to eq(@hash[:array][1][:b])
+    expect(@oh.array[0]).to eq(@hash[:array][0])
   end
 
   describe '#to_hash' do

--- a/spec/gitlab/objectified_hash_spec.rb
+++ b/spec/gitlab/objectified_hash_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Gitlab::ObjectifiedHash do
   before do
-    @hash = { a: 1, b: 2, 'string' => 'string', symbol: :symbol, array: ["string", {:a => 1, :b => 2}] }
+    @hash = { a: 1, b: 2, 'string' => 'string', symbol: :symbol, array: [ "string", {:a => 1, :b => 2} ] }
     @oh = described_class.new @hash
   end
 
@@ -17,6 +17,11 @@ describe Gitlab::ObjectifiedHash do
     expect(@oh.array[1].a).to eq(@hash[:array][1][:a])
     expect(@oh.array[1].b).to eq(@hash[:array][1][:b])
     expect(@oh.array[0]).to eq(@hash[:array][0])
+  end
+
+  it 'supports legacy addressing mode' do
+    expect(@oh['a']).to eq(@hash[:a])
+    expect(@oh['b']).to eq(@hash[:b])
   end
 
   describe '#to_hash' do

--- a/spec/gitlab/objectified_hash_spec.rb
+++ b/spec/gitlab/objectified_hash_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Gitlab::ObjectifiedHash do
   before do
-    @hash = { a: 1, b: 2, 'string' => 'string', symbol: :symbol, array: [ "string", {:a => 1, :b => 2} ] }
+    @hash = { a: 1, b: 2, 'string' => 'string', symbol: :symbol, array: ['string', { a: 1, b: 2 }] }
     @oh = described_class.new @hash
   end
 


### PR DESCRIPTION
At the moment ObjectifiedHash is missing out on hierarchies of objects where there are hashes contained within an array. Which is annoying as it happens in a lot of API calls.

This just adds an extra step to the initialiser of ObjectifiedHash so that arrays of hashes are handled properly