### PR TITLE
Add body_as_json configuration parameter

### DIFF
--- a/lib/gitlab/configuration.rb
+++ b/lib/gitlab/configuration.rb
@@ -5,7 +5,7 @@ module Gitlab
   # Defines constants and methods related to configuration.
   module Configuration
     # An array of valid keys in the options hash when configuring a Gitlab::API.
-    VALID_OPTIONS_KEYS = %i[endpoint private_token user_agent sudo httparty pat_prefix].freeze
+    VALID_OPTIONS_KEYS = %i[endpoint private_token user_agent sudo httparty pat_prefix body_as_json].freeze
 
     # The user agent that will be sent to the API endpoint if none is set.
     DEFAULT_USER_AGENT = "Gitlab Ruby Gem #{Gitlab::VERSION}"
@@ -41,6 +41,7 @@ module Gitlab
       self.httparty       = get_httparty_config(ENV['GITLAB_API_HTTPARTY_OPTIONS'])
       self.sudo           = nil
       self.user_agent     = DEFAULT_USER_AGENT
+      self.body_as_json   = false
     end
 
     private


### PR DESCRIPTION
Allow the user to configure the client to use a Content-Type of application/json for all requests with a body unless the request explicitly provides its own Content-Type header.

Using application/json provides a broader range of compatibility with the GitLab API, especially for calls where the body expects more complex data structures.

This defaults to false for backwards compatibility.
