### PR TITLE
Add the Merge Requests /diffs endpoint

### DIFF
--- a/lib/gitlab/client/merge_requests.rb
+++ b/lib/gitlab/client/merge_requests.rb
@@ -344,6 +344,18 @@ class Gitlab::Client
       delete("/projects/#{url_encode project}/merge_requests/#{merge_request_id}")
     end
 
+    # Gets a list of merge request diffs
+    #
+    # @example
+    #   Gitlab.merge_request_diffs(5, 1)
+    #   Gitlab.merge_request_diffs('gitlab', 1)
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of a merge request.
+    # @return [Gitlab::ObjectifiedHash] A list of the merge request diffs.
+    def merge_request_diffs(project, merge_request_id)
+      get("/projects/#{url_encode project}/merge_requests/#{merge_request_id}/diffs")
+    end
+
     # Gets a list of merge request diff versions
     #
     # @example

--- a/spec/fixtures/merge_request_diffs.json
+++ b/spec/fixtures/merge_request_diffs.json
@@ -1,0 +1,22 @@
+[
+  {
+    "old_path": "README",
+    "new_path": "README",
+    "a_mode": "100644",
+    "b_mode": "100644",
+    "diff": "--- a/README\ +++ b/README\ @@ -1 +1 @@\ -Title\ +README",
+    "new_file": false,
+    "renamed_file": false,
+    "deleted_file": false
+  },
+  {
+    "old_path": "VERSION",
+    "new_path": "VERSION",
+    "a_mode": "100644",
+    "b_mode": "100644",
+    "diff": "--- a/VERSION\ +++ b/VERSION\ @@ -1 +1 @@\ -1.9.7\ +1.9.8",
+    "new_file": false,
+    "renamed_file": false,
+    "deleted_file": false
+  }
+]

--- a/spec/gitlab/client/merge_requests_spec.rb
+++ b/spec/gitlab/client/merge_requests_spec.rb
@@ -403,6 +403,22 @@ RSpec.describe Gitlab::Client do
     end
   end
 
+  describe '.merge_request_diffs' do
+    before do
+      stub_get('/projects/3/merge_requests/105/diffs', 'merge_request_diffs')
+      @versions = Gitlab.merge_request_diffs(3, 105)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/merge_requests/105/diffs')).to have_been_made
+    end
+
+    it 'returns an array of the diffs' do
+      expect(@versions.length).to eq(2)
+      expect(@versions.first.old_path).to eq('README')
+    end
+  end
+
   describe '.merge_request_diff_versions' do
     before do
       stub_get('/projects/3/merge_requests/105/versions', 'merge_request_diff_versions')


### PR DESCRIPTION
["List merge request diffs"](https://docs.gitlab.com/ee/api/merge_requests.html#list-merge-request-diffs) appears to be missing from this gem, so this MR adds it. Thanks!

The fixture comes from the documentation.

Example usage:

```ruby
> Gitlab.merge_request_diffs(33727711, 1)
=> [#<Gitlab::ObjectifiedHash:2120 {hash: {"diff"=>"@@ -4,6 +4,10 @@ This README is intended to be helpful for colleagues at GitLab. For everything e\n \n Please `@` me in comments, issues, and MRs. I use TODOs, and rarely check notification emails. You can also DM me on Slack.\n \n+## My role\n+\n+I'm on the Application Security Team ([role description](https://about.gitlab.com/job-families/engineering/application-security/)) and you can find the teams I work with [on this handbook page](https://about.gitlab.com/handbook/product/categories/).\n+\n ## Communication style\n \n I tend to be concise and direct. Some might say blunt. If I overstep please [give me feedback](https://about.gitlab.com/handbook/people-group/guidance-on-feedback/) so I can improve!\n@@ -19,6 +23,16 @@ I try to use te reo Māori kupu in my messages, particularly in Slack. Here are\n \n [MaoriDictionary.co.nz](https://maoridictionary.co.nz/) can be helpful too!\n \n-## Family\n+## Personal\n \n I am married and have two young boys ❤️ They might interrupt a meeting or mean I need to postpone. Thanks for understanding!\n+\n+I like (in no particular order):\n+\n+- Trail running\n+- Family time\n+- Lasagne\n+- Going to church\n+- Blobbing in front of the TV\n+- Reading fantasy (Riftwar Cycle, Wheel of Time, Kingkiller Chronicle, Mistborn, etc) or popcorn thriller (Jack Reacher)\n+- Learning about New Zealand history & te ao Māori\n", "new_path"=>"README.md", "old_path"=>"README.md", "a_mode"=>"100644", "b_mode"=>"100644", "new_file"=>false, "renamed_file"=>false, "deleted_file"=>false}}]
```