### PR TITLE
Raise error for any 4xx or 5xx HTTP status code

### DIFF
--- a/lib/gitlab/error.rb
+++ b/lib/gitlab/error.rb
@@ -154,5 +154,17 @@ module Gitlab
       503 => ServiceUnavailable,
       522 => ConnectionTimedOut
     }.freeze
+
+    # Returns error class that should be raised for this response. Returns nil
+    # if the response status code is not 4xx or 5xx.
+    #
+    # @param  [HTTParty::Response] response The response object.
+    # @return [Class<Error::ResponseError>, nil]
+    def self.klass(response)
+      error_klass = STATUS_MAPPINGS[response.code]
+      return error_klass if error_klass
+
+      ResponseError if response.server_error? || response.client_error?
+    end
   end
 end

--- a/lib/gitlab/request.rb
+++ b/lib/gitlab/request.rb
@@ -67,7 +67,7 @@ module Gitlab
     # Checks the response code for common errors.
     # Returns parsed response for successful requests.
     def validate(response)
-      error_klass = Error::STATUS_MAPPINGS[response.code]
+      error_klass = Error.klass(response)
       raise error_klass, response if error_klass
 
       parsed = response.parsed_response

--- a/spec/gitlab/request_spec.rb
+++ b/spec/gitlab/request_spec.rb
@@ -115,6 +115,32 @@ RSpec.describe Gitlab::Request do
     end
   end
 
+  describe 'errors' do
+    before do
+      @request.private_token = 'token'
+      @request.endpoint = 'https://example.com/api/v4'
+      @rpath = "#{@request.endpoint}/version"
+
+      allow(@request).to receive(:httparty)
+    end
+
+    it 'raises error for 5xx status code without special error class' do
+      stub_request(:get, @rpath).to_return(status: 599)
+
+      expect { @request.get('/version') }.to raise_error(Gitlab::Error::ResponseError)
+
+      expect(a_request(:get, @rpath)).to have_been_made
+    end
+
+    it 'raises error for 4xx status code without special error class' do
+      stub_request(:get, @rpath).to_return(status: 499)
+
+      expect { @request.get('/version') }.to raise_error(Gitlab::Error::ResponseError)
+
+      expect(a_request(:get, @rpath)).to have_been_made
+    end
+  end
+
   describe 'ratelimiting' do
     before do
       @request.private_token = 'token'


### PR DESCRIPTION
Raise error for any 4xx or 5xx HTTP status code. If there is no special error class, raise `ResponseError`.

Fixes #639 