### PR TITLE
Updating the runners API

### DIFF
--- a/lib/gitlab/help.rb
+++ b/lib/gitlab/help.rb
@@ -74,14 +74,14 @@ module Gitlab::Help
     # Returns full namespace of a command (e.g. Gitlab::Client::Branches.cmd)
     def namespace(cmd)
       method_owners.select { |method| method[:name] == cmd }
-                   .map { |method| method[:owner] + '.' + method[:name] }
+                   .map { |method| "#{method[:owner]}.#{method[:name]}" }
                    .shift
     end
 
     # Massage output from 'ri'.
     def change_help_output!(cmd, output_str)
       output_str = +output_str
-      output_str.gsub!(/#{cmd}\((.*?)\)/m, cmd + ' \1')
+      output_str.gsub!(/#{cmd}\((.*?)\)/m, "#{cmd} \1")
       output_str.gsub!(/,\s*/, ' ')
 
       # Ensure @option descriptions are on a single line

--- a/spec/fixtures/group_runners.json
+++ b/spec/fixtures/group_runners.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": 3,
+    "description": "Shared",
+    "ip_address": "127.0.0.1",
+    "active": true,
+    "is_shared": true,
+    "name": "gitlab-runner",
+    "online": null,
+    "status": "not_connected"
+  },
+  {
+    "id": 6,
+    "description": "Test",
+    "ip_address": "127.0.0.1",
+    "active": true,
+    "is_shared": true,
+    "name": "gitlab-runner",
+    "online": false,
+    "status": "offline"
+  },
+  {
+    "id": 8,
+    "description": "Test 2",
+    "ip_address": "127.0.0.1",
+    "active": true,
+    "is_shared": false,
+    "name": "gitlab-runner",
+    "online": null,
+    "status": "not_connected"
+  }
+]

--- a/spec/gitlab/cli_spec.rb
+++ b/spec/gitlab/cli_spec.rb
@@ -99,7 +99,7 @@ describe Gitlab::CLI do
       end
 
       it 'renders output as json' do
-        expect(JSON.parse(@output)['result']).to eq(JSON.parse(File.read(File.dirname(__FILE__) + '/../fixtures/user.json')))
+        expect(JSON.parse(@output)['result']).to eq(JSON.parse(File.read("#{File.dirname(__FILE__)}/../fixtures/user.json")))
         expect(JSON.parse(@output)['cmd']).to eq('Gitlab.user')
       end
     end

--- a/spec/gitlab/client/runners_spec.rb
+++ b/spec/gitlab/client/runners_spec.rb
@@ -8,7 +8,7 @@ describe Gitlab::Client do
       stub_get('/runners', 'runners')
     end
 
-    context 'without scope' do
+    context 'without extra queries' do
       before do
         @runner = Gitlab.runners
       end
@@ -24,14 +24,14 @@ describe Gitlab::Client do
       end
     end
 
-    context 'with scope' do
+    context 'with queries' do
       before do
-        stub_get('/runners?scope=online', 'runners')
-        @runner = Gitlab.runners(scope: :online)
+        stub_get('/runners?type=instance_type', 'runners')
+        @runner = Gitlab.runners(type: :instance_type)
       end
 
       it 'gets the correct resource' do
-        expect(a_get('/runners').with(query: { scope: :online })).to have_been_made
+        expect(a_get('/runners').with(query: { type: :instance_type })).to have_been_made
       end
 
       it 'returns a paginated response of runners' do
@@ -47,7 +47,7 @@ describe Gitlab::Client do
       stub_get('/runners/all', 'runners')
     end
 
-    context 'without scope' do
+    context 'without extra queries' do
       before do
         @runner = Gitlab.all_runners
       end
@@ -63,14 +63,14 @@ describe Gitlab::Client do
       end
     end
 
-    context 'with scope' do
+    context 'with queries' do
       before do
-        stub_get('/runners/all?scope=online', 'runners')
-        @runner = Gitlab.all_runners(scope: :online)
+        stub_get('/runners/all?type=instance_type', 'runners')
+        @runner = Gitlab.all_runners(type: :instance_type)
       end
 
       it 'gets the correct resource' do
-        expect(a_get('/runners/all').with(query: { scope: :online })).to have_been_made
+        expect(a_get('/runners/all').with(query: { type: :instance_type })).to have_been_made
       end
 
       it 'returns a paginated response of runners' do
@@ -100,12 +100,12 @@ describe Gitlab::Client do
 
   describe '.update_runner' do
     before do
-      stub_put('/runners/6', 'runner_edit').with(query: { description: 'abcefg' })
+      stub_put('/runners/6', 'runner_edit').with(body: { description: 'abcefg' })
       @runner = Gitlab.update_runner(6, description: 'abcefg')
     end
 
     it 'gets the correct resource' do
-      expect(a_put('/runners/6').with(query: { description: 'abcefg' })).to have_been_made
+      expect(a_put('/runners/6').with(body: { description: 'abcefg' })).to have_been_made
     end
 
     it 'returns an updated response of a runner' do
@@ -189,6 +189,41 @@ describe Gitlab::Client do
       expect(@runner).to be_a Gitlab::ObjectifiedHash
       expect(@runner.id).to eq(6)
       expect(@runner.description).to eq('test-1-20150125')
+    end
+  end
+
+  describe '.group_runners' do
+    before do
+      stub_get('/groups/9/runners', 'group_runners')
+    end
+
+    context 'without extra queries' do
+      before do
+        @runners = Gitlab.group_runners(9)
+      end
+
+      it 'gets the correct resource' do
+        expect(a_get('/groups/9/runners')).to have_been_made
+      end
+
+      it 'returns a paginated response of runners' do
+        expect(@runners).to be_a Gitlab::PaginatedResponse
+      end
+    end
+
+    context 'with queries' do
+      before do
+        stub_get('/groups/9/runners?type=instance_type', 'group_runners')
+        @runner = Gitlab.group_runners(9, type: :instance_type)
+      end
+
+      it 'gets the correct resource' do
+        expect(a_get('/groups/9/runners').with(query: { type: :instance_type })).to have_been_made
+      end
+
+      it 'returns a paginated response of runners' do
+        expect(@runner).to be_a Gitlab::PaginatedResponse
+      end
     end
   end
 

--- a/spec/gitlab/objectified_hash_spec.rb
+++ b/spec/gitlab/objectified_hash_spec.rb
@@ -13,8 +13,8 @@ describe Gitlab::ObjectifiedHash do
     let(:oh) { described_class.new(hash) }
 
     it 'allows to call Hash methods' do
-      expect(oh.dig('foo')).to eq('bar')
-      expect(oh.merge(key: :value)).to eq({ 'foo' => 'bar', key: :value })
+      expect(oh['foo']).to eq('bar')
+      expect(oh.merge(key: :value)).to eq('foo' => 'bar', key: :value)
     end
 
     it 'warns about calling Hash methods' do


### PR DESCRIPTION
Closes #581 

Also 
1. removed a few deprecated options
2. fixed the update method to use `body` instead of `query`
3. updated tests