### PR TITLE
Add Pipeline Variables endpoint

### DIFF
--- a/lib/gitlab/client/pipelines.rb
+++ b/lib/gitlab/client/pipelines.rb
@@ -43,6 +43,18 @@ class Gitlab::Client
       get("/projects/#{url_encode project}/pipelines/#{id}/test_report")
     end
 
+    # Gets a single pipeline's variables.
+    #
+    # @example
+    #   Gitlab.pipeline_variables(5, 36)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of a pipeline.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def pipeline_variables(project, id)
+      get("/projects/#{url_encode project}/pipelines/#{id}/variables")
+    end
+
     # Create a pipeline.
     #
     # @example

--- a/spec/fixtures/pipeline_variables.json
+++ b/spec/fixtures/pipeline_variables.json
@@ -1,0 +1,11 @@
+[
+  {
+    "key": "RUN_NIGHTLY_BUILD",
+    "variable_type": "env_var",
+    "value": "true"
+  },
+  {
+    "key": "foo",
+    "value": "bar"
+  }
+]

--- a/spec/gitlab/client/pipelines_spec.rb
+++ b/spec/gitlab/client/pipelines_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Gitlab::Client do
     end
 
     it "returns pipeline's variables" do
-      expect(@variables[0]["key"]).to eq('RUN_NIGHTLY_BUILD')
+      expect(@variables[0]['key']).to eq('RUN_NIGHTLY_BUILD')
     end
   end
 

--- a/spec/gitlab/client/pipelines_spec.rb
+++ b/spec/gitlab/client/pipelines_spec.rb
@@ -58,6 +58,25 @@ RSpec.describe Gitlab::Client do
     end
   end
 
+  describe '.pipeline_variables' do
+    before do
+      stub_get('/projects/3/pipelines/46/variables', 'pipeline_variables')
+      @variables = Gitlab.pipeline_variables(3, 46)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/pipelines/46/variables')).to have_been_made
+    end
+
+    it 'returns a paginated response of pipeline variables' do
+      expect(@variables).to be_a Gitlab::PaginatedResponse
+    end
+
+    it "returns pipeline's variables" do
+      expect(@variables[0]["key"]).to eq('RUN_NIGHTLY_BUILD')
+    end
+  end
+
   describe '.create_pipeline' do
     let(:pipeline_path) { '/projects/3/pipeline?ref=master' }
 


### PR DESCRIPTION
```ruby
Gitlab.pipeline_variables(12, 3)
# => [#<Gitlab::ObjectifiedHash:70126709383040 {hash: {"variable_type"=>"env_var", "key"=>"FOO", "value"=>"bar"}}]
```

https://docs.gitlab.com/ee/api/pipelines.html#get-variables-of-a-pipeline