### PR TITLE
Redact short and known private tokens

### DIFF
--- a/lib/gitlab/client.rb
+++ b/lib/gitlab/client.rb
@@ -77,7 +77,7 @@ module Gitlab
     # @return [String]
     def inspect
       inspected = super
-      inspected.sub! @private_token, only_show_last_four_chars(@private_token) if @private_token
+      inspected = redact_private_token(inspected, @private_token) if @private_token
       inspected
     end
 
@@ -91,7 +91,14 @@ module Gitlab
 
     private
 
+    def redact_private_token(inspected, private_token)
+      redacted = only_show_last_four_chars(private_token)
+      inspected.sub %(@private_token="#{private_token}"), %(@private_token="#{redacted}")
+    end
+
     def only_show_last_four_chars(token)
+      return '****' if token.size <= 4
+
       "#{'*' * (token.size - 4)}#{token[-4..]}"
     end
   end

--- a/spec/gitlab/client_spec.rb
+++ b/spec/gitlab/client_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Gitlab::Client do
+  subject(:client) { described_class.new(options) }
+
+  describe '#inspect' do
+    subject { client.inspect }
+
+    context 'without private token' do
+      let(:options) { { private_token: nil } }
+
+      it { is_expected.not_to include('@private_token=') }
+    end
+
+    context 'with a some lengthy private token' do
+      let(:options) { { private_token: 'some token' } }
+
+      it { is_expected.to include('@private_token="******oken"') }
+    end
+
+    context 'with a known private token' do
+      let(:options) { { private_token: 'endpoint' } }
+
+      it { is_expected.to include('@private_token="****oint"') }
+      it { is_expected.to include('@endpoint=') }
+    end
+
+    context 'with empty private token' do
+      let(:options) { { private_token: '' } }
+
+      it { is_expected.to include('@private_token="****"') }
+    end
+
+    context 'with short private token' do
+      let(:options) { { private_token: 'abcd' } }
+
+      it { is_expected.to include('@private_token="****"') }
+    end
+  end
+end


### PR DESCRIPTION
Prior this commit very short private tokens (< 4 chars) triggered: `ArgumentError: negative argument`

Also, if private token was a term which was part of the inspected string only the first occurrence was redacted.

## Refs

https://gitlab.com/gitlab-org/quality/triage-ops/-/merge_requests/2919#note_1983270817

## Verification

```
# Rollback production changes
git checkout master -- lib

bundle exec rspec spec/gitlab/client_spec.rb

Randomized with seed 22140

Gitlab::Client
  #inspect
    with a known private token
      is expected to include "@endpoint=" (FAILED - 1)
      is expected to include "@private_token=\"****oint\"" (FAILED - 2)
    with very short private token
      example at ./spec/gitlab/client_spec.rb:33 (FAILED - 3)
    with a private token
      is expected to include "@private_token=\"******oken\""
    with short private token
      is expected to include "@private_token=\"****\"" (FAILED - 4)
    without private token
      is expected not to include "@private_token="

Failures:

  1) Gitlab::Client#inspect with a known private token is expected to include "@endpoint="
     Failure/Error: it { is_expected.to include('@endpoint=') }
       expected "#<Gitlab::Client:0x00007f7d05a9ff90 @****oint=\"https://api.example.com\", @private_token=\"endpoint\", @user_agent=\"Gitlab Ruby Gem 5.0.0\">" to include "@endpoint="
     # ./spec/gitlab/client_spec.rb:27:in `block (4 levels) in <top (required)>'

  2) Gitlab::Client#inspect with a known private token is expected to include "@private_token=\"****oint\""
     Failure/Error: it { is_expected.to include('@private_token="****oint"') }
       expected "#<Gitlab::Client:0x00007f7d05fc9bd8 @****oint=\"https://api.example.com\", @private_token=\"endpoint\", @user_agent=\"Gitlab Ruby Gem 5.0.0\">" to include "@private_token=\"****oint\""
     # ./spec/gitlab/client_spec.rb:26:in `block (4 levels) in <top (required)>'

  3) Gitlab::Client#inspect with very short private token
     Failure/Error: "#{'*' * (token.size - 4)}#{token[-4..]}"

     ArgumentError:
       negative argument
     # ./lib/gitlab/client.rb:95:in `*'
     # ./lib/gitlab/client.rb:95:in `only_show_last_four_chars'
     # ./lib/gitlab/client.rb:80:in `inspect'
     # ./spec/gitlab/client_spec.rb:9:in `block (3 levels) in <top (required)>'
     # ./spec/gitlab/client_spec.rb:33:in `block (4 levels) in <top (required)>'

  4) Gitlab::Client#inspect with short private token is expected to include "@private_token=\"****\""
     Failure/Error: it { is_expected.to include('@private_token="****"') }
       expected "#<Gitlab::Client:0x00007f7d05cb9ba0 @endpoint=\"https://api.example.com\", @private_token=\"abcd\", @user_agent=\"Gitlab Ruby Gem 5.0.0\">" to include "@private_token=\"****\""
     # ./spec/gitlab/client_spec.rb:39:in `block (4 levels) in <top (required)>'

Finished in 0.0212 seconds (files took 0.19272 seconds to load)
6 examples, 4 failures

Failed examples:

rspec ./spec/gitlab/client_spec.rb:27 # Gitlab::Client#inspect with a known private token is expected to include "@endpoint="
rspec ./spec/gitlab/client_spec.rb:26 # Gitlab::Client#inspect with a known private token is expected to include "@private_token=\"****oint\""
rspec ./spec/gitlab/client_spec.rb:33 # Gitlab::Client#inspect with very short private token
rspec ./spec/gitlab/client_spec.rb:39 # Gitlab::Client#inspect with short private token is expected to include "@private_token=\"****\""

Randomized with seed 22140
```