### PR TITLE
Add merge request level rule endpoints

### DIFF
--- a/lib/gitlab/client/merge_request_approvals.rb
+++ b/lib/gitlab/client/merge_request_approvals.rb
@@ -126,6 +126,8 @@ class Gitlab::Client
     end
 
     # Change allowed approvers and approver groups for a merge request
+    # @deprecated Since Gitlab 13.12 /approvers endpoints are removed!!!
+    # See Gitlab.create_merge_request_level_rule
     #
     # @example
     #    Gitlab.edit_merge_request_approvers(1, 5, {approver_ids: [5], approver_groups: [1]})
@@ -137,6 +139,32 @@ class Gitlab::Client
     # @return [Gitlab::ObjectifiedHash] MR approval configuration information about the project
     def edit_merge_request_approvers(project, merge_request, options = {})
       put("/projects/#{url_encode project}/merge_requests/#{merge_request}/approvers", body: options)
+    end
+
+    # Create merge request level rule
+    #
+    # @example
+    #   Gitlab.create_merge_request_level_rule(1, 2, {
+    #     name: "devs",
+    #     approvals_required: 2,
+    #     approval_project_rule_id: 99,
+    #     user_ids: [3, 4],
+    #     group_ids: [5, 6],
+    #   })
+    #
+    # Important: When approval_project_rule_id is set, the name, users and groups of project-level rule are copied.
+    # The approvals_required specified is used.
+    #
+    # @param [Integer] project(required) The ID of a project.
+    # @param [Integer] merge_request(required) The IID of a merge request.
+    # @option options [String] :name(required) The name of the approval rule
+    # @option options [Integer] :approvals_required(required) The number of required approvals for this rule
+    # @option options [Integer] :approval_project_rule_id(optional) The ID of a project-level approval rule
+    # @option options [Array] :user_ids(optional) The ids of users as approvers
+    # @option options [Array] :group_ids(optional) The ids of groups as approvers
+    # @return [Gitlab::ObjectifiedHash] New MR level approval rule
+    def create_merge_request_level_rule(project, merge_request, options = {})
+      post("/projects/#{url_encode project}/merge_requests/#{merge_request}/approval_rules", body: options)
     end
 
     # Approve a merge request

--- a/lib/gitlab/client/merge_request_approvals.rb
+++ b/lib/gitlab/client/merge_request_approvals.rb
@@ -88,6 +88,8 @@ class Gitlab::Client
     end
 
     # Change allowed approvers and approver groups for a project
+    # @deprecated Since Gitlab 13.12 /approvers endpoints are removed!!!
+    # See Gitlab.create_project_merge_request_approval_rule
     #
     # @example
     #    Gitlab.edit_project_approvers(1, {approver_ids: [5], approver_groups: [1]})
@@ -165,6 +167,18 @@ class Gitlab::Client
     # @return [Gitlab::ObjectifiedHash] New MR level approval rule
     def create_merge_request_level_rule(project, merge_request, options = {})
       post("/projects/#{url_encode project}/merge_requests/#{merge_request}/approval_rules", body: options)
+    end
+
+    # Get merge request level rule
+    #
+    # @example
+    #   Gitlab.merge_request_level_rule(1, 2)
+    #
+    # @param [Integer] project(required) The ID of a project.
+    # @param [Integer] merge_request(required) The IID of a merge request.
+    # @return [Gitlab::ObjectifiedHash] New MR level approval rule
+    def merge_request_level_rule(project, merge_request)
+      get("/projects/#{url_encode project}/merge_requests/#{merge_request}/approval_rules")
     end
 
     # Update merge request level rule

--- a/lib/gitlab/client/merge_request_approvals.rb
+++ b/lib/gitlab/client/merge_request_approvals.rb
@@ -177,6 +177,10 @@ class Gitlab::Client
     #     group_ids: [5, 6],
     #   })
     #
+    # Important: Approvers and groups not in the users/groups parameters are removed
+    # Important: Updating a report_approver or code_owner rule is not allowed.
+    # These are system generated rules.
+    #
     # @param [Integer] project(required) The ID of a project.
     # @param [Integer] merge_request(required) The IID of a merge request.
     # @param [Integer] appr_rule_id(required) The ID of a approval rule
@@ -187,6 +191,22 @@ class Gitlab::Client
     # @return [Gitlab::ObjectifiedHash] Updated MR level approval rule
     def update_merge_request_level_rule(project, merge_request, appr_rule_id, options = {})
       put("/projects/#{url_encode project}/merge_requests/#{merge_request}/approval_rules/#{appr_rule_id}", body: options)
+    end
+
+    # Delete merge request level rule
+    #
+    # @example
+    #   Gitlab.delete_merge_request_level_rule(1, 2, 69)
+    #
+    # Important: Deleting a report_approver or code_owner rule is not allowed.
+    # These are system generated rules.
+    #
+    # @param [Integer] project(required) The ID of a project.
+    # @param [Integer] merge_request(required) The IID of a merge request.
+    # @param [Integer] appr_rule_id(required) The ID of a approval rule
+    # @return [void] This API call returns an empty response body
+    def delete_merge_request_level_rule(project, merge_request, appr_rule_id)
+      delete("/projects/#{url_encode project}/merge_requests/#{merge_request}/approval_rules/#{appr_rule_id}")
     end
 
     # Approve a merge request

--- a/lib/gitlab/client/merge_request_approvals.rb
+++ b/lib/gitlab/client/merge_request_approvals.rb
@@ -167,6 +167,28 @@ class Gitlab::Client
       post("/projects/#{url_encode project}/merge_requests/#{merge_request}/approval_rules", body: options)
     end
 
+    # Update merge request level rule
+    #
+    # @example
+    #   Gitlab.update_merge_request_level_rule(1, 2, 69, {
+    #     name: "devs",
+    #     approvals_required: 2,
+    #     user_ids: [3, 4],
+    #     group_ids: [5, 6],
+    #   })
+    #
+    # @param [Integer] project(required) The ID of a project.
+    # @param [Integer] merge_request(required) The IID of a merge request.
+    # @param [Integer] appr_rule_id(required) The ID of a approval rule
+    # @option options [String] :name(required) The name of the approval rule
+    # @option options [Integer] :approvals_required(required) The number of required approvals for this rule
+    # @option options [Array] :user_ids(optional) The ids of users as approvers
+    # @option options [Array] :group_ids(optional) The ids of groups as approvers
+    # @return [Gitlab::ObjectifiedHash] Updated MR level approval rule
+    def update_merge_request_level_rule(project, merge_request, appr_rule_id, options = {})
+      put("/projects/#{url_encode project}/merge_requests/#{merge_request}/approval_rules/#{appr_rule_id}", body: options)
+    end
+
     # Approve a merge request
     #
     # @example

--- a/spec/fixtures/merge_request_level_rule.json
+++ b/spec/fixtures/merge_request_level_rule.json
@@ -1,0 +1,55 @@
+{
+  "id": 1,
+  "name": "security",
+  "rule_type": "regular",
+  "eligible_approvers": [
+    {
+      "id": 2,
+      "name": "John Doe",
+      "username": "jdoe",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+      "web_url": "http://localhost/jdoe"
+    },
+    {
+      "id": 50,
+      "name": "Group Member 1",
+      "username": "group_member_1",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+      "web_url": "http://localhost/group_member_1"
+    }
+  ],
+  "approvals_required": 1,
+  "source_rule": null,
+  "users": [
+    {
+      "id": 2,
+      "name": "John Doe",
+      "username": "jdoe",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/0?s=80&d=identicon",
+      "web_url": "http://localhost/jdoe"
+    }
+  ],
+  "groups": [
+    {
+      "id": 5,
+      "name": "group1",
+      "path": "group1",
+      "description": "",
+      "visibility": "public",
+      "lfs_enabled": false,
+      "avatar_url": null,
+      "web_url": "http://localhost/groups/group1",
+      "request_access_enabled": false,
+      "full_name": "group1",
+      "full_path": "group1",
+      "parent_id": null,
+      "ldap_cn": null,
+      "ldap_access": null
+    }
+  ],
+  "contains_hidden_groups": false,
+  "overridden": false
+}

--- a/spec/gitlab/client/merge_request_approvals_spec.rb
+++ b/spec/gitlab/client/merge_request_approvals_spec.rb
@@ -178,20 +178,20 @@ RSpec.describe Gitlab::Client do
 
   describe '.create_merge_request_level_rule' do
     before do
-      body = { name: "security", approvals_required: 1, approval_project_rule_id: 99, user_ids: [3, 4], group_ids: [5, 6] }
+      body = { name: 'security', approvals_required: 1, approval_project_rule_id: 99, user_ids: [3, 4], group_ids: [5, 6] }
       stub_post('/projects/1/merge_requests/5/approval_rules', 'merge_request_level_rule').with(body: body)
       @merge_request_lvl_rule = Gitlab.create_merge_request_level_rule(1, 5, body)
     end
 
     it 'gets the correct resource' do
-      body = { name: "security", approvals_required: 1, approval_project_rule_id: 99, user_ids: [3, 4], group_ids: [5, 6] }
+      body = { name: 'security', approvals_required: 1, approval_project_rule_id: 99, user_ids: [3, 4], group_ids: [5, 6] }
       expect(a_post('/projects/1/merge_requests/5/approval_rules')
                .with(body: body)).to have_been_made
     end
 
     it 'returns the correct updated configuration' do
       expect(@merge_request_lvl_rule).to be_a Gitlab::ObjectifiedHash
-      expect(@merge_request_lvl_rule.name).to eq "security"
+      expect(@merge_request_lvl_rule.name).to eq 'security'
       expect(@merge_request_lvl_rule.approvals_required).to eq 1
     end
   end
@@ -220,14 +220,14 @@ RSpec.describe Gitlab::Client do
     end
 
     it 'gets the correct resource' do
-      body = { name: "security", approvals_required: 1, user_ids: [3, 4], group_ids: [5, 6] }
+      body = { name: 'security', approvals_required: 1, user_ids: [3, 4], group_ids: [5, 6] }
       expect(a_put('/projects/1/merge_requests/5/approval_rules/69')
                .with(body: body)).to have_been_made
     end
 
     it 'returns the correct updated configuration' do
       expect(@merge_request_lvl_rule).to be_a Gitlab::ObjectifiedHash
-      expect(@merge_request_lvl_rule.name).to eq "security"
+      expect(@merge_request_lvl_rule.name).to eq 'security'
       expect(@merge_request_lvl_rule.approvals_required).to eq 1
     end
   end

--- a/spec/gitlab/client/merge_request_approvals_spec.rb
+++ b/spec/gitlab/client/merge_request_approvals_spec.rb
@@ -216,6 +216,17 @@ RSpec.describe Gitlab::Client do
     end
   end
 
+  describe '.delete_merge_request_level_rule' do
+    before do
+      stub_delete('/projects/1/merge_requests/5/approval_rules/69', 'empty')
+      Gitlab.delete_merge_request_level_rule(1, 5, 69)
+    end
+
+    it 'deletes the correct resource' do
+      expect(a_delete('/projects/1/merge_requests/5/approval_rules/69')).to have_been_made
+    end
+  end
+
   describe '.approve_merge_request' do
     before do
       stub_post('/projects/1/merge_requests/5/approve', 'merge_request_approvals')

--- a/spec/gitlab/client/merge_request_approvals_spec.rb
+++ b/spec/gitlab/client/merge_request_approvals_spec.rb
@@ -196,6 +196,22 @@ RSpec.describe Gitlab::Client do
     end
   end
 
+  describe '.merge_request_level_rule' do
+    before do
+      stub_get('/projects/3/merge_requests/1/approval_rules', 'merge_request_level_rule')
+      @approval_state = Gitlab.merge_request_level_rule(3, 1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/merge_requests/1/approval_rules')).to have_been_made
+    end
+
+    it 'returns information about all merge request level approval rules' do
+      expect(@approval_state.approvals_required).to eq(1)
+      expect(@approval_state.id).to eq(1)
+    end
+  end
+
   describe '.update_merge_request_level_rule' do
     before do
       body = { name: 'security', approvals_required: 1, user_ids: [3, 4], group_ids: [5, 6] }

--- a/spec/gitlab/client/merge_request_approvals_spec.rb
+++ b/spec/gitlab/client/merge_request_approvals_spec.rb
@@ -196,6 +196,26 @@ RSpec.describe Gitlab::Client do
     end
   end
 
+  describe '.update_merge_request_level_rule' do
+    before do
+      body = { name: 'security', approvals_required: 1, user_ids: [3, 4], group_ids: [5, 6] }
+      stub_put('/projects/1/merge_requests/5/approval_rules/69', 'merge_request_level_rule').with(body: body)
+      @merge_request_lvl_rule = Gitlab.update_merge_request_level_rule(1, 5, 69, body)
+    end
+
+    it 'gets the correct resource' do
+      body = { name: "security", approvals_required: 1, user_ids: [3, 4], group_ids: [5, 6] }
+      expect(a_put('/projects/1/merge_requests/5/approval_rules/69')
+               .with(body: body)).to have_been_made
+    end
+
+    it 'returns the correct updated configuration' do
+      expect(@merge_request_lvl_rule).to be_a Gitlab::ObjectifiedHash
+      expect(@merge_request_lvl_rule.name).to eq "security"
+      expect(@merge_request_lvl_rule.approvals_required).to eq 1
+    end
+  end
+
   describe '.approve_merge_request' do
     before do
       stub_post('/projects/1/merge_requests/5/approve', 'merge_request_approvals')

--- a/spec/gitlab/client/merge_request_approvals_spec.rb
+++ b/spec/gitlab/client/merge_request_approvals_spec.rb
@@ -176,6 +176,26 @@ RSpec.describe Gitlab::Client do
     end
   end
 
+  describe '.create_merge_request_level_rule' do
+    before do
+      body = { name: "security", approvals_required: 1, approval_project_rule_id: 99, user_ids: [3, 4], group_ids: [5, 6] }
+      stub_post('/projects/1/merge_requests/5/approval_rules', 'merge_request_level_rule').with(body: body)
+      @merge_request_lvl_rule = Gitlab.create_merge_request_level_rule(1, 5, body)
+    end
+
+    it 'gets the correct resource' do
+      body = { name: "security", approvals_required: 1, approval_project_rule_id: 99, user_ids: [3, 4], group_ids: [5, 6] }
+      expect(a_post('/projects/1/merge_requests/5/approval_rules')
+               .with(body: body)).to have_been_made
+    end
+
+    it 'returns the correct updated configuration' do
+      expect(@merge_request_lvl_rule).to be_a Gitlab::ObjectifiedHash
+      expect(@merge_request_lvl_rule.name).to eq "security"
+      expect(@merge_request_lvl_rule.approvals_required).to eq 1
+    end
+  end
+
   describe '.approve_merge_request' do
     before do
       stub_post('/projects/1/merge_requests/5/approve', 'merge_request_approvals')


### PR DESCRIPTION
Seems that after Gitlab 13.12 MR /approvers endpoint was removed. 
(cant find endpoint in 13.12 https://docs.gitlab.com/13.12/ee/api/merge_request_approvals.html but was available in 13.10 - https://docs.gitlab.com/13.10/ee/api/merge_request_approvals.html#change-allowed-approvers-for-merge-request)

Added 3 new endpoints:

* Create merge request level rule (https://docs.gitlab.com/13.12/ee/api/merge_request_approvals.html#create-merge-request-level-rule)
* Update merge request level rule (https://docs.gitlab.com/13.12/ee/api/merge_request_approvals.html#update-merge-request-level-rule)
* Get merge request level rule (https://docs.gitlab.com/13.12/ee/api/merge_request_approvals.html#get-merge-request-level-rule)
* Delete merge request level rule (https://docs.gitlab.com/13.12/ee/api/merge_request_approvals.html#delete-merge-request-level-rule)

~Have not tested them e2e yet, gonna try in my project~ - OK 

~Maybe its worth adding @deprecated for other MR /approvers endpoints also~ - added