### PR TITLE
Maintain methods across redirects

### DIFF
--- a/lib/gitlab/request.rb
+++ b/lib/gitlab/request.rb
@@ -8,6 +8,7 @@ module Gitlab
   class Request
     include HTTParty
     format :json
+    maintain_method_across_redirects true
     headers 'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'
     parser(proc { |body, _| parse(body) })
 


### PR DESCRIPTION
I've originally stumbled upon this issue after upgrading Gitlab server
from HTTP-only to HTTPS, but forgetting to update some scripts
which use gitlab cli. The cli behaved like everything is fine, but a
server has effectively become "read-only". I guess, I may be not the
only one bitten by this issue, so I've fixed it for everyone.

Citing the commit message:
> If HTTPS is enabled on a server, but the client uses plain HTTP
> Gitlab generates HTTP 301 redirect. By default HTTParty will
> follow with GET request regardless of the original method and
> any PUT/POST will silently fail to update the target. Fix by
> enabling HTTParty::maintain_method_across_redirects.
