### PR TITLE
Adding the group billable members call as described in the Gitlab documentation

### DIFF
--- a/lib/gitlab/client/groups.rb
+++ b/lib/gitlab/client/groups.rb
@@ -71,6 +71,21 @@ class Gitlab::Client
       get("/groups/#{url_encode id}/members", query: options)
     end
 
+    # Get a list of group members that are billable.
+    #
+    # @example
+    #   Gitlab.group_billable_members(1)
+    #   Gitlab.group_billable_members(1, { per_page: 40 })
+    #
+    # @param  [Integer] id The ID of a group.
+    # @param  [Hash] options A customizable set of options.
+    # @option options [Integer] :page The page number.
+    # @option options [Integer] :per_page The number of results per page.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def group_billable_members(id, options = {})
+      get("/groups/#{url_encode id}/billable_members", query: options)
+    end
+
     # Get details of a single group member.
     #
     # @example

--- a/spec/fixtures/group_billable_members.json
+++ b/spec/fixtures/group_billable_members.json
@@ -1,0 +1,1 @@
+[{"id":1,"username":"eraymond","email":"eraymond@local.host","name":"Edward Raymond","state":"active","created_at":"2013-08-30T16:16:22Z","access_level":50},{"id":1,"username":"jsmith","email":"jsmith@local.host","name":"John Smith","state":"active","created_at":"2013-08-30T16:16:22Z","access_level":50}]

--- a/spec/gitlab/client/groups_spec.rb
+++ b/spec/gitlab/client/groups_spec.rb
@@ -126,6 +126,23 @@ describe Gitlab::Client do
     end
   end
 
+  describe '.group_billable_members' do
+    before do
+      stub_get('/groups/3/billable_members', 'group_billable_members')
+      @members = Gitlab.group_billable_members(3)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/groups/3/billable_members')).to have_been_made
+    end
+
+    it "returns information about a group's billable members" do
+      expect(@members).to be_a Gitlab::PaginatedResponse
+      expect(@members.size).to eq(2)
+      expect(@members[1].name).to eq('John Smith')
+    end
+  end
+
   describe '.group_member' do
     before do
       stub_get('/groups/3/members/2', 'group_member')


### PR DESCRIPTION
Added the method according to the documentation from Gitlab https://docs.gitlab.com/ee/api/members.html\#list-all-billable-members-of-a-group