### PR TITLE
Fix example rdoc comment for create_commit

### DIFF
--- a/lib/gitlab/client/commits.rb
+++ b/lib/gitlab/client/commits.rb
@@ -172,14 +172,14 @@ class Gitlab::Client
 
     # Creates a single commit with one or more changes
     #
-    # @see https://docs.gitlab.com/ce/api/commits.html#create-a-commit-with-multiple-files-and-actions
+    # @see https://docs.gitlab.com/api/commits/#create-a-commit-with-multiple-files-and-actions
     # Introduced in Gitlab 8.13
     #
     # @example
-    # Gitlab.create_commit(2726132, 'master', 'refactors everything', [{action: 'create', file_path: '/foo.txt', content: 'bar'}])
-    # Gitlab.create_commit(2726132, 'master', 'refactors everything', [{action: 'delete', file_path: '/foo.txt'}])
+    #   Gitlab.create_commit(2726132, 'master', 'refactors everything', [{action: 'create', file_path: '/foo.txt', content: 'bar'}])
+    #   Gitlab.create_commit(2726132, 'master', 'refactors everything', [{action: 'delete', file_path: '/foo.txt'}])
     #
-    # @param  [Integer, String] project The ID or name of a project.
+    # @param [Integer, String] project The ID or name of a project.
     # @param [String] branch the branch name you wish to commit to
     # @param [String] message the commit message
     # @param [Array[Hash]] An array of action hashes to commit as a batch. See the next table for what attributes it can take.


### PR DESCRIPTION
The `example` rdoc for the [create_commit](https://www.rubydoc.info/gems/gitlab/Gitlab%2FClient%2FCommits:create_commit) method should be indented and displayed a code block, however, it's currently rendering incorrectly with two `Gitlab.create_commit` method calls showing up as text on a single line:

<img width="1124" alt="image" src="https://github.com/user-attachments/assets/5414821e-383d-42f9-8a72-2cffe5f23229" />

This pull request adds indentation to fix this.

