### PR TITLE
Add support for Gitlab group access tokens API.

### DIFF
--- a/lib/gitlab/client/groups.rb
+++ b/lib/gitlab/client/groups.rb
@@ -355,4 +355,59 @@ class Gitlab::Client
       delete("/groups/#{group_id}/custom_attributes/#{key}")
     end
   end
+
+  # Get all access tokens for a group
+  #
+  # @example
+  #   Gitlab.group_access_tokens(1)
+  #
+  # @param  [Integer] group_id The ID of the group.
+  # @return [Array<Gitlab::ObjectifiedHash>]
+  def group_access_tokens(group_id)
+    get("/groups/#{group_id}/access_tokens")
+  end
+
+  # Get group access token information
+  #
+  # @example
+  #   Gitlab.group_access_token(1, 1)
+  #
+  # @param  [Integer] group_id The ID of the group.
+  # @param  [Integer] group_access_token_id ID of the group access token.
+  # @return [Gitlab::ObjectifiedHash]
+  def group_access_token(group_id, group_access_token_id)
+    get("/groups/#{group_id}/access_tokens/#{group_access_token_id}")
+  end
+
+  # Create group access token
+  #
+  # @example
+  #   Gitlab.create_group_access_token(2, "token", ["api", "read_user"])
+  #   Gitlab.create_group_access_token(2, "token", ["api", "read_user"], 20)
+  #   Gitlab.create_group_access_token(2, "token", ["api", "read_user"], 20, "1970-01-01")
+  #
+  # @param  [Integer] group_id The ID of the group.
+  # @param  [String] name Name for group access token.
+  # @param  [Array<String>] scopes Array of scopes for the group access token
+  # @param  [Integer] access_level Project access level (10: Guest, 20: Reporter, 30: Developer, 40: Maintainer, 50: Owner).
+  # @param  [String] expires_at Date for group access token expiration in ISO format.
+  # @return [Gitlab::ObjectifiedHash]
+  def create_group_access_token(group_id, name, scopes, access_level = nil, expires_at = nil)
+    body = { name: name, scopes: scopes }
+    body[:access_level] = access_level if access_level
+    body[:expires_at] = expires_at if expires_at
+    post("/groups/#{group_id}/access_tokens", body: body)
+  end
+
+  # Revoke a group access token
+  #
+  # @example
+  #   Gitlab.revoke_group_access_token(1, 1)
+  #
+  # @param  [Integer] user_id The ID of the group.
+  # @param  [Integer] group_access_token_id ID of the group access token.
+  # @return [Gitlab::ObjectifiedHash]
+  def revoke_group_access_token(group_id, group_access_token_id)
+    delete("/groups/#{group_id}/access_tokens/#{group_access_token_id}")
+  end
 end

--- a/spec/fixtures/group_access_token_create.json
+++ b/spec/fixtures/group_access_token_create.json
@@ -1,0 +1,13 @@
+{
+   "id" : 2,
+   "revoked" : false,
+   "user_id" : 2,
+   "scopes" : [
+      "api"
+   ],
+   "token" : "zMrP_vusadyipEaqued1",
+   "active" : true,
+   "name" : "mygrouptoken",
+   "created_at" : "2023-04-26T17:18:09.283Z",
+   "expires_at" : "2024-04-30"
+}

--- a/spec/fixtures/group_access_token_get.json
+++ b/spec/fixtures/group_access_token_get.json
@@ -1,0 +1,12 @@
+{
+   "active" : true,
+   "user_id" : 2,
+   "scopes" : [
+      "api"
+   ],
+   "revoked" : false,
+   "name" : "mygrouptoken",
+   "id" : 2,
+   "created_at" : "2024-04-26T17:18:09.283Z",
+   "expires_at" : "2024-04-30"
+}

--- a/spec/fixtures/group_access_token_get_all.json
+++ b/spec/fixtures/group_access_token_get_all.json
@@ -1,0 +1,26 @@
+[
+  {
+    "active": true,
+    "user_id": 2,
+    "scopes": [
+      "api"
+    ],
+    "revoked": false,
+    "name": "mygrouptoken",
+    "id": 2,
+    "created_at": "2024-04-26T17:18:09.283Z",
+    "expires_at": "2024-04-30"
+  },
+  {
+    "active": false,
+    "user_id": 2,
+    "scopes": [
+      "read_registry"
+    ],
+    "revoked": true,
+    "name": "mygrouptoken2",
+    "created_at": "2024-04-26T17:19:28.697Z",
+    "id": 3,
+    "expires_at": "2024-04-30"
+  }
+]

--- a/spec/gitlab/client/groups_spec.rb
+++ b/spec/gitlab/client/groups_spec.rb
@@ -446,4 +446,70 @@ RSpec.describe Gitlab::Client do
       end
     end
   end
+
+  describe 'group access tokens' do
+    describe 'get all' do
+      before do
+        stub_get('/groups/2/access_tokens', 'group_access_token_get_all')
+        @tokens = Gitlab.group_access_tokens(2)
+      end
+
+      it 'gets the correct resource' do
+        expect(a_get('/groups/2/access_tokens')).to have_been_made
+      end
+
+      it 'gets an array of group access tokens' do
+        expect(@tokens.first.id).to eq(2)
+        expect(@tokens.last.id).to eq(3)
+      end
+    end
+
+    describe 'get one' do
+      before do
+        stub_get('/groups/2/access_tokens/2', 'group_access_token_get')
+        @token = Gitlab.group_access_token(2, 2)
+      end
+
+      it 'gets the correct resource' do
+        expect(a_get('/groups/2/access_tokens/2')).to have_been_made
+      end
+
+      it 'gets a group access token' do
+        expect(@token.user_id).to eq(2)
+        expect(@token.id).to eq(2)
+      end
+    end
+
+    describe 'create' do
+      before do
+        stub_post('/groups/2/access_tokens', 'group_access_token_create')
+        @token = Gitlab.create_group_access_token(2, 'mytoken', ['api'])
+      end
+
+      it 'gets the correct resource' do
+        expect(a_post('/groups/2/access_tokens').with(body: 'name=mytoken&scopes%5B%5D=api')).to have_been_made
+      end
+
+      it 'returns a valid group access token' do
+        expect(@token.user_id).to eq(2)
+        expect(@token.id).to eq(2)
+        expect(@token.active).to be_truthy
+        expect(@token.token).to eq('zMrP_vusadyipEaqued1')
+      end
+    end
+
+    describe 'revoke' do
+      before do
+        stub_request(:delete, "#{Gitlab.endpoint}/groups/2/access_tokens/2")
+          .with(headers: { 'PRIVATE-TOKEN' => Gitlab.private_token })
+          .to_return(status: 204)
+        @token = Gitlab.revoke_group_access_token(2, 2)
+      end
+
+      it 'removes a token' do
+        expect(a_delete('/groups/2/access_tokens/2')).to have_been_made
+        expect(@token.to_hash).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds support for the Gitlab group access tokens API (list get create revoke).

See https://docs.gitlab.com/ee/api/group_access_tokens.html