### PR TITLE
Add get_pipelines_by_pipeline_schedule method

### DIFF
--- a/lib/gitlab/client/pipeline_schedules.rb
+++ b/lib/gitlab/client/pipeline_schedules.rb
@@ -30,6 +30,18 @@ class Gitlab::Client
       get("/projects/#{url_encode project}/pipeline_schedules/#{id}")
     end
 
+    # Get all pipelines triggered by a pipeline schedule
+    #
+    # @example
+    #   Gitlab.get_pipelines_by_pipeline_schedule(5, 3)
+    #
+    # @param  [Integer, String] project The ID or name of a project.
+    # @param  [Integer] id The ID of the pipeline schedule.
+    # @return  [Array<Gitlab::ObjectifiedHash>]
+    def get_pipelines_by_pipeline_schedule(project, id)
+      get("/projects/#{url_encode project}/pipeline_schedules/#{id}/pipelines")
+    end
+
     # Create a pipeline schedule.
     #
     # @example

--- a/lib/gitlab/client/pipeline_schedules.rb
+++ b/lib/gitlab/client/pipeline_schedules.rb
@@ -33,12 +33,12 @@ class Gitlab::Client
     # Get all pipelines triggered by a pipeline schedule
     #
     # @example
-    #   Gitlab.get_pipelines_by_pipeline_schedule(5, 3)
+    #   Gitlab.pipelines_by_pipeline_schedule(5, 3)
     #
     # @param  [Integer, String] project The ID or name of a project.
     # @param  [Integer] id The ID of the pipeline schedule.
     # @return  [Array<Gitlab::ObjectifiedHash>]
-    def get_pipelines_by_pipeline_schedule(project, id)
+    def pipelines_by_pipeline_schedule(project, id)
       get("/projects/#{url_encode project}/pipeline_schedules/#{id}/pipelines")
     end
 

--- a/spec/fixtures/pipeline_schedule_get_pipelines.json
+++ b/spec/fixtures/pipeline_schedule_get_pipelines.json
@@ -1,0 +1,1 @@
+[{"id":15,"iid":2,"project_id":100,"sha":"a91957a858320c0e17f3a0eca7cfacbff50ea29a","ref":"new-pipeline","status":"pending","source":"schedule","created_at":"2016-08-16T10:23:19.007Z","updated_at":"2016-08-16T10:23:19.216Z","web_url":"http://localhost:3000/root"}]

--- a/spec/gitlab/client/pipeline_schedules_spec.rb
+++ b/spec/gitlab/client/pipeline_schedules_spec.rb
@@ -33,6 +33,21 @@ RSpec.describe Gitlab::Client do
     end
   end
 
+  describe '.get_pipelines_by_pipeline_schedule' do
+    before do
+      stub_get('/projects/3/pipeline_schedules/5/pipelines', 'pipeline_schedule_get_pipelines')
+      @pipeline_schedule_get_pipelines = Gitlab.get_pipelines_by_pipeline_schedule(3, 5)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_get('/projects/3/pipeline_schedules/5/pipelines')).to have_been_made
+    end
+
+    it "returns a response of project's pipeline schedules" do
+      expect(@pipeline_schedule_get_pipelines).to be_a Gitlab::PaginatedResponse
+    end
+  end
+
   describe '.create_pipeline_schedule' do
     before do
       stub_post('/projects/3/pipeline_schedules', 'pipeline_schedule_create')

--- a/spec/gitlab/client/pipeline_schedules_spec.rb
+++ b/spec/gitlab/client/pipeline_schedules_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe Gitlab::Client do
     end
   end
 
-  describe '.get_pipelines_by_pipeline_schedule' do
+  describe '.pipelines_by_pipeline_schedule' do
     before do
       stub_get('/projects/3/pipeline_schedules/5/pipelines', 'pipeline_schedule_get_pipelines')
-      @pipeline_schedule_get_pipelines = Gitlab.get_pipelines_by_pipeline_schedule(3, 5)
+      @pipeline_schedule_get_pipelines = Gitlab.pipelines_by_pipeline_schedule(3, 5)
     end
 
     it 'gets the correct resource' do


### PR DESCRIPTION
# What does this PR do?

GitLab pipeline now support getting all pipelines triggered by a pipeline schedule in a project
(https://docs.gitlab.com/ee/api/pipeline_schedules.html#get-all-pipelines-triggered-by-a-pipeline-schedule).

```ruby
Gitlab.get_pipelines_by_pipeline_schedule(5, 3)
```