### PR TITLE
Add an API endpoint for merge request deletion.

### DIFF
--- a/lib/gitlab/client/merge_requests.rb
+++ b/lib/gitlab/client/merge_requests.rb
@@ -332,6 +332,18 @@ class Gitlab::Client
       delete("/projects/#{url_encode project}/merge_requests/#{merge_request_id}/discussions/#{discussion_id}/notes/#{note_id}")
     end
 
+    # Delete a merge request
+    #
+    # @example
+    #   Gitlab.delete_merge_request(5, 1)
+    #   Gitlab.delete_merge_request('gitlab', 1)
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of a merge request.
+    # @return [Gitlab::ObjectifiedHash] An empty response.
+    def delete_merge_request(project, merge_request_id)
+      delete("/projects/#{url_encode project}/merge_requests/#{merge_request_id}")
+    end
+
     # Gets a list of merge request diff versions
     #
     # @example

--- a/spec/gitlab/client/merge_requests_spec.rb
+++ b/spec/gitlab/client/merge_requests_spec.rb
@@ -388,6 +388,21 @@ RSpec.describe Gitlab::Client do
     end
   end
 
+  describe '.delete_merge_request' do
+    before do
+      stub_request(:delete, 'https://api.example.com/projects/3/merge_requests/2').to_return(body: '')
+      @merge_request = Gitlab.delete_merge_request(3, 2)
+    end
+
+    it 'deletes the correct resource' do
+      expect(a_delete('/projects/3/merge_requests/2')).to have_been_made
+    end
+
+    it 'returns nothing' do
+      expect(@merge_request).to be_falsy
+    end
+  end
+
   describe '.merge_request_diff_versions' do
     before do
       stub_get('/projects/3/merge_requests/105/versions', 'merge_request_diff_versions')


### PR DESCRIPTION
I noticed the endpoint for merge request deletion did not exist.  I added it and added the test for it.