### PR TITLE
Ruby 3 support

### DIFF
--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -42,13 +42,6 @@ module Gitlab
   end
 
   # Delegate to Gitlab::Client
-  def self.method_missing(method, *args, &block)
-    return super unless client.respond_to?(method)
-
-    client.send(method, *args, &block)
-  end
-
-  # Delegate to Gitlab::Client
   def self.respond_to_missing?(method_name, include_private = false)
     client.respond_to?(method_name) || super
   end

--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -24,11 +24,13 @@ module Gitlab
   if RUBY_VERSION >= '3.0.0'
     def self.method_missing(method, *args, **keywargs, &block)
       return super unless client.respond_to?(method)
+
       client.send(method, *args, **keywargs, &block)
     end
   else
     def self.method_missing(method, *args, &block)
       return super unless client.respond_to?(method)
+  
       client.send(method, *args, &block)
     end
   end

--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -35,7 +35,7 @@ module Gitlab
     end
   )
 
-  if RUBY_VERSION >= "3.0.0"
+  if RUBY_VERSION >= '3.0.0'
     eval(method_missing_ruby3)
   else
     eval(method_missing_ruby2)

--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -21,14 +21,14 @@ module Gitlab
     Gitlab::Client.new(options)
   end
 
-  method_missing_ruby_2 = %(
+  method_missing_ruby2 = %(
     def self.method_missing(method, *args, &block)
       return super unless client.respond_to?(method)
       client.send(method, *args, &block)
     end
   )
 
-  method_missing_ruby_3 = %(
+  method_missing_ruby3 = %(
     def self.method_missing(method, ...)
       return super unless client.respond_to?(method)
       client.send(method, ...)
@@ -36,9 +36,9 @@ module Gitlab
   )
 
   if RUBY_VERSION >= "3.0.0"
-    eval(method_missing_ruby_3)
+    eval(method_missing_ruby3)
   else
-    eval(method_missing_ruby_2)
+    eval(method_missing_ruby2)
   end
 
   # Delegate to Gitlab::Client

--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -21,24 +21,16 @@ module Gitlab
     Gitlab::Client.new(options)
   end
 
-  method_missing_ruby2 = %(
+  if RUBY_VERSION >= '3.0.0'
+    def self.method_missing(method, *args, **keywargs, &block)
+      return super unless client.respond_to?(method)
+      client.send(method, *args, **keywargs, &block)
+    end
+  else
     def self.method_missing(method, *args, &block)
       return super unless client.respond_to?(method)
       client.send(method, *args, &block)
     end
-  )
-
-  method_missing_ruby3 = %(
-    def self.method_missing(method, ...)
-      return super unless client.respond_to?(method)
-      client.send(method, ...)
-    end
-  )
-
-  if RUBY_VERSION >= '3.0.0'
-    eval(method_missing_ruby3)
-  else
-    eval(method_missing_ruby2)
   end
 
   # Delegate to Gitlab::Client

--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -20,21 +20,21 @@ module Gitlab
   def self.client(options = {})
     Gitlab::Client.new(options)
   end
-  
+
   method_missing_ruby_2 = %(
     def self.method_missing(method, *args, &block)
       return super unless client.respond_to?(method)
       client.send(method, *args, &block)
     end
   )
-  
+
   method_missing_ruby_3 = %(
     def self.method_missing(method, ...)
       return super unless client.respond_to?(method)
       client.send(method, ...)
     end
   )
-  
+
   if RUBY_VERSION >= "3.0.0"
     eval(method_missing_ruby_3)
   else

--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -21,7 +21,7 @@ module Gitlab
     Gitlab::Client.new(options)
   end
 
-  if RUBY_VERSION >= '3.0.0'
+  if Gem::Version.new(RUBY_VERSION).release >= Gem::Version.new('3.0.0')
     def self.method_missing(method, *args, **keywargs, &block)
       return super unless client.respond_to?(method)
 
@@ -30,7 +30,7 @@ module Gitlab
   else
     def self.method_missing(method, *args, &block)
       return super unless client.respond_to?(method)
-  
+
       client.send(method, *args, &block)
     end
   end

--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -20,6 +20,26 @@ module Gitlab
   def self.client(options = {})
     Gitlab::Client.new(options)
   end
+  
+  method_missing_ruby_2 = %(
+    def self.method_missing(method, *args, &block)
+      return super unless client.respond_to?(method)
+      client.send(method, *args, &block)
+    end
+  )
+  
+  method_missing_ruby_3 = %(
+    def self.method_missing(method, ...)
+      return super unless client.respond_to?(method)
+      client.send(method, ...)
+    end
+  )
+  
+  if RUBY_VERSION >= "3.0.0"
+    eval(method_missing_ruby_3)
+  else
+    eval(method_missing_ruby_2)
+  end
 
   # Delegate to Gitlab::Client
   def self.method_missing(method, *args, &block)

--- a/lib/gitlab/cli.rb
+++ b/lib/gitlab/cli.rb
@@ -80,7 +80,7 @@ class Gitlab::CLI
   # Helper method that checks whether we want to get the output as json
   # @return [nil]
   def self.render_output(cmd, args, data)
-    if @json_output
+    if defined?(@json_output) && @json_output
       output_json(cmd, args, data)
     else
       output_table(cmd, args, data)

--- a/lib/gitlab/help.rb
+++ b/lib/gitlab/help.rb
@@ -80,15 +80,15 @@ module Gitlab::Help
     # Massage output from 'ri'.
     def change_help_output!(cmd, output_str)
       output_str = +output_str
-      output_str.gsub!(/#{cmd}\((.*?)\)/m, "#{cmd} \1")
-      output_str.gsub!(/,\s*/, ' ')
+      output_str.gsub!(/#{cmd}(\(.*?\))/m, "#{cmd}\\1")
+      output_str.gsub!(/,\s*/, ', ')
 
       # Ensure @option descriptions are on a single line
       output_str.gsub!(/\n\[/, " \[")
       output_str.gsub!(/\s(@)/, "\n@")
-      output_str.gsub!(/(\])\n(:)/, '\1 \2')
-      output_str.gsub!(/(:.*)(\n)(.*\.)/, '\1 \3')
-      output_str.gsub!(/\{(.+)\}/, '"{\1}"')
+      output_str.gsub!(/(\])\n(:)/, '\\1 \\2')
+      output_str.gsub!(/(:.*)(\n)(.*\.)/, '\\1 \\3')
+      output_str.gsub!(/\{(.+)\}/, '"{\\1}"')
     end
   end
 end

--- a/spec/gitlab/client/build_variables_spec.rb
+++ b/spec/gitlab/client/build_variables_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Gitlab::Client do
 
   describe '.create_variable' do
     before do
-      stub_post('/projects/3/variables', 'variable')
+      stub_post('/projects/3/variables', 'variable', { masked: true })
       @variable = Gitlab.create_variable(3, 'NEW_VARIABLE', 'new value')
     end
 

--- a/spec/gitlab/client/users_spec.rb
+++ b/spec/gitlab/client/users_spec.rb
@@ -614,7 +614,7 @@ RSpec.describe Gitlab::Client do
 
     it 'removes a token' do
       expect(a_delete('/users/2/impersonation_tokens/2')).to have_been_made
-      expect(@token.to_hash()).to be_empty
+      expect(@token.to_hash).to be_empty
     end
   end
 end

--- a/spec/gitlab/client/users_spec.rb
+++ b/spec/gitlab/client/users_spec.rb
@@ -588,7 +588,7 @@ RSpec.describe Gitlab::Client do
   describe 'create' do
     before do
       stub_post('/users/2/impersonation_tokens', 'impersonation_create')
-      @token = Gitlab.create_user_impersonation_token(2, 'mytoken', scopes)
+      @token = Gitlab.create_user_impersonation_token(2, 'mytoken', ['api'])
     end
 
     it 'gets the correct resource' do
@@ -614,7 +614,7 @@ RSpec.describe Gitlab::Client do
 
     it 'removes a token' do
       expect(a_delete('/users/2/impersonation_tokens/2')).to have_been_made
-      expect(@token).to be_empty
+      expect(@token.to_hash()).to be_empty
     end
   end
 end


### PR DESCRIPTION
I ran into a problem (wrong number of arguments) passing optional params to the variables endpoint using Ruby 3.

The problem related to this change: Keyword arguments are separated from other arguments (https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/).