### PR TITLE
Add Packages API implementation

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -40,6 +40,7 @@ module Gitlab
     include Milestones
     include Namespaces
     include Notes
+    include Packages
     include PipelineSchedules
     include PipelineTriggers
     include Pipelines

--- a/lib/gitlab/client/packages.rb
+++ b/lib/gitlab/client/packages.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+class Gitlab::Client
+  # Defines methods related to GitLab Packages.
+  # @see https://docs.gitlab.com/ee/api/packages.html
+  module ContainerRegistry
+    # Gets a list of project packages.
+    #
+    # @example
+    #   Gitlab.project_packages(5)
+    #   Gitlab.project_packages(5, { package_type: 'npm', sort: 'desc' })
+    #
+    # @param   [Integer, String] :project the ID or name of a project.
+    # @param   [Hash] options A customizable set of options.
+    # @options options [String] :order_by The field to use as order. One of created_at (default), name, version, or type.
+    # @options options [String] :sort The direction of the order, either asc (default) for ascending order or desc for descending order.
+    # @options options [String] :package_type Filter the returned packages by type. One of conan, maven, npm, pypi, composer, nuget, helm, terraform_module, or golang.
+    # @options options [String] :package_name Filter the project packages with a fuzzy search by name.
+    # @options options [String] :include_versionless When set to true, versionless packages are included in the response.
+    # @options options [String] :status Filter the returned packages by status. One of default (default), hidden, processing, error, or pending_destruction.
+    # @return  [Array<Gitlab::ObjectifiedHash>]
+    def project_packages(project, options = {})
+      get("/projects/#{url_encode project}/packages", query: options)
+    end
+
+    # Gets a list of project packages.
+    #
+    # @example
+    #   Gitlab.group_packages(5)
+    #   Gitlab.group_packages(5, { package_type: 'npm', sort: 'desc' })
+    #
+    # @param   [Integer, String] project the ID or name of a project.
+    # @param   [Hash] options A customizable set of options.
+    # @options options [String] :exclude_subgroups If the parameter is included as true, packages from projects from subgroups are not listed. Default is false.
+    # @options options [String] :order_by The field to use as order. One of created_at (default), name, version, or type.
+    # @options options [String] :sort The direction of the order, either asc (default) for ascending order or desc for descending order.
+    # @options options [String] :package_type Filter the returned packages by type. One of conan, maven, npm, pypi, composer, nuget, helm, terraform_module, or golang.
+    # @options options [String] :package_name Filter the project packages with a fuzzy search by name.
+    # @options options [String] :include_versionless When set to true, versionless packages are included in the response.
+    # @options options [String] :status Filter the returned packages by status. One of default (default), hidden, processing, error, or pending_destruction.
+    # @return  [Array<Gitlab::ObjectifiedHash>]
+    def group_packages(group, options = {})
+      get("/groups/#{url_encode group}/packages", query: options)
+    end
+
+    # Get a single project package.
+    #
+    # @example
+    #   Gitlab.project_package(5, 3)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id ID of a package.
+    # @return [Gitlab::ObjectifiedHash]
+    def project_package(project, id)
+      get("/projects/#{url_encode project}/packages/#{id}")
+    end
+
+    # Get a list of package files of a single package.
+    #
+    # @example
+    #   Gitlab.project_package_files(5, 3)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id ID of a package.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def project_package_files(project, id)
+      get("/projects/#{url_encode project}/packages/#{id}/package_files")
+    end
+
+    # Deletes a project package.
+    #
+    # @example
+    #   Gitlab.delete_project_package(5, 3)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id ID of a package.
+    # @return [void] This API call returns an empty response body.
+    def delete_project_package(project, id)
+      delete("/projects/#{url_encode project}/packages/#{id}")
+    end
+
+    # Delete a package file.
+    #
+    # @example
+    #   Gitlab.delete_project_file(5, 3, 1)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] package_id ID of a package.
+    # @param  [Integer] file_id ID of a package file.
+    # @return [void] This API call returns an empty response body.
+    def delete_project_package_file(project, package_id, file_id)
+      delete("/projects/#{url_encode project}/packages/#{package_id}/package_files/#{file_id}")
+    end
+  end
+end

--- a/lib/gitlab/client/packages.rb
+++ b/lib/gitlab/client/packages.rb
@@ -3,7 +3,7 @@
 class Gitlab::Client
   # Defines methods related to GitLab Packages.
   # @see https://docs.gitlab.com/ee/api/packages.html
-  module ContainerRegistry
+  module Packages
     # Gets a list of project packages.
     #
     # @example

--- a/spec/fixtures/group_packages.json
+++ b/spec/fixtures/group_packages.json
@@ -1,0 +1,54 @@
+[
+    {
+        "id": 1,
+        "name": "com/mycompany/my-app",
+        "version": "1.0-SNAPSHOT",
+        "package_type": "maven",
+        "_links": {
+            "web_path": "/namespace1/project1/-/packages/1",
+            "delete_api_path": "/namespace1/project1/-/packages/1"
+        },
+        "created_at": "2019-11-27T03:37:38.711Z",
+        "pipelines": [
+            {
+                "id": 123,
+                "status": "pending",
+                "ref": "new-pipeline",
+                "sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+                "web_url": "https://example.com/foo/bar/pipelines/47",
+                "created_at": "2016-08-11T11:28:34.085Z",
+                "updated_at": "2016-08-11T11:32:35.169Z",
+                "user": {
+                    "name": "Administrator",
+                    "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon"
+                }
+            }
+        ]
+    },
+    {
+        "id": 2,
+        "name": "@foo/bar",
+        "version": "1.0.3",
+        "package_type": "npm",
+        "_links": {
+            "web_path": "/namespace1/project1/-/packages/1",
+            "delete_api_path": "/namespace1/project1/-/packages/1"
+        },
+        "created_at": "2019-11-27T03:37:38.711Z",
+        "pipelines": [
+            {
+                "id": 123,
+                "status": "pending",
+                "ref": "new-pipeline",
+                "sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+                "web_url": "https://example.com/foo/bar/pipelines/47",
+                "created_at": "2016-08-11T11:28:34.085Z",
+                "updated_at": "2016-08-11T11:32:35.169Z",
+                "user": {
+                    "name": "Administrator",
+                    "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon"
+                }
+            }
+        ]
+    }
+]

--- a/spec/fixtures/project_package.json
+++ b/spec/fixtures/project_package.json
@@ -1,0 +1,48 @@
+{
+    "id": 1,
+    "name": "com/mycompany/my-app",
+    "version": "1.0-SNAPSHOT",
+    "package_type": "maven",
+    "_links": {
+        "web_path": "/namespace1/project1/-/packages/1",
+        "delete_api_path": "/namespace1/project1/-/packages/1"
+    },
+    "created_at": "2019-11-27T03:37:38.711Z",
+    "pipelines": [
+        {
+            "id": 123,
+            "status": "pending",
+            "ref": "new-pipeline",
+            "sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+            "web_url": "https://example.com/foo/bar/pipelines/47",
+            "created_at": "2016-08-11T11:28:34.085Z",
+            "updated_at": "2016-08-11T11:32:35.169Z",
+            "user": {
+                "name": "Administrator",
+                "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon"
+            }
+        }
+    ],
+    "versions": [
+        {
+            "id": 2,
+            "version": "2.0-SNAPSHOT",
+            "created_at": "2020-04-28T04:42:11.573Z",
+            "pipelines": [
+                {
+                    "id": 234,
+                    "status": "pending",
+                    "ref": "new-pipeline",
+                    "sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+                    "web_url": "https://example.com/foo/bar/pipelines/58",
+                    "created_at": "2016-08-11T11:28:34.085Z",
+                    "updated_at": "2016-08-11T11:32:35.169Z",
+                    "user": {
+                        "name": "Administrator",
+                        "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/spec/fixtures/project_package_files.json
+++ b/spec/fixtures/project_package_files.json
@@ -1,0 +1,47 @@
+[
+    {
+        "id": 25,
+        "package_id": 4,
+        "created_at": "2018-11-07T15:25:52.199Z",
+        "file_name": "my-app-1.5-20181107.152550-1.jar",
+        "size": 2421,
+        "file_md5": "58e6a45a629910c6ff99145a688971ac",
+        "file_sha1": "ebd193463d3915d7e22219f52740056dfd26cbfe",
+        "file_sha256": "a903393463d3915d7e22219f52740056dfd26cbfeff321b",
+        "pipelines": [
+            {
+                "id": 123,
+                "status": "pending",
+                "ref": "new-pipeline",
+                "sha": "a91957a858320c0e17f3a0eca7cfacbff50ea29a",
+                "web_url": "https://example.com/foo/bar/pipelines/47",
+                "created_at": "2016-08-11T11:28:34.085Z",
+                "updated_at": "2016-08-11T11:32:35.169Z",
+                "user": {
+                    "name": "Administrator",
+                    "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon"
+                }
+            }
+        ]
+    },
+    {
+        "id": 26,
+        "package_id": 4,
+        "created_at": "2018-11-07T15:25:56.776Z",
+        "file_name": "my-app-1.5-20181107.152550-1.pom",
+        "size": 1122,
+        "file_md5": "d90f11d851e17c5513586b4a7e98f1b2",
+        "file_sha1": "9608d068fe88aff85781811a42f32d97feb440b5",
+        "file_sha256": "2987d068fe88aff85781811a42f32d97feb4f092a399"
+    },
+    {
+        "id": 27,
+        "package_id": 4,
+        "created_at": "2018-11-07T15:26:00.556Z",
+        "file_name": "maven-metadata.xml",
+        "size": 767,
+        "file_md5": "6dfd0cce1203145a927fef5e3a1c650c",
+        "file_sha1": "d25932de56052d320a8ac156f745ece73f6a8cd2",
+        "file_sha256": "ac849d002e56052d320a8ac156f745ece73f6a8cd2f3e82"
+    }
+]

--- a/spec/fixtures/project_packages.json
+++ b/spec/fixtures/project_packages.json
@@ -1,0 +1,29 @@
+[
+    {
+        "id": 1,
+        "name": "com/mycompany/my-app",
+        "version": "1.0-SNAPSHOT",
+        "package_type": "maven",
+        "created_at": "2019-11-27T03:37:38.711Z"
+    },
+    {
+        "id": 2,
+        "name": "@foo/bar",
+        "version": "1.0.3",
+        "package_type": "npm",
+        "created_at": "2019-11-27T03:37:38.711Z"
+    },
+    {
+        "id": 3,
+        "name": "Hello/0.1@mycompany/stable",
+        "conan_package_name": "Hello",
+        "version": "0.1",
+        "package_type": "conan",
+        "_links": {
+            "web_path": "/foo/bar/-/packages/3",
+            "delete_api_path": "https://gitlab.example.com/api/v4/projects/1/packages/3"
+        },
+        "created_at": "2029-12-16T20:33:34.316Z",
+        "tags": []
+    }
+]

--- a/spec/gitlab/client/packages_spec.rb
+++ b/spec/gitlab/client/packages_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Gitlab::Client do
+  describe '.project_packages' do
+    before do
+      stub_get('/projects/3/packages', 'project_packages')
+      @packages = Gitlab.project_packages(3)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/packages')).to have_been_made
+    end
+
+    it "returns a paginated response of project's packages" do
+      expect(@packages).to be_a Gitlab::PaginatedResponse
+    end
+  end
+
+  describe '.group_packages' do
+    before do
+      stub_get('/groups/3/packages', 'group_packages')
+      @packages = Gitlab.group_packages(3)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/groups/3/packages')).to have_been_made
+    end
+
+    it "returns a paginated response of group's packages" do
+      expect(@packages).to be_a Gitlab::PaginatedResponse
+    end
+  end
+
+  describe '.project_package' do
+    before do
+      stub_get('/projects/3/packages/5', 'project_package')
+      @package = Gitlab.project_package(3, 5)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/packages/5')).to have_been_made
+    end
+
+    it 'returns a single project package' do
+      expect(@package).to be_a Gitlab::ObjectifiedHash
+    end
+  end
+
+  describe '.project_package_files' do
+    before do
+      stub_get('/projects/3/packages/5/package_files', 'project_package_files')
+      @package_files = Gitlab.project_package_files(3, 5)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/packages/5/package_files')).to have_been_made
+    end
+
+    it "returns a paginated response of package's files" do
+      expect(@package_files).to be_a Gitlab::PaginatedResponse
+    end
+  end
+
+  describe '.delete_project_package' do
+    before do
+      stub_delete('/projects/3/packages/13', 'project_package')
+      Gitlab.delete_project_package(3, 13)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_delete('/projects/3/packages/13')).to have_been_made
+    end
+  end
+
+  describe '.delete_project_package_file' do
+    before do
+      stub_delete('/projects/3/packages/13/package_files/10', 'empty')
+      Gitlab.delete_project_package_file(3, 13, 10)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_delete('/projects/3/packages/13/package_files/10')).to have_been_made
+    end
+  end
+end


### PR DESCRIPTION
This add a new `Packages` module that exposes methods to interact with the [GItLab Packages API](https://docs.gitlab.com/14.9/ee/api/packages.html)

## Changes

- Implementation for all current endpoints exposed as part of the Packages API
- New spec file added plus dedicated stub content matching the example outputs from the GitLab docs