### PR TITLE
Document new Snippet creation API

### DIFF
--- a/lib/gitlab/client/snippets.rb
+++ b/lib/gitlab/client/snippets.rb
@@ -33,15 +33,14 @@ class Gitlab::Client
     # Creates a new snippet.
     #
     # @example
-    #   Gitlab.create_snippet(42, { title: 'REST', file_name: 'api.rb', code: 'some code', visibility: 'public'})
+    #   Gitlab.create_snippet(3, title: 'REST', description: 'A sample snippet', files: [ {content: 'Hello world', file_path: 'test.txt'} ], visibility: 'public')
     #
     # @param  [Integer, String] project The ID or name of a project.
     # @param  [Hash] options A customizable set of options.
-    # @option options [String] :title (required) The title of a snippet.
-    # @option options [String] :file_name (required) The name of a snippet file.
-    # @option options [String] :code (required) The content of a snippet.
-    # @option options [String] :lifetime (optional) The expiration date of a snippet.
-    # @option options [String] :visibility (required) The visibility of a snippet
+    # @option options [String] :title The title of a snippet (*required*).
+    # @option options [String] :description The description of a snippet (_optional_).
+    # @option options [Array<Hash<String, String>>] :files Array of snippet files, each _Hash_ needs +content+ and +file_path+ keys (*required*)
+    # @option options [String] :visibility The visibility of a snippet (_optional_).
     # @return [Gitlab::ObjectifiedHash] Information about created snippet.
     def create_snippet(project, options = {})
       post("/projects/#{url_encode project}/snippets", body: options)

--- a/spec/fixtures/snippet.json
+++ b/spec/fixtures/snippet.json
@@ -1,1 +1,26 @@
-{"id":1,"title":"Rails Console ActionMailer","file_name":"mailer_test.rb","author":{"id":1,"email":"john@example.com","name":"John Smith","blocked":false,"created_at":"2012-09-17T09:41:56Z"},"expires_at":"2012-09-24T00:00:00Z","updated_at":"2012-09-17T09:51:42Z","created_at":"2012-09-17T09:51:42Z"}
+{
+  "id": 1,
+  "title": "Rails Console ActionMailer",
+  "description": "A sample snippet",
+  "file_name": "mailer_test.rb",
+  "files": [
+    {
+      "path": "mailer_test.rb",
+      "raw_url": "https://example.org/group/project/-/snippet/4/raw/main/mailer_test.rb"
+    },
+    {
+      "path": "2.rb",
+      "raw_url": "https://gitlab.com/gitlab-org/gitlab/-/snippets/4881934/raw/main/2.rb"
+    }
+  ],
+  "author": {
+    "id": 1,
+    "email": "john@example.com",
+    "name": "John Smith",
+    "blocked": false,
+    "created_at": "2012-09-17T09:41:56Z"
+  },
+  "expires_at": "2012-09-24T00:00:00Z",
+  "updated_at": "2012-09-17T09:51:42Z",
+  "created_at": "2012-09-17T09:51:42Z"
+}

--- a/spec/gitlab/client/snippets_spec.rb
+++ b/spec/gitlab/client/snippets_spec.rb
@@ -38,16 +38,18 @@ RSpec.describe Gitlab::Client do
   describe '.create_snippet' do
     before do
       stub_post('/projects/3/snippets', 'snippet')
-      @snippet = Gitlab.create_snippet(3, title: 'API', file_name: 'api.rb', code: 'code', visibility: 'public')
+      @body = { title: 'REST', description: 'A sample snippet', files: [{ content: 'Hello world', 'file_path': 'mailer_test.rb' }], visibility: 'public' }
+      @snippet = Gitlab.create_snippet(3, @body)
     end
 
     it 'gets the correct resource' do
-      body = { title: 'API', file_name: 'api.rb', code: 'code', visibility: 'public' }
-      expect(a_post('/projects/3/snippets').with(body: body)).to have_been_made
+      expect(a_post('/projects/3/snippets').with(body: @body)).to have_been_made
     end
 
     it 'returns information about a new snippet' do
       expect(@snippet.file_name).to eq('mailer_test.rb')
+      expect(@snippet.files).to be_a(Array)
+      expect(@snippet.description).to eq('A sample snippet')
       expect(@snippet.author.name).to eq('John Smith')
     end
   end


### PR DESCRIPTION
When working with snippets I realized that the API has changed to accept `files: [{file_path: String, content: String}]`  instead of `file_name` and `content` - https://docs.gitlab.com/api/snippets/#create-new-snippet but the documentation doesn't reflect that.