### PR TITLE
Added deactivate_user and activate_user methods

### DIFF
--- a/lib/gitlab/client/users.rb
+++ b/lib/gitlab/client/users.rb
@@ -110,6 +110,28 @@ class Gitlab::Client
       post("/users/#{user_id}/unblock")
     end
 
+    # Deactivates the specified user. Available only for admin.
+    #
+    # @example
+    #   Gitlab.deactivate_user(15)
+    #
+    # @param [Integer] user_id The Id of user
+    # @return [Boolean] success or not
+    def deactivate_user(user_id)
+      post("/users/#{user_id}/deactivate")
+    end
+
+    # Activate the specified user. Available only for admin.
+    #
+    # @example
+    #   Gitlab.activate_user(15)
+    #
+    # @param [Integer] user_id The Id of user
+    # @return [Boolean] success or not
+    def activate_user(user_id)
+      post("/users/#{user_id}/activate")
+    end
+
     # Approves the specified user. Available only for admin.
     #
     # @example

--- a/spec/gitlab/client/users_spec.rb
+++ b/spec/gitlab/client/users_spec.rb
@@ -170,6 +170,36 @@ RSpec.describe Gitlab::Client do
     end
   end
 
+  describe '.deactivate_user' do
+    before do
+      stub_post('/users/1/deactivate', 'user_deactivate_activate')
+      @result = Gitlab.deactivate_user(1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_post('/users/1/deactivate')).to have_been_made
+    end
+
+    it 'returns boolean' do
+      expect(@result).to eq(true)
+    end
+  end
+
+  describe '.activate' do
+    before do
+      stub_post('/users/1/activate', 'user_deactivate_activate')
+      @result = Gitlab.activate(1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_post('/users/1/activate')).to have_been_made
+    end
+
+    it 'returns boolean' do
+      expect(@result).to eq(true)
+    end
+  end
+
   describe '.approve_user' do
     before do
       stub_post('/users/1/approve', 'user_approve')


### PR DESCRIPTION
Gitlab 12.4 introduced activate and deactivate users feature. These two methods, viz. deactivate_user and activate_user, implement this capability available through the GitLab API.