### PR TITLE
Add support for running a project pipeline schedule (#625)

### DIFF
--- a/lib/gitlab/client/pipeline_schedules.rb
+++ b/lib/gitlab/client/pipeline_schedules.rb
@@ -77,6 +77,18 @@ class Gitlab::Client
       post("/projects/#{url_encode project}/pipeline_schedules/#{pipeline_schedule_id}/take_ownership")
     end
 
+    # Run a scheduled pipeline immediately.
+    #
+    # @example
+    #   Gitlab.run_pipeline_schedule(5, 1)
+    #
+    # @param [Integer, String] project The ID or name of a project.
+    # @param [Integer] trigger_id The pipeline schedule ID.
+    # @return [Gitlab::ObjectifiedHash] Pipeline created message.
+    def run_pipeline_schedule(project, pipeline_schedule_id)
+      post("/projects/#{url_encode project}/pipeline_schedules/#{pipeline_schedule_id}/play")
+    end
+
     # Delete a pipeline schedule.
     #
     # @example

--- a/spec/fixtures/pipeline_schedule_run.json
+++ b/spec/fixtures/pipeline_schedule_run.json
@@ -1,0 +1,1 @@
+{"message": "201 Created"}

--- a/spec/gitlab/client/pipeline_schedules_spec.rb
+++ b/spec/gitlab/client/pipeline_schedules_spec.rb
@@ -87,6 +87,21 @@ RSpec.describe Gitlab::Client do
     end
   end
 
+  describe '.run_pipeline_schedule' do
+    before do
+      stub_post('/projects/3/pipeline_schedules/13/play', 'pipeline_schedule_run')
+      @pipeline_schedule_run = Gitlab.run_pipeline_schedule(3, 13)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_post('/projects/3/pipeline_schedules/13/play')).to have_been_made
+    end
+
+    it 'returns created message' do
+      expect(@pipeline_schedule_run).to be_a Gitlab::ObjectifiedHash
+    end
+  end
+
   describe '.delete_pipeline_schedule' do
     before do
       stub_delete('/projects/3/pipeline_schedules/13', 'pipeline_schedule')


### PR DESCRIPTION
Closes https://github.com/NARKOZ/gitlab/issues/625
GitLab doc: https://docs.gitlab.com/ee/api/pipeline_schedules.html#run-a-scheduled-pipeline-immediately