### PR TITLE
Add method to list all members including inherited members

### DIFF
--- a/lib/gitlab/client/projects.rb
+++ b/lib/gitlab/client/projects.rb
@@ -102,6 +102,22 @@ class Gitlab::Client
       get("/projects/#{url_encode project}/members", query: options)
     end
 
+    # Gets a list of all project team members including inherited members.
+    #
+    # @example
+    #   Gitlab.all_members(42)
+    #   Gitlab.all_members('gitlab')
+    #
+    # @param  [Integer, String] project The ID or path of a project.
+    # @param  [Hash] options A customizable set of options.
+    # @option options [String] :query The search query.
+    # @option options [Integer] :page The page number.
+    # @option options [Integer] :per_page The number of results per page.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def all_members(project, options = {})
+      get("/projects/#{url_encode project}/members/all", query: options)
+    end
+
     # Gets a project team member.
     #
     # @example

--- a/spec/gitlab/client/projects_spec.rb
+++ b/spec/gitlab/client/projects_spec.rb
@@ -170,6 +170,22 @@ describe Gitlab::Client do
     end
   end
 
+  describe '.all_members' do
+    before do
+      stub_get('/projects/3/members/all', 'team_members')
+      @all_members = Gitlab.all_members(3)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/members/all')).to have_been_made
+    end
+
+    it 'returns a paginated response of all team members including inherited' do
+      expect(@all_members).to be_a Gitlab::PaginatedResponse
+      expect(@all_members.first.name).to eq('John Smith')
+    end
+  end
+
   describe '.team_member' do
     before do
       stub_get('/projects/3/members/1', 'team_member')


### PR DESCRIPTION
The purpose of this MR is to implement a method to list all members including inherited members. Currently in the rudy sdk we have available only two methods, that don't return the inherited ones.

- `team_members`, `group_members` - Gets a list of group or project members viewable by the authenticated user. Returns only direct members and not inherited members through ancestors groups.

Rather than trying to find a workaround(although I am not sure there is one) I think it is a good idea to have this endpoint as in the REST API that will return all members.