### PR TITLE
Fix wiki method for non-latin and nested slugs

### DIFF
--- a/lib/gitlab/client/wikis.rb
+++ b/lib/gitlab/client/wikis.rb
@@ -27,7 +27,7 @@ class Gitlab::Client
     # @param  [String] slug The slug (a unique string) of the wiki page
     # @return [Gitlab::ObjectifiedHash]
     def wiki(project, slug)
-      get("/projects/#{url_encode project}/wikis/#{slug}")
+      get("/projects/#{url_encode project}/wikis/#{url_encode slug}")
     end
 
     # Creates a new wiki page for the given repository with the given title, slug, and content.


### PR DESCRIPTION
Slug can contain non ascii symbols and also "/" symbol making articles nesting, so it should be url encoded