### PR TITLE
Support error_code returned by specific API endpoints

### DIFF
--- a/lib/gitlab/error.rb
+++ b/lib/gitlab/error.rb
@@ -34,6 +34,17 @@ module Gitlab
         @response.parsed_response.message
       end
 
+      # Additional error context returned by some API endpoints
+      #
+      # @return [String]
+      def error_code
+        if @response.respond_to?(:error_code)
+          @response.error_code
+        else
+          ''
+        end
+      end
+
       private
 
       # Human friendly message.

--- a/spec/fixtures/cherry_pick_commit_failure.json
+++ b/spec/fixtures/cherry_pick_commit_failure.json
@@ -1,0 +1,1 @@
+{"message":"Sorry, we cannot cherry-pick this commit automatically. This commit may already have been cherry-picked, or a more recent commit may have updated some of its content.","error_code":"conflict"}

--- a/spec/gitlab/error_spec.rb
+++ b/spec/gitlab/error_spec.rb
@@ -68,4 +68,39 @@ describe Gitlab::Error::ResponseError do
       expect(described_class.new(response_double).send(:build_error_message)).to match(/Retry text/)
     end
   end
+
+  describe '#error_code' do
+    it 'returns the value when available' do
+      headers = { 'content-type' => 'application/json' }
+      response_double = double(
+        'response',
+        body: 'Retry later',
+        to_s: 'Retry text',
+        parsed_response: { message: 'Retry hash' },
+        code: 400,
+        error_code: 'conflict',
+        options: {},
+        headers: headers,
+        request: @request_double
+      )
+
+      expect(described_class.new(response_double).error_code).to eq 'conflict'
+    end
+
+    it 'returns nothing when unavailable' do
+      headers = { 'content-type' => 'application/json' }
+      response_double = double(
+        'response',
+        body: 'Retry later',
+        to_s: 'Retry text',
+        parsed_response: { message: 'Retry hash' },
+        code: 400,
+        options: {},
+        headers: headers,
+        request: @request_double
+      )
+
+      expect(described_class.new(response_double).error_code).to eq ''
+    end
+  end
 end


### PR DESCRIPTION
An error response may contain useful additional context, and this allows
users to access that context on the exception class.

For example, the cherry-pick API now includes an error_code field to
indicate why the cherry-pick failed, which can now be accessed via
`ResponseError#error_code`.

This is a second attempt at https://github.com/NARKOZ/gitlab/pull/530, without abusing `method_missing`.