### PR TITLE
Add base64 to gemspec

### DIFF
--- a/gitlab.gemspec
+++ b/gitlab.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 3.1'
 
+  gem.add_runtime_dependency 'base64', '~> 0.2.0'
   gem.add_runtime_dependency 'httparty', '~> 0.20'
   gem.add_runtime_dependency 'terminal-table', '>= 1.5.1'
 


### PR DESCRIPTION
When using this Gem in Ruby 3.3.4 i'm getting this warning:

```
/builds/gitlab-community/meta/vendor/ruby/3.3.0/gems/gitlab-5.0.0/lib/gitlab/cli_helpers.rb:5: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of gitlab-5.0.0 to add base64 into its gemspec.
```

I noticed we can also see this in checks in this in checks like: https://github.com/NARKOZ/gitlab/actions/runs/10246689948/job/28344330836?pr=695#step:4:92

We can see this no longer appears in the checks for this PR: https://github.com/NARKOZ/gitlab/actions/runs/10390243537/job/28770239632?pr=697#step:4:93