### PR TITLE
Support cherry-pick dry runs, and add revert support

### DIFF
--- a/lib/gitlab/client/commits.rb
+++ b/lib/gitlab/client/commits.rb
@@ -59,9 +59,13 @@ class Gitlab::Client
     # @param  [Integer, String] project The ID or name of a project.
     # @param  [String] sha The commit hash or name of a repository branch or tag
     # @param  [String] branch The name of the branch
+    # @param  [Hash] options A customizable set of options.
+    # @option options [Boolean] :dry_run Don't commit any changes
     # @return [Gitlab::ObjectifiedHash]
-    def cherry_pick_commit(project, sha, branch)
-      post("/projects/#{url_encode project}/repository/commits/#{sha}/cherry_pick", body: { branch: branch })
+    def cherry_pick_commit(project, sha, branch, options = {})
+      options[:branch] = branch
+
+      post("/projects/#{url_encode project}/repository/commits/#{sha}/cherry_pick", body: options)
     end
 
     # Get the diff of a commit in a project.

--- a/lib/gitlab/client/commits.rb
+++ b/lib/gitlab/client/commits.rb
@@ -68,6 +68,23 @@ class Gitlab::Client
       post("/projects/#{url_encode project}/repository/commits/#{sha}/cherry_pick", body: options)
     end
 
+    # Reverts a commit in a given branch.
+    #
+    # @example
+    #   Gitlab.revert_commit(42, '6104942438c14ec7bd21c6cd5bd995272b3faff6', 'master')
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [String] sha The commit hash or name of a repository branch or tag
+    # @param  [String] branch The name of the branch
+    # @param  [Hash] options A customizable set of options.
+    # @option options [Boolean] :dry_run Don't commit any changes
+    # @return [Gitlab::ObjectifiedHash]
+    def revert_commit(project, sha, branch, options = {})
+      options[:branch] = branch
+
+      post("/projects/#{url_encode project}/repository/commits/#{sha}/revert", body: options)
+    end
+
     # Get the diff of a commit in a project.
     #
     # @example

--- a/spec/fixtures/revert_commit_failure.json
+++ b/spec/fixtures/revert_commit_failure.json
@@ -1,0 +1,1 @@
+{"message":"Sorry, we cannot revert this commit automatically. This commit may already have been reverted, or a more recent commit may have updated some of its content.","error_code":"empty"}

--- a/spec/gitlab/client/commits_spec.rb
+++ b/spec/gitlab/client/commits_spec.rb
@@ -92,6 +92,19 @@ describe Gitlab::Client do
         end
       end
     end
+
+    context 'with additional options' do
+      it 'passes additional options' do
+        stub_post('/projects/3/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/cherry_pick', 'project_commit')
+          .with(body: { branch: 'master', dry_run: true })
+
+        Gitlab.cherry_pick_commit(3, '6104942438c14ec7bd21c6cd5bd995272b3faff6', 'master', dry_run: true)
+
+        expect(a_post('/projects/3/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/cherry_pick')
+          .with(body: { branch: 'master', dry_run: true }))
+          .to have_been_made
+      end
+    end
   end
 
   describe '.commit_diff' do

--- a/spec/gitlab/client/commits_spec.rb
+++ b/spec/gitlab/client/commits_spec.rb
@@ -107,6 +107,49 @@ describe Gitlab::Client do
     end
   end
 
+  describe '.revert_commit' do
+    context 'on success' do
+      before do
+        stub_post('/projects/3/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/revert', 'project_commit').with(body: { branch: 'master' })
+        @revert_commit = Gitlab.revert_commit(3, '6104942438c14ec7bd21c6cd5bd995272b3faff6', 'master')
+      end
+
+      it 'gets the correct resource' do
+        expect(a_post('/projects/3/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/revert')
+          .with(body: { branch: 'master' }))
+          .to have_been_made
+      end
+
+      it 'returns the correct response' do
+        expect(@revert_commit).to be_a Gitlab::ObjectifiedHash
+        expect(@revert_commit.id).to eq('6104942438c14ec7bd21c6cd5bd995272b3faff6')
+      end
+    end
+
+    context 'on failure' do
+      it 'includes the error_code' do
+        stub_post('/projects/3/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/revert', 'revert_commit_failure', 400)
+
+        expect { Gitlab.revert_commit(3, '6104942438c14ec7bd21c6cd5bd995272b3faff6', 'master') }.to raise_error(Gitlab::Error::BadRequest) do |ex|
+          expect(ex.error_code).to eq('empty')
+        end
+      end
+    end
+
+    context 'with additional options' do
+      it 'passes additional options' do
+        stub_post('/projects/3/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/revert', 'project_commit')
+          .with(body: { branch: 'master', dry_run: true })
+
+        Gitlab.revert_commit(3, '6104942438c14ec7bd21c6cd5bd995272b3faff6', 'master', dry_run: true)
+
+        expect(a_post('/projects/3/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/revert')
+          .with(body: { branch: 'master', dry_run: true }))
+          .to have_been_made
+      end
+    end
+  end
+
   describe '.commit_diff' do
     before do
       stub_get('/projects/3/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/diff', 'project_commit_diff')


### PR DESCRIPTION
The [commit revert API](https://docs.gitlab.com/ee/api/commits.html#revert-a-commit) was added in GitLab 11.5, and I was surprised to see it's not yet added to the gem, so I've added it here.

Additionally, as of 13.3 the cherry-pick and revert APIs will support a `dry_run` flag, which prevents committing any potential changes. This PR adds support for that in both APIs as well.