### PR TITLE
Add before, after and around hooks for each API call

### DIFF
--- a/lib/gitlab/error.rb
+++ b/lib/gitlab/error.rb
@@ -34,6 +34,13 @@ module Gitlab
         @response.parsed_response.message
       end
 
+      # Headers returned in the HTTP response
+      #
+      # @return [HTTParty::Response::Headers]
+      def response_headers
+        @response.headers
+      end
+
       # Additional error context returned by some API endpoints
       #
       # @return [String]


### PR DESCRIPTION
The order of execution is:
- Before hooks
- First part of around hooks
- API call
- After hooks
- Second part of around hooks

Additional work required:
- [ ] Specs for `ResponseError#response_headers`
- [ ] Additional request specs
  - [ ] Test that after hooks are called even if an exception is raised
  - [ ] Test access to response object in around hooks where no exception is raised
  - [x] Test with empty hooks
- [ ] Documentation

https://github.com/NARKOZ/gitlab/issues/715