### PR TITLE
Add pipeline metadata update endpoint

### DIFF
--- a/lib/gitlab/client/pipelines.rb
+++ b/lib/gitlab/client/pipelines.rb
@@ -101,5 +101,18 @@ class Gitlab::Client
     def delete_pipeline(project, id)
       delete("/projects/#{url_encode project}/pipelines/#{id}")
     end
+
+    # Update a pipeline metadata
+    #
+    # @example
+    #   Gitlab.update_pipeline_metadata(5, 1, name: 'new name')
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of a pipeline.
+    # @option options [String] :name The new name of the pipeline.
+    # @return [Gitlab::ObjectifiedHash]
+    def update_pipeline_metadata(project, id, options = {})
+      put("/projects/#{url_encode project}/pipelines/#{id}/metadata", body: options)
+    end
   end
 end

--- a/spec/gitlab/client/pipelines_spec.rb
+++ b/spec/gitlab/client/pipelines_spec.rb
@@ -140,4 +140,17 @@ RSpec.describe Gitlab::Client do
       expect(a_delete('/projects/3/pipelines/46')).to have_been_made
     end
   end
+
+  describe '.update_pipeline_metadata' do
+    before do
+      stub_put('/projects/3/pipelines/46/metadata', 'pipeline')
+      Gitlab.update_pipeline_metadata(3, 46, name: 'new pipeline name')
+    end
+
+    it 'gets the correct resource' do
+      expect(
+        a_put('/projects/3/pipelines/46/metadata').with(body: { name: 'new pipeline name' })
+      ).to have_been_made
+    end
+  end
 end


### PR DESCRIPTION
## What does this PR do?

Adds support for the update pipeline metadata endpoint: https://docs.gitlab.com/ee/api/pipelines.html#update-pipeline-metadata:

```ruby
Gitlab.update_pipeline_metadata(5, 1, name: 'new name')
```