### PR TITLE
allow max 4 optional parameters for passing self.http_proxy()

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
 
+Metrics/ParameterLists:
+  MaxOptionalParameters: 4
+
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
There's only one method with 4 optional parameters: 

```
$git blame lib/gitlab.rb | grep def\ self.http_proxy
33654bf1 (Nihad Abbasov    2018-08-07 13:34:00 +0400 37)   def self.http_proxy(address = nil, port = nil, username = nil, password = nil)
``` 