### PR TITLE
Add users disable 2FA

### DIFF
--- a/lib/gitlab.rb
+++ b/lib/gitlab.rb
@@ -50,7 +50,7 @@ module Gitlab
   # @return [Array<Symbol>]
   def self.actions
     hidden =
-      /endpoint|private_token|auth_token|user_agent|sudo|get|post|put|\Adelete\z|validate\z|request_defaults|httparty/
+      /endpoint|private_token|auth_token|user_agent|sudo|get|post|put|patch|\Adelete\z|validate\z|request_defaults|httparty/
     (Gitlab::Client.instance_methods - Object.methods).reject { |e| e[hidden] }
   end
 end

--- a/lib/gitlab/client/users.rb
+++ b/lib/gitlab/client/users.rb
@@ -393,5 +393,16 @@ class Gitlab::Client
     def revoke_user_impersonation_token(user_id, impersonation_token_id)
       delete("/users/#{user_id}/impersonation_tokens/#{impersonation_token_id}")
     end
+
+    # Disables two factor authentication (2FA) for the specified user.
+    #
+    # @example
+    #   Gitlab.disable_two_factor(1)
+    #
+    # @param [Integer] id The ID of a user.
+    # @return [Gitlab::ObjectifiedHash]
+    def disable_two_factor(user_id)
+      patch("/users/#{user_id}/disable_two_factor")
+    end
   end
 end

--- a/lib/gitlab/request.rb
+++ b/lib/gitlab/request.rb
@@ -38,7 +38,7 @@ module Gitlab
       raise Error::Parsing, 'The response is not a valid JSON'
     end
 
-    %w[get post put delete].each do |method|
+    %w[get post put patch delete].each do |method|
       define_method method do |path, options = {}|
         params = options.dup
 

--- a/spec/gitlab/client/users_spec.rb
+++ b/spec/gitlab/client/users_spec.rb
@@ -632,4 +632,18 @@ RSpec.describe Gitlab::Client do
       expect(@token.to_hash).to be_empty
     end
   end
+
+  describe '.disable_two_factor' do
+    before do
+      stub_request(:patch, "#{Gitlab.endpoint}/users/1/disable_two_factor")
+        .with(headers: { 'PRIVATE-TOKEN' => Gitlab.private_token })
+        .to_return(status: 204)
+      @token = Gitlab.disable_two_factor(1)
+    end
+
+    it 'successfully disabled 2fa' do
+      expect(a_response(:patch, '/users/1/disable_two_factor')).to have_been_made
+      expect(@token.to_hash).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Adds support for the [disable two factor authentication](https://docs.gitlab.com/ee/api/users.html#disable-two-factor-authentication) endpoint introduced in GitLab `15.2`.