### PR TITLE
Allow updating base64

### DIFF
--- a/gitlab.gemspec
+++ b/gitlab.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 3.2'
 
-  gem.add_runtime_dependency 'base64', '~> 0.2.0'
+  gem.add_runtime_dependency 'base64'
   gem.add_runtime_dependency 'httparty', '~> 0.20'
   gem.add_runtime_dependency 'terminal-table', '>= 1.5.1'
 


### PR DESCRIPTION
Hey there! This is just a quick PR to allow updating base64.

This unpins base64 so that it can be updated to the latest version. The current version of base64 is 0.3.0. See: https://github.com/ruby/base64/releases