### PR TITLE
Create Gitlab::Pipeline.pipeline_test_report

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,16 +169,22 @@ in order to craft an excellent pull request:
    rake
    ```
 
-6. Push your topic branch up to your fork:
+6. Make sure you comply with rubocop style guide. You can run the linter using
+
+  ```sh
+  rake rubocop
+  ```
+
+7. Push your topic branch up to your fork:
 
    ```sh
    git push origin <topic-branch-name>
    ```
 
-7. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/)
+8. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/)
     with a clear title and description.
 
-8. If you haven't updated your pull request for a while, you should consider
+9. If you haven't updated your pull request for a while, you should consider
    rebasing on master and resolving any conflicts.
 
    **IMPORTANT**: _Never ever_ merge upstream `master` into your branches. You

--- a/lib/gitlab/client/pipelines.rb
+++ b/lib/gitlab/client/pipelines.rb
@@ -31,6 +31,18 @@ class Gitlab::Client
       get("/projects/#{url_encode project}/pipelines/#{id}")
     end
 
+    # Gets a single pipeline's test report.
+    #
+    # @example
+    #   Gitlab.pipeline_test_report(5, 36)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of a pipeline.
+    # @return [Gitlab::ObjectifiedHash]
+    def pipeline_test_report(project, id)
+      get("/projects/#{url_encode project}/pipelines/#{id}/test_report")
+    end
+
     # Create a pipeline.
     #
     # @example

--- a/lib/gitlab/paginated_response.rb
+++ b/lib/gitlab/paginated_response.rb
@@ -43,17 +43,17 @@ module Gitlab
     end
 
     def lazy_paginate
-      to_enum(:each_page).lazy.flat_map(&:to_ary)
+      to_enum(:each_page).lazy.flat_map(&:to_ary) # rubocop:disable Lint/ToEnumArguments
     end
 
     def auto_paginate(&block)
-      return lazy_paginate.to_a unless block_given?
+      return lazy_paginate.to_a unless block
 
       lazy_paginate.each(&block)
     end
 
     def paginate_with_limit(limit, &block)
-      return lazy_paginate.take(limit).to_a unless block_given?
+      return lazy_paginate.take(limit).to_a unless block
 
       lazy_paginate.take(limit).each(&block)
     end

--- a/lib/gitlab/request.rb
+++ b/lib/gitlab/request.rb
@@ -25,8 +25,6 @@ module Gitlab
         true
       elsif !body
         false
-      elsif body.nil?
-        false
       else
         raise Error::Parsing, "Couldn't parse a response body"
       end

--- a/spec/fixtures/pipeline_test_report.json
+++ b/spec/fixtures/pipeline_test_report.json
@@ -1,0 +1,29 @@
+{
+  "total_time": 5,
+  "total_count": 1,
+  "success_count": 1,
+  "failed_count": 0,
+  "skipped_count": 0,
+  "error_count": 0,
+  "test_suites": [
+    {
+      "name": "Secure",
+      "total_time": 5,
+      "total_count": 1,
+      "success_count": 1,
+      "failed_count": 0,
+      "skipped_count": 0,
+      "error_count": 0,
+      "test_cases": [
+        {
+          "status": "success",
+          "name": "Security Reports can create an auto-remediation MR",
+          "classname": "vulnerability_management_spec",
+          "execution_time": 5,
+          "system_output": null,
+          "stack_trace": null
+        }
+      ]
+    }
+  ]
+}

--- a/spec/gitlab/client/pipelines_spec.rb
+++ b/spec/gitlab/client/pipelines_spec.rb
@@ -38,6 +38,26 @@ describe Gitlab::Client do
     end
   end
 
+  describe '.pipeline_test_report' do
+    before do
+      stub_get('/projects/3/pipelines/46/test_report', 'pipeline_test_report')
+      @report = Gitlab.pipeline_test_report(3, 46)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/pipelines/46/test_report')).to have_been_made
+    end
+
+    it 'returns a single pipeline' do
+      expect(@report).to be_a Gitlab::ObjectifiedHash
+    end
+
+    it 'returns information about a pipeline' do
+      expect(@report.total_time).to eq(5)
+      expect(@report.test_suites[0].name).to eq('Secure')
+    end
+  end
+
   describe '.create_pipeline' do
     let(:pipeline_path) { '/projects/3/pipeline?ref=master' }
 

--- a/spec/gitlab/paginated_response_spec.rb
+++ b/spec/gitlab/paginated_response_spec.rb
@@ -73,10 +73,9 @@ describe Gitlab::PaginatedResponse do
       allow(@paginated_response).to receive(:has_next_page?).and_return(true)
       allow(@paginated_response).to receive(:next_page).and_return(next_page)
       allow(next_page).to receive(:has_next_page?).and_return(true)
-      # NOTE:
-      # Do not define :next_page on the next_page double to prove that it is NOT
-      # called even though :has_next_page? has been defined to claim another
-      # page is available.
+      # NOTE: Do not define :next_page on the next_page double
+      # to prove that it is NOT called even though :has_next_page?
+      # has been defined to claim another page is available.
       allow(next_page).to receive(:to_ary).and_return([5, 6, 7, 8])
       expect(@paginated_response.lazy_paginate.take(8)).to contain_exactly(1, 2, 3, 4, 5, 6, 7, 8)
     end


### PR DESCRIPTION
This method fetches the test report for a pipeline available
through the [Unit test report](https://docs.gitlab.com/ee/ci/unit_test_reports.html) feature.