### PR TITLE
feat: Enhance member management with custom roles

### DIFF
--- a/lib/gitlab/client/groups.rb
+++ b/lib/gitlab/client/groups.rb
@@ -148,26 +148,34 @@ class Gitlab::Client
     #
     # @example
     #   Gitlab.add_group_member(1, 2, 40)
+    #   Gitlab.add_group_member(1, 2, 40, member_role_id: 5)
     #
     # @param  [Integer] team_id The group id to add a member to.
     # @param  [Integer] user_id The user id of the user to add to the team.
     # @param  [Integer] access_level Project access level.
+    # @param  [Hash] options A customizable set of options.
+    # @option options [Integer] :member_role_id The id of a custom member role.
     # @return [Gitlab::ObjectifiedHash] Information about added team member.
-    def add_group_member(team_id, user_id, access_level)
-      post("/groups/#{url_encode team_id}/members", body: { user_id: user_id, access_level: access_level })
+    def add_group_member(team_id, user_id, access_level, options = {})
+      body = { user_id: user_id, access_level: access_level }.merge(options)
+      post("/groups/#{url_encode team_id}/members", body: body)
     end
 
     # Edit a user of a group.
     #
     # @example
     #   Gitlab.edit_group_member(1, 2, 40)
+    #   Gitlab.edit_group_member(1, 2, 40, member_role_id: 5)
     #
     # @param  [Integer] team_id The group id of member to edit.
     # @param  [Integer] user_id The user id of the user to edit.
     # @param  [Integer] access_level Project access level.
+    # @param  [Hash] options A customizable set of options.
+    # @option options [Integer] :member_role_id The id of a custom member role.
     # @return [Gitlab::ObjectifiedHash] Information about edited team member.
-    def edit_group_member(team_id, user_id, access_level)
-      put("/groups/#{url_encode team_id}/members/#{user_id}", body: { access_level: access_level })
+    def edit_group_member(team_id, user_id, access_level, options = {})
+      body = { access_level: access_level }.merge(options)
+      put("/groups/#{url_encode team_id}/members/#{user_id}", body: body)
     end
 
     # Removes user from user group.

--- a/lib/gitlab/client/projects.rb
+++ b/lib/gitlab/client/projects.rb
@@ -138,12 +138,14 @@ class Gitlab::Client
     # @example
     #   Gitlab.add_team_member('gitlab', 2, 40)
     #   Gitlab.add_team_member('gitlab', 2, 40, { expires_at: "2018-12-31"})
+    #   Gitlab.add_team_member('gitlab', 2, 40, { member_role_id: 5 })
     #
     # @param  [Integer, String] project The ID or path of a project.
     # @param  [Integer] id The ID of a user.
     # @param  [Integer] access_level The access level to project.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :expires_at A date string in the format YEAR-MONTH-DAY.
+    # @option options [Integer] :member_role_id The id of a custom member role.
     # @return [Gitlab::ObjectifiedHash] Information about added team member.
     def add_team_member(project, id, access_level, options = {})
       body = { user_id: id, access_level: access_level }.merge(options)
@@ -155,12 +157,14 @@ class Gitlab::Client
     # @example
     #   Gitlab.edit_team_member('gitlab', 3, 20)
     #   Gitlab.edit_team_member('gitlab', 3, 20, { expires_at: "2018-12-31"})
+    #   Gitlab.edit_team_member('gitlab', 3, 20, { member_role_id: 5 })
     #
     # @param  [Integer, String] project The ID or path of a project.
     # @param  [Integer] id The ID of a user.
     # @param  [Integer] access_level The access level to project.
     # @param  [Hash] options A customizable set of options.
     # @option options [String] :expires_at A date string in the format YEAR-MONTH-DAY.
+    # @option options [Integer] :member_role_id The id of a custom member role.
     # @return [Array<Gitlab::ObjectifiedHash>] Information about updated team member.
     def edit_team_member(project, id, access_level, options = {})
       body = { access_level: access_level }.merge(options)

--- a/spec/gitlab/client/groups_spec.rb
+++ b/spec/gitlab/client/groups_spec.rb
@@ -208,6 +208,24 @@ RSpec.describe Gitlab::Client do
     it 'returns information about the added member' do
       expect(@member.name).to eq('John Smith')
     end
+
+    context 'with member_role_id' do
+      before do
+        stub_post('/groups/4/members', 'group_member') # Assuming fixture 'group_member' is suitable
+        @member_with_role = Gitlab.add_group_member(4, 2, 30, member_role_id: 5)
+      end
+
+      it 'gets the correct resource with member_role_id' do
+        expect(a_post('/groups/4/members')
+          .with(body: { user_id: '2', access_level: '30', member_role_id: '5' })).to have_been_made
+      end
+
+      it 'returns information about the added member' do
+        # NOTE: The 'group_member' fixture does not include member_role_id in the response.
+        # So, we can only verify the request was made correctly.
+        expect(@member_with_role.name).to eq('John Smith')
+      end
+    end
   end
 
   describe '.edit_group_member' do
@@ -223,6 +241,24 @@ RSpec.describe Gitlab::Client do
 
     it 'returns information about the edited member' do
       expect(@member.access_level).to eq(50)
+    end
+
+    context 'with member_role_id' do
+      before do
+        stub_put('/groups/4/members/2', 'group_member_edit') # Assuming fixture 'group_member_edit' is suitable
+        @member_with_role = Gitlab.edit_group_member(4, 2, 20, member_role_id: 6)
+      end
+
+      it 'gets the correct resource with member_role_id' do
+        expect(a_put('/groups/4/members/2')
+          .with(body: { access_level: '20', member_role_id: '6' })).to have_been_made
+      end
+
+      it 'returns information about the edited member' do
+        # NOTE: The 'group_member_edit' fixture does not include member_role_id in the response.
+        # So, we can only verify the request was made correctly.
+        expect(@member_with_role.access_level).to eq(50) # This will depend on the 'group_member_edit' fixture content
+      end
     end
   end
 

--- a/spec/gitlab/client/projects_spec.rb
+++ b/spec/gitlab/client/projects_spec.rb
@@ -216,6 +216,22 @@ RSpec.describe Gitlab::Client do
       expect(@team_member.name).to eq('John Smith')
       expect(@team_member.expires_at).to eq('2018-12-31T00:00:00Z')
     end
+
+    context 'with member_role_id' do
+      before do
+        stub_post('/projects/example-project/members', 'team_member')
+        @member_with_role = Gitlab.add_team_member('example-project', 2, 30, member_role_id: 5)
+      end
+
+      it 'gets the correct resource with member_role_id' do
+        expect(a_post('/projects/example-project/members')
+          .with(body: { user_id: '2', access_level: '30', member_role_id: '5' })).to have_been_made
+      end
+
+      it 'returns information about the added member' do
+        expect(@member_with_role.name).to eq('John Smith')
+      end
+    end
   end
 
   describe '.edit_team_member' do
@@ -232,6 +248,22 @@ RSpec.describe Gitlab::Client do
     it 'returns information about an edited team member' do
       expect(@team_member.name).to eq('John Smith')
       expect(@team_member.expires_at).to eq('2018-12-31T00:00:00Z')
+    end
+
+    context 'with member_role_id' do
+      before do
+        stub_put('/projects/example-project/members/2', 'group_member_edit')
+        @member_with_role = Gitlab.edit_team_member('example-project', 2, 10, member_role_id: 6)
+      end
+
+      it 'gets the correct resource with member_role_id' do
+        expect(a_put('/projects/example-project/members/2')
+          .with(body: { access_level: '10', member_role_id: '6' })).to have_been_made
+      end
+
+      it 'returns information about the edited member' do
+        expect(@member_with_role.access_level).to eq(50)
+      end
     end
   end
 


### PR DESCRIPTION
This commit introduces the ability to assign custom member roles when adding or editing members in both groups and projects.

The following methods have been updated:
- `Gitlab::Client::Groups#add_group_member`
- `Gitlab::Client::Groups#edit_group_member`
- `Gitlab::Client::Projects#add_team_member`
- `Gitlab::Client::Projects#edit_team_member`

Each of these methods now accepts an optional `member_role_id` parameter within the `options` hash.