### PR TITLE
Add all group members endpoint

### DIFF
--- a/lib/gitlab/client/groups.rb
+++ b/lib/gitlab/client/groups.rb
@@ -71,6 +71,21 @@ class Gitlab::Client
       get("/groups/#{url_encode id}/members", query: options)
     end
 
+    # Gets a list of all group members including inherited members.
+    #
+    # @example
+    #   Gitlab.all_group_members(1)
+    #   Gitlab.all_group_members(1, { per_page: 40 })
+    #
+    # @param  [Integer] id The ID of a group.
+    # @param  [Hash] options A customizable set of options.
+    # @option options [Integer] :page The page number.
+    # @option options [Integer] :per_page The number of results per page.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def all_group_members(id, options = {})
+      get("/groups/#{url_encode id}/members/all", query: options)
+    end
+
     # Get a list of descendant groups of a group.
     #
     # @example

--- a/spec/gitlab/client/groups_spec.rb
+++ b/spec/gitlab/client/groups_spec.rb
@@ -126,6 +126,23 @@ RSpec.describe Gitlab::Client do
     end
   end
 
+  describe '.all_group_members' do
+    before do
+      stub_get('/groups/3/members/all', 'group_members')
+      @all_members = Gitlab.all_group_members(3)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/groups/3/members/all')).to have_been_made
+    end
+
+    it "returns information about a group's members" do
+      expect(@all_members).to be_a Gitlab::PaginatedResponse
+      expect(@all_members.size).to eq(2)
+      expect(@all_members[1].name).to eq('John Smith')
+    end
+  end
+
   describe '.group_descendants' do
     before do
       stub_get('/groups/3/descendant_groups', 'group_descendants')


### PR DESCRIPTION
As described in the [members endpoint](https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project): 

> Returns only direct members and not inherited members through ancestors groups.

This PR introduces [all members endpoint](https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-and-invited-members):

> [...] including inherited members, invited users, and permissions through ancestor groups. 