### PR TITLE
Add the set override flag API endpoint (of LDAP-sync'ed users)

### DIFF
--- a/lib/gitlab/client/groups.rb
+++ b/lib/gitlab/client/groups.rb
@@ -161,6 +161,17 @@ class Gitlab::Client
       post("/groups/#{url_encode team_id}/members", body: body)
     end
 
+    # Set LDAP override flag for a member of a group
+    #
+    # @example
+    #   Gitlab.override_group_member(1, 2)
+    #
+    # @param  [Integer] team_id The group id into which LDAP syncs the user.
+    # @param  [Integer] user_id The user id of the user.
+    def override_group_member(team_id, user_id)
+      post("/groups/#{url_encode team_id}/members/#{user_id}/override")
+    end
+
     # Edit a user of a group.
     #
     # @example

--- a/spec/fixtures/group_member_override.json
+++ b/spec/fixtures/group_member_override.json
@@ -1,0 +1,1 @@
+{"id":1,"username":"jsmith","email":"jsmith@local.host","name":"John Smith","state":"active","created_at":"2013-09-04T18:15:30Z","override":true}

--- a/spec/gitlab/client/groups_spec.rb
+++ b/spec/gitlab/client/groups_spec.rb
@@ -262,6 +262,21 @@ RSpec.describe Gitlab::Client do
     end
   end
 
+  describe '.override_group_member' do
+    before do
+      stub_post('/groups/3/members/1/override', 'group_member_override')
+      @member = Gitlab.override_group_member(3, 1)
+    end
+
+    it 'gets the correct resource' do
+      expect(a_post('/groups/3/members/1/override')).to have_been_made
+    end
+
+    it 'returns the override flag for the member' do
+      expect(@member.override).to be(true)
+    end
+  end
+
   describe '.remove_group_member' do
     before do
       stub_delete('/groups/3/members/1', 'group_member_delete')


### PR DESCRIPTION
Forwarding a suggestion by a GitLab customer to add this `post("/groups/#{url_encode team_id}/members/#{user_id}/override")` method, as it proved useful for custom scripting against a self-hosted GitLab server. I've added tests and a fixture, _greening_ `rspec` locally for me.

The [API endpoind is documented here](https://gitlab.com/gitlab-org/gitlab/-/blob/v18.1.1-ee/doc/api/members.md#set-override-flag-for-a-member-of-a-group).