### PR TITLE
Feature : Resource State Events API Addition

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -52,6 +52,7 @@ module Gitlab
     include RepositoryFiles
     include RepositorySubmodules
     include ResourceLabelEvents
+    include ResourceStateEvents
     include Runners
     include Search
     include Services

--- a/lib/gitlab/client/resource_state_events.rb
+++ b/lib/gitlab/client/resource_state_events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Gitlab::Client
   # Defines methods related to resource state events.
   # @see https://docs.gitlab.com/ee/api/resource_state_events.html
@@ -10,7 +12,7 @@ class Gitlab::Client
     # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] issue_iid The IID of an issue.
     # @return [Array<Gitlab::ObjectifiedHash>]
-    def issue_state_events(project,issue_iid)
+    def issue_state_events(project, issue_iid)
       get("/projects/#{url_encode project}/issues/#{issue_iid}/resource_state_events")
     end
 
@@ -23,7 +25,7 @@ class Gitlab::Client
     # @param  [Integer] issue_iid The IID of an issue.
     # @param  [Integer] id The ID of a resource event.
     # @return Gitlab::ObjectifiedHash
-    def issue_state_event(project,issue_iid,id)
+    def issue_state_event(project, issue_iid,id)
       get("/projects/#{url_encode project}/issues/#{issue_iid}/resource_state_events/#{id}")
     end
 

--- a/lib/gitlab/client/resource_state_events.rb
+++ b/lib/gitlab/client/resource_state_events.rb
@@ -1,0 +1,55 @@
+class Gitlab::Client
+  # Defines methods related to resource state events.
+  # @see https://docs.gitlab.com/ee/api/resource_state_events.html
+  module ResourceStateEvents
+    # Gets a list of all state events for a single issue.
+    #
+    # @example
+    #   Gitlab.issue_state_events(5, 42)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] issue_iid The IID of an issue.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def issue_state_events(project,issue_iid)
+      get("/projects/#{url_encode project}/issues/#{issue_iid}/resource_state_events")
+    end
+
+    # Returns a single state event for a specific project issue
+    #
+    # @example
+    #   Gitlab.issue_state_event(5, 42, 1)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] issue_iid The IID of an issue.
+    # @param  [Integer] id The ID of a resource event.
+    # @return Gitlab::ObjectifiedHash
+    def issue_state_event(project,issue_iid,id)
+      get("/projects/#{url_encode project}/issues/#{issue_iid}/resource_state_events/#{id}")
+    end
+
+    # Gets a list of all state events for a single merge request.
+    #
+    # @example
+    #   Gitlab.merge_request_state_events(5, 42)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] merge_request_iid The IID of a merge request.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def merge_request_state_events(project, merge_request_iid)
+      get("/projects/#{url_encode project}/merge_requests/#{merge_request_iid}/resource_state_events")
+    end
+
+    # Returns a single state event for a specific project merge request
+    #
+    # @example
+    #   Gitlab.merge_request_state_event(5, 42, 1)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] merge_request_iid The IID of an merge request.
+    # @param  [Integer] id The ID of a state event.
+    # @return Gitlab::ObjectifiedHash
+    def merge_request_state_event(project, merge_request_iid, id)
+      get("/projects/#{url_encode project}/merge_requests/#{merge_request_iid}/resource_state_events/#{id}")
+    end
+  end
+end

--- a/lib/gitlab/client/resource_state_events.rb
+++ b/lib/gitlab/client/resource_state_events.rb
@@ -25,7 +25,7 @@ class Gitlab::Client
     # @param  [Integer] issue_iid The IID of an issue.
     # @param  [Integer] id The ID of a resource event.
     # @return Gitlab::ObjectifiedHash
-    def issue_state_event(project, issue_iid,id)
+    def issue_state_event(project, issue_iid, id)
       get("/projects/#{url_encode project}/issues/#{issue_iid}/resource_state_events/#{id}")
     end
 

--- a/spec/fixtures/issue_resource_state_event.json
+++ b/spec/fixtures/issue_resource_state_event.json
@@ -1,0 +1,15 @@
+{
+    "id": 143,
+    "user": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "created_at": "2018-08-21T14:38:20.077Z",
+    "resource_type": "Issue",
+    "resource_id": 11,
+    "state": "closed"
+  }

--- a/spec/fixtures/issue_resource_state_events.json
+++ b/spec/fixtures/issue_resource_state_events.json
@@ -1,0 +1,32 @@
+[
+    {
+      "id": 142,
+      "user": {
+        "id": 1,
+        "name": "Administrator",
+        "username": "root",
+        "state": "active",
+        "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+        "web_url": "http://gitlab.example.com/root"
+      },
+      "created_at": "2018-08-20T13:38:20.077Z",
+      "resource_type": "Issue",
+      "resource_id": 11,
+      "state": "opened"
+    },
+    {
+      "id": 143,
+      "user": {
+        "id": 1,
+        "name": "Administrator",
+        "username": "root",
+        "state": "active",
+        "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+        "web_url": "http://gitlab.example.com/root"
+      },
+      "created_at": "2018-08-21T14:38:20.077Z",
+      "resource_type": "Issue",
+      "resource_id": 11,
+      "state": "closed"
+    }
+  ]

--- a/spec/fixtures/mr_resource_state_event.json
+++ b/spec/fixtures/mr_resource_state_event.json
@@ -1,0 +1,15 @@
+{
+    "id": 120,
+    "user": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "created_at": "2018-08-21T14:38:20.077Z",
+    "resource_type": "MergeRequest",
+    "resource_id": 11,
+    "state": "closed"
+  }

--- a/spec/fixtures/mr_resource_state_events.json
+++ b/spec/fixtures/mr_resource_state_events.json
@@ -1,0 +1,32 @@
+[
+    {
+      "id": 142,
+      "user": {
+        "id": 1,
+        "name": "Administrator",
+        "username": "root",
+        "state": "active",
+        "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+        "web_url": "http://gitlab.example.com/root"
+      },
+      "created_at": "2018-08-20T13:38:20.077Z",
+      "resource_type": "MergeRequest",
+      "resource_id": 11,
+      "state": "opened"
+    },
+    {
+      "id": 143,
+      "user": {
+        "id": 1,
+        "name": "Administrator",
+        "username": "root",
+        "state": "active",
+        "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+        "web_url": "http://gitlab.example.com/root"
+      },
+      "created_at": "2018-08-21T14:38:20.077Z",
+      "resource_type": "MergeRequest",
+      "resource_id": 11,
+      "state": "closed"
+    }
+  ]

--- a/spec/gitlab/client/resource_state_events_spec.rb
+++ b/spec/gitlab/client/resource_state_events_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Gitlab::Client do
+  describe '.issue_state_events' do
+    before do
+      stub_get('/projects/5/issues/42/resource_state_events', 'issue_resource_state_events')
+      @events = Gitlab.issue_state_events(5, 42)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/5/issues/42/resource_state_events')).to have_been_made
+    end
+
+    it "returns a paginated response of project's issue's state events" do
+      expect(@events).to be_a Gitlab::PaginatedResponse
+      expect(@events.first.id).to eq(142)
+    end
+  end
+
+  describe '.issue_state_event' do
+    before do
+      stub_get('/projects/5/issues/42/resource_state_events/142', 'issue_resource_state_event')
+      @event = Gitlab.issue_state_event(5, 42, 142)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/5/issues/42/resource_state_events/142')).to have_been_made
+    end
+
+    it "returns a paginated response of project's issue's state event" do
+      expect(@event).to be_a Gitlab::ObjectifiedHash
+      expect(@event.user.name).to eq('Administrator')
+    end
+  end
+
+  describe '.merge_request_state_events' do
+    before do
+      stub_get('/projects/5/merge_requests/42/resource_state_events', 'mr_resource_state_events')
+      @events = Gitlab.merge_request_state_events(5, 42)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/5/merge_requests/42/resource_state_events')).to have_been_made
+    end
+
+    it "returns a paginated response of project's merge request's state events" do
+      expect(@events).to be_a Gitlab::PaginatedResponse
+      expect(@events.first.id).to eq(142)
+    end
+  end
+
+  describe '.merge_request_state_event' do
+    before do
+      stub_get('/projects/5/merge_requests/42/resource_state_events/142', 'mr_resource_state_event')
+      @event = Gitlab.merge_request_state_event(5, 42, 142)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/5/merge_requests/42/resource_state_events/142')).to have_been_made
+    end
+
+    it "returns a paginated response of project's merge request's state event" do
+      expect(@event).to be_a Gitlab::ObjectifiedHash
+      expect(@event.user.name).to eq('Administrator')
+    end
+  end
+end

--- a/spec/gitlab/shell_spec.rb
+++ b/spec/gitlab/shell_spec.rb
@@ -63,7 +63,7 @@ describe Gitlab::Shell do
       it 'returns an Array of matching commands' do
         completed_cmds = @comp.call 'issue'
         expect(completed_cmds).to be_a Array
-        expect(completed_cmds.sort).to eq(%w[issue issue_label_event issue_label_events issue_links issue_note issue_notes issues])
+        expect(completed_cmds.sort).to eq(%w[issue issue_label_event issue_label_events issue_links issue_note issue_notes issue_state_event issue_state_events issues])
       end
     end
   end


### PR DESCRIPTION
Resource state events represent the states that the MR or Issue has transitioned in its life time.
This allows us to track, which state was set, who did it, and when it happened.

1. Resource state events api's added
2. Linking resoruce state event module into client.rb

Resource state event api added in Gitlab 3.2

More information [here](https://docs.gitlab.com/13.2/ee/api/resource_state_events.html#list-project-merge-request-state-events)