### PR TITLE
Implemented ability to create service accounts which was introduced i…

### DIFF
--- a/lib/gitlab/client/users.rb
+++ b/lib/gitlab/client/users.rb
@@ -58,6 +58,22 @@ class Gitlab::Client
       post('/users', body: body)
     end
 
+    # Creates a service account.
+    # Requires authentication from an admin account.
+    #
+    # @example
+    #   Gitlab.create_service_account('service_account_6018816a18e515214e0c34c2b33523fc', 'Service account user')
+    #
+    # @param  [String] name (required) The email of the service account.
+    # @param  [String] username (required) The username of the service account.
+    # @return [Gitlab::ObjectifiedHash] Information about created service account.
+    def create_service_account(*args)
+      raise ArgumentError, 'Missing required parameters' unless args[1]
+
+      body = { name: args[0], username: args[1] }
+      post('/service_accounts', body: body)
+    end
+
     # Updates a user.
     #
     # @example
@@ -404,6 +420,47 @@ class Gitlab::Client
       post("/users/#{user_id}/impersonation_tokens", body: body)
     end
 
+    # Get all personal access tokens for a user
+    #
+    # @example
+    #   Gitlab.user_personal_access_tokens(1)
+    #
+    # @param  [Integer] user_id The ID of the user.
+    # @return [Array<Gitlab::ObjectifiedHash>]
+    def user_personal_access_tokens(user_id)
+      get("/personal_access_tokens?user_id=#{user_id}")
+    end
+
+    # Create personal access token
+    #
+    # @example
+    #   Gitlab.create_personal_access_token(2, "token", ["api", "read_user"])
+    #   Gitlab.create_personal_access_token(2, "token", ["api", "read_user"], "1970-01-01")
+    #
+    # @param  [Integer] user_id The ID of the user.
+    # @param  [String] name Name of the personal access token.
+    # @param  [Array<String>] scopes Array of scopes for the impersonation token
+    # @param  [String] expires_at Date for impersonation token expiration in ISO format.
+    # @return [Gitlab::ObjectifiedHash]
+    def create_personal_access_token(user_id, name, scopes, expires_at = nil)
+      body = { name: name, scopes: scopes }
+      body[:expires_at] = expires_at if expires_at
+      post("/users/#{user_id}/personal_access_tokens", body: body)
+    end
+
+    # Rotate a personal access token
+    #
+    # @example
+    #   Gitlab.rotate_personal_access_token(1)
+    #
+    # @param  [Integer] personal_access_token_id ID of the personal access token.
+    # @return [Gitlab::ObjectifiedHash]
+    def rotate_personal_access_token(personal_access_token_id, expires_at = nil)
+      body = {}
+      body[:expires_at] = expires_at if expires_at
+      post("/personal_access_tokens/#{personal_access_token_id}/rotate", body: body)
+    end
+
     # Revoke an impersonation token
     #
     # @example
@@ -414,6 +471,17 @@ class Gitlab::Client
     # @return [Gitlab::ObjectifiedHash]
     def revoke_user_impersonation_token(user_id, impersonation_token_id)
       delete("/users/#{user_id}/impersonation_tokens/#{impersonation_token_id}")
+    end
+
+    # Revoke a personal access token
+    #
+    # @example
+    #   Gitlab.revoke_personal_access_token(1)
+    #
+    # @param  [Integer] personal_access_token_id ID of the personal access token.
+    # @return [Gitlab::ObjectifiedHash]
+    def revoke_personal_access_token(personal_access_token_id)
+      delete("/personal_access_tokens/#{personal_access_token_id}")
     end
 
     # Disables two factor authentication (2FA) for the specified user.

--- a/spec/fixtures/personal_access_create.json
+++ b/spec/fixtures/personal_access_create.json
@@ -1,0 +1,13 @@
+{
+    "id": 2,
+    "name": "service_account_token",
+    "revoked": false,
+    "created_at": "2024-05-24T06:46:43.160Z",
+    "scopes" : [
+        "api"
+     ],
+    "user_id": 2,
+    "active": true,
+    "expires_at": "2025-05-24",
+    "token": "glpat-3Hm21_tY3sn4Wafwq39p"
+}

--- a/spec/fixtures/personal_access_get_all.json
+++ b/spec/fixtures/personal_access_get_all.json
@@ -1,0 +1,28 @@
+[
+    {
+        "id": 2,
+        "name": "service_account_token_1",
+        "revoked": false,
+        "created_at": "2024-05-24T06:46:43.160Z",
+        "scopes" : [
+            "api"
+        ],
+        "user_id": 2,
+        "last_used_at": "2024-05-24T16:00:00.000Z",
+        "active": true,
+        "expires_at": "2025-05-24"
+    },
+    {
+        "id": 3,
+        "name": "service_account_token_2",
+        "revoked": false,
+        "created_at": "2024-05-25T06:46:43.160Z",
+        "scopes" : [
+            "api"
+        ],
+        "user_id": 2,
+        "last_used_at": "2024-05-24T16:00:00.100Z",
+        "active": true,
+        "expires_at": "2025-05-24"
+    }
+]

--- a/spec/fixtures/personal_access_rotate.json
+++ b/spec/fixtures/personal_access_rotate.json
@@ -1,0 +1,13 @@
+{
+    "id": 4,
+    "name": "service_account_token",
+    "revoked": false,
+    "created_at": "2024-05-24T06:46:44.000Z",
+    "scopes" : [
+        "api"
+     ],
+    "user_id": 2,
+    "active": true,
+    "expires_at": "2025-05-24",
+    "token": "glpat--xSo18jU2MPtQ576ZYnp"
+}

--- a/spec/fixtures/service_account.json
+++ b/spec/fixtures/service_account.json
@@ -1,0 +1,1 @@
+{"id":2,"name":"Service Account 2","username":"service_account_2","state":"active","locked":false}

--- a/spec/gitlab/client/users_spec.rb
+++ b/spec/gitlab/client/users_spec.rb
@@ -113,6 +113,33 @@ RSpec.describe Gitlab::Client do
     end
   end
 
+  describe '.create_service_account' do
+    context 'when successful request' do
+      before do
+        stub_post('/service_accounts', 'service_account')
+        @user = Gitlab.create_service_account('name', 'username')
+      end
+
+      it 'gets the correct resource' do
+        body = { name: 'name', username: 'username' }
+        expect(a_post('/service_accounts').with(body: body)).to have_been_made
+      end
+
+      it 'returns information about a created user' do
+        expect(@user.username).to eq('service_account_2')
+      end
+    end
+
+    context 'when bad request' do
+      it 'throws an exception' do
+        stub_post('/service_accounts', 'error_already_exists', 409)
+        expect do
+          Gitlab.create_service_account('name', 'username')
+        end.to raise_error(Gitlab::Error::Conflict, "Server responded with code 409, message: 409 Already exists. Request URI: #{Gitlab.endpoint}/service_accounts")
+      end
+    end
+  end
+
   describe '.edit_user' do
     before do
       @options = { name: 'Roberto' }
@@ -659,6 +686,79 @@ RSpec.describe Gitlab::Client do
 
     it 'removes a token' do
       expect(a_delete('/users/2/impersonation_tokens/2')).to have_been_made
+      expect(@token.to_hash).to be_empty
+    end
+  end
+
+  describe 'get all personal access tokens' do
+    describe 'get all' do
+      before do
+        stub_get('/user_personal_access_tokens?user_id=2', 'personal_access_get_all')
+        @token = Gitlab.user_personal_access_tokens(2)
+      end
+
+      it 'gets the correct resource' do
+        expect(a_get('/personal_access_tokens?user_id=2')).to have_been_made
+      end
+
+      it 'gets an array of user impersonation tokens' do
+        expect(@tokens.first.id).to eq(2)
+        expect(@tokens.last.id).to eq(3)
+        expect(@tokens.first.active).to be_truthy
+        expect(@tokens.last.active).to be_truthy
+      end
+    end
+  end
+
+  describe 'create personal access token' do
+    before do
+      stub_post('/user/personal_access_tokens/', 'personal_access_create')
+      @token = Gitlab.create_personal_access_token(2, 'service_account_2', ['api'])
+    end
+
+    it 'gets the correct resource' do
+      expect(a_post('/user/personal_access_tokens').with(body: 'name=service_account_2&scopes%5B%5D=api')).to have_been_made
+    end
+
+    it 'returns a valid personal access token' do
+      expect(@token.name).to eq('service_account_token')
+      expect(@token.user_id).to eq(2)
+      expect(@token.id).to eq(2)
+      expect(@token.active).to be_truthy
+      expect(@token.token).to eq('glpat-3Hm21_tY3sn4Wafwq39p')
+    end
+  end
+
+  describe 'rotate personal access token' do
+    before do
+      stub_post('/personal_access_tokens/2/rotate', 'personal_access_rotate')
+      @token = Gitlab.rotate_personal_access_token(2, '2025-05-24')
+    end
+
+    it 'gets the correct resource' do
+      body = { expires_at: '2025-05-24' }
+      expect(a_post('/personal_access_tokens/2/rotate').with(body: body)).to have_been_made
+    end
+
+    it 'returns a valid personal access token' do
+      expect(@token.user_id).to eq(2)
+      expect(@token.id).to eq(4)
+      expect(@token.active).to be_truthy
+      expect(@token.expires_at).to eq('2025-05-24')
+      expect(@token.token).to eq('glpat--xSo18jU2MPtQ576ZYnp')
+    end
+  end
+
+  describe 'revoke personal accees token' do
+    before do
+      stub_request(:delete, "#{Gitlab.endpoint}/personal_access_tokens/2")
+        .with(headers: { 'PRIVATE-TOKEN' => Gitlab.private_token })
+        .to_return(status: 204)
+      @token = Gitlab.revoke_user_impersonation_token(2)
+    end
+
+    it 'revokes a personal access token' do
+      expect(a_delete('/personal_access_tokens/2')).to have_been_made
       expect(@token.to_hash).to be_empty
     end
   end


### PR DESCRIPTION
Implemented ability to create service accounts which was introduced in GitLab v16.1. This type of user does not take up a license seat and can only be created through the API. Also implemented the ability to create, rotate and revoke personal access tokens as these can also not be created through the GitLab web UI for service accounts.

I've only tested these new methods on Self-managed GitLab. The Gitlab.create_service_account method will only work on Self-managed and service accounts need to be created in the context of a group on GitLab.com.